### PR TITLE
fix: prevent infinite resize loop

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -132,7 +132,9 @@ export default function EditorCanvas({
   useEffect(() => {
     const ro = new ResizeObserver(() => {
       const r = wrapRef.current?.getBoundingClientRect();
-      if (r) setWrapSize({ w: r.width, h: Math.max(360, r.height) });
+      if (!r) return;
+      const next = { w: r.width, h: Math.max(360, r.height) };
+      setWrapSize((prev) => (prev.w !== next.w || prev.h !== next.h ? next : prev));
     });
     if (wrapRef.current) ro.observe(wrapRef.current);
     return () => ro.disconnect();


### PR DESCRIPTION
## Summary
- avoid ResizeObserver triggering infinite state updates by checking size changes before updating

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7b60f1d6083279e3c52bb22597c9d