### PR TITLE
Add confirmation before submit and generate 1080 mockups

### DIFF
--- a/api/worker-process.js
+++ b/api/worker-process.js
@@ -98,13 +98,26 @@ export default async function handler(req, res) {
     page.drawImage(jpg, { x:0, y:0, width:pageWpt, height:pageHpt });
     const pdfBytes = await pdf.save();
 
-    // 7) Preview
+    // 7) Preview / mockup 1080x1080
     step.name='preview';
-    const maxPreview = 1600;
-    const scale = Math.min(1, maxPreview / Math.max(targetW, targetH));
-    const prevW = Math.max(1, Math.round(targetW*scale));
-    const prevH = Math.max(1, Math.round(targetH*scale));
-    const preview = await sharp(fitted).resize(prevW, prevH).png().toBuffer();
+    const mockSize = 1080;
+    const scale = Math.min(mockSize / targetW, mockSize / targetH);
+    const mockW = Math.max(1, Math.round(targetW * scale));
+    const mockH = Math.max(1, Math.round(targetH * scale));
+    const resized = await sharp(fitted).resize(mockW, mockH).png().toBuffer();
+    const left = Math.round((mockSize - mockW) / 2);
+    const top = Math.round((mockSize - mockH) / 2);
+    const preview = await sharp({
+      create: {
+        width: mockSize,
+        height: mockSize,
+        channels: 3,
+        background: job.bg || '#ffffff'
+      }
+    })
+      .composite([{ input: resized, left, top }])
+      .png()
+      .toBuffer();
 
     // 8) Subir a outputs
     step.name='upload';

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -56,6 +56,8 @@ export default function Home() {
       setErr('Falta el nombre del modelo');
       return;
     }
+    if (!window.confirm('¿La imagen está editada completamente?')) return;
+    if (!window.confirm('¿No realizarás más cambios?')) return;
     setBusy(true);
     setErr('');
     try {


### PR DESCRIPTION
## Summary
- ask user twice before final submission to ensure edits complete
- create 1080x1080 mockup preview centered and scaled to product size

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix mgm-front test` *(fails: Missing script: "test")*
- `npm --prefix mgm-front run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a20bca0cb0832798b8bdbec25c773f