### PR TITLE
Fix color picker copy and remove initial animations

### DIFF
--- a/mgm-front/src/App.css
+++ b/mgm-front/src/App.css
@@ -18,20 +18,7 @@
   filter: drop-shadow(0 0 2em #61dafbaa);
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
+/* Removed logo spin animation to keep page static on load */
 
 .card {
   padding: 2em;

--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -50,6 +50,9 @@ function ColorPopover({ value, onChange, open, onClose }) {
         const res = await eyedropper.open();
         setHex(res.sRGBHex);
         onChange?.(res.sRGBHex);
+        await navigator.clipboard?.writeText(res.sRGBHex);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 900);
       }
     } catch { /* ignore */ }
   };

--- a/mgm-front/src/index.css
+++ b/mgm-front/src/index.css
@@ -38,17 +38,12 @@ button:hover:not(:disabled) {
   border-color: #646cff;
 }
 
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(360deg); }
-}
-
+/* Removed loading spinner animation to prevent moving content on load */
 .spinner {
   width: 40px;
   height: 40px;
   border: 4px solid rgba(255,255,255,0.3);
   border-top-color: #fff;
   border-radius: 50%;
-  animation: spin 1s linear infinite;
 }
 


### PR DESCRIPTION
## Summary
- remove initial CSS animations so text stays static on load
- copy selected color to clipboard when using eyedropper

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab348e20c8832790424d4faf51e2aa