### PR TITLE
feat: improve job flow and DPI handling

### DIFF
--- a/lib/cors.js
+++ b/lib/cors.js
@@ -1,9 +1,9 @@
 export function cors(req, res) {
-  const allowed = (process.env.ALLOWED_ORIGINS || '').split(',').map(s=>s.trim()).filter(Boolean);
+  const allowed = (process.env.ALLOWED_ORIGINS || '').split(',').map(s => s.trim()).filter(Boolean);
   const origin = req.headers.origin || '';
-  if (allowed.includes(origin)) {
-    res.setHeader('Access-Control-Allow-Origin', origin);
-    res.setHeader('Vary', 'Origin');
+  if (allowed.length === 0 || allowed.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', allowed.length ? origin : '*');
+    if (allowed.length) res.setHeader('Vary', 'Origin');
   }
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Idempotency-Key');

--- a/mgm-front/src/pages/Confirm.jsx
+++ b/mgm-front/src/pages/Confirm.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { api } from '../lib/api';
 
 export default function Confirm() {
   const [sp] = useSearchParams();
@@ -11,16 +12,14 @@ export default function Confirm() {
     let t;
     async function tick() {
       try {
-        const res = await fetch(`${import.meta.env.VITE_API_BASE}/api/job-summary?id=${encodeURIComponent(jobId)}`);
-        const json = await res.json();
-        if (!res.ok) throw new Error(json?.error || 'fetch_failed');
+        const json = await api(`/api/job-summary?id=${encodeURIComponent(jobId)}`);
         setData(json);
         // si falta cart_url o status no listo, repoll
         if (!json.cart_url || (json.status !== 'READY_FOR_PRODUCTION' && json.status !== 'SHOPIFY_CREATED')) {
           t = setTimeout(tick, 2000);
         }
       } catch (e) {
-        setErr(String(e?.message || e));
+        setErr(String(e?.body?.error || e?.message || e));
         t = setTimeout(tick, 3000);
       }
     }
@@ -42,15 +41,15 @@ export default function Confirm() {
 
       <div style={{display:'flex', gap:12, marginTop:12}}>
         {data.cart_url && (
-          <a className="btn" href={data.cart_url}>Ir al carrito</a>
+          <a className="btn" href={data.cart_url}>Agregar al carrito</a>
         )}
         {data.shopify_product_url && (
           <a className="btn" href={data.shopify_product_url} target="_blank">Ver producto</a>
         )}
-        {/* opcional: si mantenés invoice */}
         {data.checkout_url && (
           <a className="btn" href={data.checkout_url} target="_blank" rel="noreferrer">Pagar ahora</a>
         )}
+        <a className="btn" href="/">Cargar otro diseño</a>
       </div>
 
       {err && <p style={{color:'crimson'}}>{err}</p>}


### PR DESCRIPTION
## Summary
- allow any origin when ALLOWED_ORIGINS is not set
- compute and send SHA-256 hash for uploaded files
- require model name and low DPI acknowledgement before submitting
- add cart and "Cargar otro diseño" options on confirmation page

## Testing
- `npm test` (fails: Missing script "test")
- `cd mgm-front && npm test` (fails: Missing script "test")
- `cd mgm-front && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f7bb4a1c883279f2e612028a4e606