### PR TITLE
fix: allow signed storage URLs in submit-job

### DIFF
--- a/api/submit-job.js
+++ b/api/submit-job.js
@@ -91,7 +91,8 @@ export default async function handler(req, res) {
     }
 
     // La URL del original debe provenir del bucket 'uploads' (carpeta original/)
-    if (!/\/storage\/v1\/object\/.+\/uploads\/original\//.test(body.file_original_url)) {
+    // y puede o no incluir el segmento "/sign" antes del bucket.
+    if (!/\/storage\/v1\/object(?:\/sign)?\/uploads\/original\//.test(body.file_original_url)) {
       return res.status(400).json({ error: 'invalid_original_url' });
     }
 

--- a/docs/curl-examples.md
+++ b/docs/curl-examples.md
@@ -1,0 +1,57 @@
+# cURL examples for MGM API
+
+## 1. Obtain signed upload URL
+```bash
+curl -X POST https://mgm-api.vercel.app/api/upload-url \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "ext": "png",
+    "mime": "image/png",
+    "size_bytes": 123456,
+    "material": "Classic",
+    "w_cm": 10,
+    "h_cm": 10,
+    "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  }'
+```
+
+La respuesta incluye `object_key` y `signed_url`.
+
+## 2. Subir el archivo con el `signed_url`
+```bash
+curl -X PUT '<SIGNED_URL>' \
+  -H 'Content-Type: image/png' \
+  --data-binary '@local.png'
+```
+
+## 3. Enviar el job
+```bash
+curl -X POST https://mgm-api.vercel.app/api/submit-job \
+  -H 'Content-Type: application/json' \
+  -H 'Idempotency-Key: demo-1' \
+  -d '{
+    "customer": { "email": "cliente@example.com", "name": "Cliente Demo" },
+    "design_name": "Prueba",
+    "publish_to_shopify": false,
+    "material": "Classic",
+    "size_cm": { "w": 10, "h": 10, "bleed_mm": 3 },
+    "fit_mode": "cover",
+    "bg": "#ffffff",
+    "file_original_url": "https://vxkewodclwozoennpqqv.supabase.co/storage/v1/object/uploads/original/2025/08/job_20250824_6cf3a8da/0123456789abcdef.png",
+    "file_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "dpi_report": { "dpi": 300, "level": "ok" },
+    "price": { "currency": "ARS", "amount": 1000 },
+    "notes": "Job de prueba",
+    "source": "curl"
+  }'
+```
+
+## 4. Consultar estado del job
+```bash
+curl https://mgm-api.vercel.app/api/job-status?id=<JOB_ID>
+```
+
+## 5. Resumen del job
+```bash
+curl https://mgm-api.vercel.app/api/job-summary?id=<JOB_ID>
+```

--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -1,0 +1,71 @@
+{
+  "info": {
+    "name": "MGM API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Upload URL",
+      "request": {
+        "method": "POST",
+        "header": [ { "key": "Content-Type", "value": "application/json" } ],
+        "url": "{{api_base}}/api/upload-url",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"ext\": \"png\",\n  \"mime\": \"image/png\",\n  \"size_bytes\": 123456,\n  \"material\": \"Classic\",\n  \"w_cm\": 10,\n  \"h_cm\": 10,\n  \"sha256\": \"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\"\n}"
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Upload File",
+      "request": {
+        "method": "PUT",
+        "header": [ { "key": "Content-Type", "value": "image/png" } ],
+        "url": "{{signed_url}}",
+        "body": {
+          "mode": "file",
+          "file": { "src": "/path/to/local.png" }
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Submit Job",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "Idempotency-Key", "value": "demo-1" }
+        ],
+        "url": "{{api_base}}/api/submit-job",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"customer\": { \"email\": \"cliente@example.com\", \"name\": \"Cliente Demo\" },\n  \"design_name\": \"Prueba\",\n  \"publish_to_shopify\": false,\n  \"material\": \"Classic\",\n  \"size_cm\": { \"w\": 10, \"h\": 10, \"bleed_mm\": 3 },\n  \"fit_mode\": \"cover\",\n  \"bg\": \"#ffffff\",\n  \"file_original_url\": \"https://vxkewodclwozoennpqqv.supabase.co/storage/v1/object/uploads/original/2025/08/job_20250824_6cf3a8da/0123456789abcdef.png\",\n  \"file_hash\": \"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\",\n  \"dpi_report\": { \"dpi\": 300, \"level\": \"ok\" },\n  \"price\": { \"currency\": \"ARS\", \"amount\": 1000 },\n  \"notes\": \"Job de prueba\",\n  \"source\": \"postman\"\n}"
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Job Status",
+      "request": {
+        "method": "GET",
+        "url": "{{api_base}}/api/job-status?id={{job_id}}"
+      },
+      "response": []
+    },
+    {
+      "name": "Job Summary",
+      "request": {
+        "method": "GET",
+        "url": "{{api_base}}/api/job-summary?id={{job_id}}"
+      },
+      "response": []
+    }
+  ],
+  "variable": [
+    { "key": "api_base", "value": "https://mgm-api.vercel.app" },
+    { "key": "signed_url", "value": "" },
+    { "key": "job_id", "value": "" }
+  ]
+}


### PR DESCRIPTION
## Summary
- allow submit-job to accept URLs with optional /sign/ segment
- add reproducible cURL examples and Postman collection

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7c304db2883278b8f8afe4adbf78a