### PR TITLE
fix: handle CORS in submit-job endpoint

### DIFF
--- a/api/submit-job.js
+++ b/api/submit-job.js
@@ -1,6 +1,8 @@
 import supabase from './_lib/supabaseAdmin.js';
+import { cors } from '../lib/cors.js';
 
 export default async function handler(req, res) {
+  if (cors(req, res)) return;
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
     return res.status(405).json({ error: 'method_not_allowed' });


### PR DESCRIPTION
## Summary
- handle CORS preflight and origin headers for submit-job API

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab2f2b4c848327a6a8f198684a51d2