### PR TITLE
Allow all origins by default in CORS

### DIFF
--- a/lib/cors.js
+++ b/lib/cors.js
@@ -1,10 +1,16 @@
 export function cors(req, res) {
-  const allowed = (process.env.ALLOWED_ORIGINS || '').split(',').map(s=>s.trim()).filter(Boolean);
+  const allowedEnv = process.env.ALLOWED_ORIGINS || '';
+  const allowed = allowedEnv.split(',').map(s => s.trim()).filter(Boolean);
   const origin = req.headers.origin || '';
-  if (allowed.includes(origin)) {
+
+  if (allowed.length === 0) {
+    // Sin restricciones: permitir cualquier origen (útil en desarrollo)
+    res.setHeader('Access-Control-Allow-Origin', '*');
+  } else if (allowed.includes(origin)) {
     res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader('Vary', 'Origin');
   }
+
   res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Idempotency-Key');
   if (req.method === 'OPTIONS') { res.status(204).end(); return true; }


### PR DESCRIPTION
## Summary
- Relax CORS handling to permit any origin when `ALLOWED_ORIGINS` is unset, easing local development and avoiding blocked requests between front-end and back-end.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bbd6670f08327bb92e71c65f8dc96