### PR TITLE
Remove initial EditorCanvas movement

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -144,12 +144,11 @@ export default function EditorCanvas({
     return s * 0.95;
   }, [wrapSize.w, wrapSize.h, workCm.w, workCm.h]);
   const [viewScale, setViewScale] = useState(1);
-  const [viewPos, setViewPos] = useState({ x: 0, y: 0 });
-  useEffect(() => {
-    const W = workCm.w * baseScale * viewScale;
-    const H = workCm.h * baseScale * viewScale;
-    setViewPos({ x: (wrapSize.w - W) / 2, y: (wrapSize.h - H) / 2 });
-  }, [wrapSize.w, wrapSize.h, baseScale, workCm.w, workCm.h]);
+  const [viewPos, setViewPos] = useState(() => {
+    const W = workCm.w * baseScale;
+    const H = workCm.h * baseScale;
+    return { x: (wrapSize.w - W) / 2, y: (wrapSize.h - H) / 2 };
+  });
 
   // pan
   const isPanningRef = useRef(false);


### PR DESCRIPTION
## Summary
- Compute initial canvas position once and drop auto-centering effect to prevent drift

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab27b305108327bb59d8d2d06eac3e