### PR TITLE
fix layout change effect

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -610,20 +610,31 @@ export default function EditorCanvas({
   const [colorOpen, setColorOpen] = useState(false);
   const toggleContain = () => { fitContain(); setColorOpen(true); };
   const closeColor = () => setColorOpen(false);
+  // track latest callback to avoid effect loops when parent re-renders
+  const layoutChangeRef = useRef(onLayoutChange);
+  useEffect(() => {
+    layoutChangeRef.current = onLayoutChange;
+  }, [onLayoutChange]);
 
   // export layout
   useEffect(() => {
-    onLayoutChange?.({
+    layoutChangeRef.current?.({
       dpi,
       bleed_mm: bleedMm,
       size_cm: { w: wCm, h: hCm },
       image: imgEl ? { natural_px: { w: imgEl.naturalWidth, h: imgEl.naturalHeight } } : null,
-      transform: { x_cm: imgTx.x_cm, y_cm: imgTx.y_cm, scaleX: imgTx.scaleX, scaleY: imgTx.scaleY, rotation_deg: imgTx.rotation_deg },
+      transform: {
+        x_cm: imgTx.x_cm,
+        y_cm: imgTx.y_cm,
+        scaleX: imgTx.scaleX,
+        scaleY: imgTx.scaleY,
+        rotation_deg: imgTx.rotation_deg
+      },
       mode,
       background: mode === 'contain' ? bgColor : '#ffffff',
       corner_radius_cm: cornerRadiusCm
     });
-  }, [onLayoutChange, dpi, bleedMm, wCm, hCm, imgEl, imgTx, mode, bgColor, cornerRadiusCm]);
+  }, [dpi, bleedMm, wCm, hCm, imgEl, imgTx, mode, bgColor, cornerRadiusCm]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- prevent infinite re-render by tracking `onLayoutChange` in a ref and removing it from effect deps

## Testing
- `npm test` *(fails: Missing script)*
- `cd mgm-front && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab2bfdea308327adb11e746aee7240