### PR TITLE
Implement publish-product endpoint and Supabase schema docs

### DIFF
--- a/api/create-cart-link.js
+++ b/api/create-cart-link.js
@@ -2,6 +2,7 @@
 // Crea (o reutiliza) un producto/variante y devuelve un link que agrega el ítem al carrito con properties.
 import { supa } from '../lib/supa.js';
 import { shopifyAdmin } from '../lib/shopify.js';
+import { cors } from '../lib/cors.js';
 
 function sizeLabel(w, h) {
   return `${Number(w)}x${Number(h)} cm`;
@@ -13,6 +14,7 @@ function qs(obj) {
 }
 
 export default async function handler(req, res) {
+  if (cors(req, res)) return;
   try {
     if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
     const { job_id } = req.body || {};

--- a/api/publish-product.js
+++ b/api/publish-product.js
@@ -1,0 +1,32 @@
+import { supa } from '../lib/supa.js';
+import { shopifyAdmin } from '../lib/shopify.js';
+import { cors } from '../lib/cors.js';
+
+export default async function handler(req, res) {
+  if (cors(req, res)) return;
+  try {
+    if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+    const { job_id } = req.body || {};
+    if (!job_id) return res.status(400).json({ error: 'missing_job_id' });
+
+    const { data: job, error } = await supa.from('jobs').select('*').eq('job_id', job_id).single();
+    if (error || !job) return res.status(404).json({ error: 'job_not_found' });
+    if (!job.shopify_product_id) return res.status(409).json({ error: 'missing_product_id' });
+
+    await shopifyAdmin(`/products/${job.shopify_product_id}.json`, {
+      method: 'PUT',
+      body: JSON.stringify({ product: { id: job.shopify_product_id, status: 'active' } })
+    });
+
+    const { product } = await shopifyAdmin(`/products/${job.shopify_product_id}.json`, { method: 'GET' });
+    const pubBase = process.env.SHOPIFY_PUBLIC_BASE || `https://${process.env.SHOPIFY_STORE_DOMAIN}`;
+    const productUrl = `${pubBase}/products/${product.handle}`;
+
+    await supa.from('jobs').update({ shopify_product_url: productUrl }).eq('id', job.id);
+
+    return res.status(200).json({ ok: true, job_id: job.job_id, product_url: productUrl });
+  } catch (e) {
+    console.error('publish_product_error', e);
+    return res.status(500).json({ error: 'publish_product_failed', detail: String(e?.message || e) });
+  }
+}

--- a/mgm-front/README.md
+++ b/mgm-front/README.md
@@ -2,6 +2,18 @@
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
+## Variables de entorno
+
+Antes de iniciar el entorno de desarrollo crea un archivo `.env` con:
+
+```
+VITE_API_BASE=URL_de_tu_API
+VITE_SUPABASE_URL=URL_de_tu_proyecto_Supabase
+VITE_SUPABASE_ANON_KEY=clave_anon_de_Supabase
+```
+
+Luego ejecuta `npm run dev` para iniciar el frontend.
+
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh

--- a/mgm-front/src/lib/api.js
+++ b/mgm-front/src/lib/api.js
@@ -1,4 +1,6 @@
-const BASE = import.meta.env.VITE_API_BASE;
+const rawBase = import.meta.env.VITE_API_BASE;
+if (!rawBase) throw new Error('VITE_API_BASE missing');
+const BASE = rawBase.replace(/\/$/, '');
 
 export async function api(path, init = {}) {
   const res = await fetch(`${BASE}${path}`, {

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,12 @@
+# Supabase setup
+
+## Buckets
+
+- Crear un bucket **privado** llamado `uploads` para recibir los archivos originales.
+- Crear un bucket **público** llamado `outputs` donde se guardarán los JPG/PDF de salida y las previews.
+- Asegurarse de que las políticas RLS permitan acceso con la clave de servicio (service role).
+
+## Esquema
+
+El archivo [`schema.sql`](./schema.sql) contiene la definición de las tablas `jobs` y `job_events`.
+Ejecuta ese SQL en tu proyecto de Supabase para crear las tablas e índices necesarios.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,40 @@
+-- Supabase schema for MGM personalized orders
+
+-- Table: jobs
+create table if not exists public.jobs (
+  id uuid primary key default gen_random_uuid(),
+  job_id text unique not null,
+  status text not null default 'CREATED',
+  material text,
+  w_cm numeric,
+  h_cm numeric,
+  bleed_mm numeric,
+  file_original_url text,
+  file_hash text,
+  design_name text,
+  print_jpg_url text,
+  pdf_url text,
+  preview_url text,
+  price_amount numeric,
+  cart_url text,
+  checkout_url text,
+  shopify_product_id text,
+  shopify_variant_id text,
+  shopify_product_url text,
+  is_public boolean default false,
+  created_at timestamptz default now()
+);
+
+create index if not exists jobs_job_id_idx on public.jobs(job_id);
+create index if not exists jobs_file_hash_idx on public.jobs(file_hash);
+
+-- Table: job_events
+create table if not exists public.job_events (
+  id uuid primary key default gen_random_uuid(),
+  job_id uuid references public.jobs(id) on delete cascade,
+  event text not null,
+  detail jsonb,
+  created_at timestamptz default now()
+);
+
+create index if not exists job_events_job_id_idx on public.job_events(job_id);


### PR DESCRIPTION
## Summary
- Implement `/api/publish-product` endpoint to activate Shopify product and save public URL
- Apply CORS to cart link endpoint and validate API base on the frontend
- Document required env vars and Supabase schema/buckets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix mgm-front test` *(fails: Missing script "test")*
- `npm --prefix mgm-front run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a27cd5e7348327a02387e13e242eda