### PR TITLE
Enable CORS for job summary endpoints

### DIFF
--- a/api/job-status.js
+++ b/api/job-status.js
@@ -1,6 +1,8 @@
 import { supa } from '../lib/supa.js';
+import { cors } from '../lib/cors.js';
 
 export default async function handler(req, res) {
+  if (cors(req, res)) return;
   const id = req.query.id; // puede ser job_id legible o el uuid con un flag
   if (!id) return res.status(400).json({ error: 'missing_id' });
 

--- a/api/job-summary.js
+++ b/api/job-summary.js
@@ -1,6 +1,8 @@
 import { supa } from '../lib/supa.js';
+import { cors } from '../lib/cors.js';
 
 export default async function handler(req, res) {
+  if (cors(req, res)) return;
   const id = req.query.id; // job_id legible
   if (!id) return res.status(400).json({ error: 'missing_id' });
 

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -5,7 +5,7 @@ export function cors(req, res) {
     res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader('Vary', 'Origin');
   }
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Idempotency-Key');
   if (req.method === 'OPTIONS') { res.status(204).end(); return true; }
   return false;


### PR DESCRIPTION
## Summary
- allow GET requests in CORS helper
- add CORS handling to job summary and job status endpoints to unblock cross-origin calls

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689bcb2ccd58832789e0e70e37788b9d