### PR TITLE
feat: default job id

### DIFF
--- a/api/submit-job.js
+++ b/api/submit-job.js
@@ -3,8 +3,15 @@
 import { z } from 'zod';
 import { supa } from '../lib/supa.js';
 import { cors } from '../lib/cors.js';
+import { randomUUID } from 'crypto';
 
 const LIMITS = { Classic: { maxW: 140, maxH: 100 }, PRO: { maxW: 120, maxH: 60 } };
+
+function generateJobId() {
+  const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+  const uuid8 = randomUUID().split('-')[0];
+  return `job_${date}_${uuid8}`;
+}
 
 const Body = z.object({
   customer: z.object({
@@ -122,6 +129,7 @@ export default async function handler(req, res) {
 
     // INSERT de job nuevo
     const insertPayload = {
+      job_id: generateJobId(),
       customer_email: body.customer?.email || null,
       customer_name: body.customer?.name || null,
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,9 +1,17 @@
 -- Supabase schema for MGM personalized orders
 
+-- Function to generate default job_id: job_YYYYMMDD_uuid8
+create or replace function public.default_job_id()
+returns text
+language sql
+as $$
+  select 'job_' || to_char(now(), 'YYYYMMDD') || '_' || substr(gen_random_uuid()::text, 1, 8);
+$$;
+
 -- Table: jobs
 create table if not exists public.jobs (
   id uuid primary key default gen_random_uuid(),
-  job_id text unique not null,
+  job_id text unique not null default public.default_job_id(),
   status text not null default 'CREATED',
   material text,
   w_cm numeric,


### PR DESCRIPTION
## Summary
- add SQL function to generate job IDs and set `job_id` default
- generate `job_id` in submit-job API payload

## Testing
- `npm test` (fails: Missing script "test")
- `psql -f supabase/schema.sql` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ab19496cc083279c4e26a7823d4b67