### PR TITLE
Avoid blocking worker when firing async link tasks

### DIFF
--- a/api/worker-process.js
+++ b/api/worker-process.js
@@ -103,27 +103,23 @@ export default async function handler(req, res) {
       preview_url: prevUrl,
       status: 'READY_FOR_PRODUCTION'
     }).eq('id', job.id);
+    if (upDb.error) return res.status(500).json({ step: step.name, error: upDb.error.message || String(upDb.error) });
 
-      // 10) Disparar creación de enlaces (sin bloquear la respuesta)
-// a) Checkout (Draft Order) SI aún no existe
-try {
-  await fetch(`${process.env.API_BASE_URL}/api/create-cart-link`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ job_id: job.job_id })
-  });
-} catch(_) {}
-// b) Producto público SI el cliente marcó publicar
-if (job.is_public) {
-  try {
-    await fetch(`${process.env.API_BASE_URL}/api/publish-product`, {
+    // 10) Disparar creación de enlaces (sin bloquear la respuesta)
+    fetch(`${process.env.API_BASE_URL}/api/create-cart-link`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ job_id: job.job_id })
-    });
-  } catch (_) {}
-}
-    if (upDb.error) return res.status(500).json({ step: step.name, error: upDb.error.message || String(upDb.error) });
+    }).catch(() => {});
+
+    // b) Producto público SI el cliente marcó publicar
+    if (job.is_public) {
+      fetch(`${process.env.API_BASE_URL}/api/publish-product`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ job_id: job.job_id })
+      }).catch(() => {});
+    }
 
     return res.status(200).json({ ok:true, step:'done', job_id: job.job_id, print_jpg_url: printUrl, pdf_url: pdfUrl, preview_url: prevUrl });
 


### PR DESCRIPTION
## Summary
- ensure worker aborts if DB update fails
- fire asynchronous link creation without blocking response

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bbd3e62bc83278684e2115668b72e