### PR TITLE
Validate positive price and add front-end placeholder

### DIFF
--- a/api/submit-job.js
+++ b/api/submit-job.js
@@ -51,7 +51,7 @@ const Body = z.object({
   notes: z.string().max(1000).optional(),
   price: z.object({
     currency: z.string().default('ARS'),
-    amount: z.number().nonnegative()
+    amount: z.number().positive()
   }),
   source: z.string().default('web')
 });
@@ -67,6 +67,10 @@ export default async function handler(req, res) {
 
   try {
     const body = Body.parse(req.body);
+
+    if (!body.price.amount || body.price.amount <= 0) {
+      return res.status(400).json({ error: 'invalid_price' });
+    }
 
     // Límites por material
     const lim = LIMITS[body.material];

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -74,7 +74,8 @@ export default function Home() {
         file_hash: uploaded.file_hash,
         dpi_report: { dpi: effDpi, level, customer_ack: ackLow },
         notes: '',
-        price: { currency: 'ARS', amount: 0 },
+        // TODO: reemplazar con calculadora real
+        price: { currency: 'ARS', amount: 45900 },
         source: 'web',
         layout,
       };


### PR DESCRIPTION
## Summary
- Ensure submit-job API rejects non-positive prices
- Add temporary price placeholder on Home page when creating jobs

## Testing
- `npm test` *(fails: Missing script)*
- `cd mgm-front && npm test` *(fails: Missing script)*
- `cd mgm-front && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a2762a12cc832796ed0ce7f8a6da41