### PR TITLE
Evita animación inicial y agrega spinner de carga

### DIFF
--- a/mgm-front/index.html
+++ b/mgm-front/index.html
@@ -3,11 +3,22 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="stylesheet" href="/src/index.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
+    <style>
+      #initial-spinner {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div id="initial-spinner" class="spinner"></div>
+    </div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -234,7 +234,7 @@ export default function EditorCanvas({
   };
 
   // imagen
-  const [imgEl] = useImage(imageUrl || undefined);
+  const [imgEl, imgStatus] = useImage(imageUrl || undefined);
   const imgBaseCm = useMemo(() => {
     if (!imgEl) return null;
     return {
@@ -843,6 +843,17 @@ export default function EditorCanvas({
             />
           </Layer>
         </Stage>
+        {imageUrl && imgStatus !== 'loaded' && (
+          <div
+            className="spinner"
+            style={{
+              position: 'absolute',
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)'
+            }}
+          />
+        )}
       </div>
     </div>
   );

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from './App.jsx';
 import Home from './pages/Home.jsx';
 import Confirm from './pages/Confirm.jsx';
+import './index.css';
 
 const router = createBrowserRouter([
   {


### PR DESCRIPTION
## Summary
- Carga los estilos globales antes de inicializar la app y añade un spinner de arranque
- Importa `index.css` en `main.jsx`
- Muestra un indicador de carga mientras la imagen del lienzo está pendiente

## Testing
- `npm test` *(missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7bbc8bde48327a369e391f937ca3c