### PR TITLE
Handle duplicate job records with maybeSingle

### DIFF
--- a/api/job-status.js
+++ b/api/job-status.js
@@ -7,12 +7,19 @@ export default async function handler(req, res) {
   if (!id) return res.status(400).json({ error: 'missing_id' });
 
   // buscamos por job_id (legible)
-  const { data, error } = await supa
+  let { data, error } = await supa
     .from('jobs')
     .select('job_id,status,print_jpg_url,pdf_url,preview_url,checkout_url')
     .eq('job_id', id)
-    .single();
+    .limit(2)
+    .maybeSingle();
 
-  if (error) return res.status(404).json({ error: 'not_found' });
+  if (error) return res.status(500).json({ error: 'unknown_error' });
+  if (Array.isArray(data)) {
+    if (data.length === 0) return res.status(404).json({ error: 'not_found' });
+    if (data.length > 1) return res.status(409).json({ error: 'duplicate' });
+    data = data[0];
+  }
+  if (!data) return res.status(404).json({ error: 'not_found' });
   res.status(200).json(data);
 }

--- a/api/job-summary.js
+++ b/api/job-summary.js
@@ -6,12 +6,19 @@ export default async function handler(req, res) {
   const id = req.query.id; // job_id legible
   if (!id) return res.status(400).json({ error: 'missing_id' });
 
-  const { data, error } = await supa
+  let { data, error } = await supa
     .from('jobs')
     .select('job_id,status,material,w_cm,h_cm,price_amount,print_jpg_url,pdf_url,preview_url,checkout_url,shopify_product_url')
     .eq('job_id', id)
-    .single();
+    .limit(2)
+    .maybeSingle();
 
-  if (error || !data) return res.status(404).json({ error: 'not_found' });
+  if (error) return res.status(500).json({ error: 'unknown_error' });
+  if (Array.isArray(data)) {
+    if (data.length === 0) return res.status(404).json({ error: 'not_found' });
+    if (data.length > 1) return res.status(409).json({ error: 'duplicate' });
+    data = data[0];
+  }
+  if (!data) return res.status(404).json({ error: 'not_found' });
   res.status(200).json(data);
 }


### PR DESCRIPTION
## Summary
- replace `single()` with `maybeSingle()` in job endpoints
- detect duplicate job records and return 409

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7b03f55548327ae774e04796f9122