### PR TITLE
feat: add env validation and robust submit job endpoint

### DIFF
--- a/api/_lib/env.js
+++ b/api/_lib/env.js
@@ -1,0 +1,21 @@
+import 'dotenv/config';
+
+export function mask(value = '') {
+  if (!value) return '';
+  return `${value.slice(0, 6)}…****`;
+}
+
+export function getEnv() {
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE } = process.env;
+  const missing = [];
+  if (!SUPABASE_URL) missing.push('SUPABASE_URL');
+  if (!SUPABASE_SERVICE_ROLE) missing.push('SUPABASE_SERVICE_ROLE');
+  if (missing.length) {
+    const err = new Error(`Missing required env vars: ${missing.join(', ')}`);
+    err.missing = missing;
+    throw err;
+  }
+  return { SUPABASE_URL, SUPABASE_SERVICE_ROLE };
+}
+
+export default { getEnv, mask };

--- a/api/_lib/supabaseAdmin.js
+++ b/api/_lib/supabaseAdmin.js
@@ -1,17 +1,19 @@
 import { createClient } from '@supabase/supabase-js';
+import { getEnv } from './env.js';
 
-const SUPABASE_URL = process.env.SUPABASE_URL;
-const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+let client;
 
-if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
-  throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE env vars');
+export function getSupabaseAdmin() {
+  if (!client) {
+    const { SUPABASE_URL, SUPABASE_SERVICE_ROLE } = getEnv();
+    client = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE, {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    });
+  }
+  return client;
 }
 
-export const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE, {
-  auth: {
-    autoRefreshToken: false,
-    persistSession: false
-  }
-});
-
-export default supabaseAdmin;
+export default getSupabaseAdmin;

--- a/api/env-check.js
+++ b/api/env-check.js
@@ -1,0 +1,24 @@
+import { getEnv, mask } from './_lib/env.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ ok: false, error: 'method_not_allowed' });
+  }
+  try {
+    const env = getEnv();
+    return res.status(200).json({
+      ok: true,
+      env: {
+        SUPABASE_URL: env.SUPABASE_URL,
+        SUPABASE_SERVICE_ROLE: mask(env.SUPABASE_SERVICE_ROLE),
+      },
+    });
+  } catch (err) {
+    return res.status(200).json({
+      ok: false,
+      error: err.message,
+      meta: { missing: err.missing, hint: 'Check Supabase env vars' },
+    });
+  }
+}

--- a/api/submit-job.js
+++ b/api/submit-job.js
@@ -1,42 +1,139 @@
-import supabase from './_lib/supabaseAdmin.js';
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
 import { cors } from '../lib/cors.js';
+import getSupabaseAdmin from './_lib/supabaseAdmin.js';
+import { getEnv } from './_lib/env.js';
+
+async function parseBody(req) {
+  if (req.body) {
+    if (typeof req.body === 'string') {
+      try { return JSON.parse(req.body); } catch { return {}; }
+    }
+    return req.body;
+  }
+  return await new Promise((resolve) => {
+    let data = '';
+    req.on('data', (chunk) => { data += chunk; });
+    req.on('end', () => {
+      try { resolve(JSON.parse(data || '{}')); } catch { resolve({}); }
+    });
+  });
+}
 
 export default async function handler(req, res) {
+  const diagId = randomUUID();
+  res.setHeader('X-Diag-Id', diagId);
+
   if (cors(req, res)) return;
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
-    return res.status(405).json({ error: 'method_not_allowed' });
+    return res.status(405).json({ ok: false, diag_id: diagId, stage: 'validate', message: 'method_not_allowed' });
   }
 
-  const body = req.body || {};
-  const required = ['job_id','material','w_cm','h_cm','bleed_mm','fit_mode','bg','dpi','file_original_url'];
-  const missing = required.filter((f) => body[f] === undefined || body[f] === null || body[f] === '');
-  if (missing.length) {
-    return res.status(400).json({ error: 'missing_fields', fields: missing });
+  let env;
+  try {
+    env = getEnv();
+  } catch (err) {
+    console.error('submit-job env', { diagId, stage: 'env', error: err.message });
+    return res.status(500).json({
+      ok: false,
+      diag_id: diagId,
+      stage: 'env',
+      message: 'Missing environment variables',
+      missing: err.missing,
+      hints: ['Configure SUPABASE_URL and SUPABASE_SERVICE_ROLE'],
+    });
   }
 
-  const { mode, ...payload } = body;
+  const body = await parseBody(req);
+
+  const uploadsPrefix = `${env.SUPABASE_URL}/storage/v1/object/uploads/`;
+
+  const schema = z.object({
+    job_id: z.string(),
+    material: z.string(),
+    w_cm: z.preprocess((v) => Number(v), z.number()),
+    h_cm: z.preprocess((v) => Number(v), z.number()),
+    bleed_mm: z.preprocess((v) => Number(v), z.number()),
+    fit_mode: z.string(),
+    bg: z.string(),
+    dpi: z.preprocess((v) => parseInt(v, 10), z.number().int()),
+    file_original_url: z.string().url().refine((u) => u.startsWith(uploadsPrefix), { message: 'must be a Supabase uploads URL' }),
+    customer_email: z.string().email().optional(),
+    customer_name: z.string().optional(),
+    file_hash: z.string().optional(),
+    price_amount: z.preprocess((v) => v === undefined ? undefined : Number(v), z.number().optional()),
+    price_currency: z.string().optional(),
+    notes: z.string().optional(),
+    source: z.string().optional(),
+  });
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    const missing = [];
+    const hints = [];
+    for (const issue of parsed.error.issues) {
+      if (issue.code === 'invalid_type' && issue.received === 'undefined') {
+        missing.push(issue.path.join('.'));
+      } else {
+        hints.push(`${issue.path.join('.')}: ${issue.message}`);
+      }
+    }
+    console.error('submit-job validate', { diagId, stage: 'validate', issues: parsed.error.issues });
+    return res.status(400).json({
+      ok: false,
+      diag_id: diagId,
+      stage: 'validate',
+      message: 'Invalid request body',
+      missing,
+      hints,
+    });
+  }
+
+  const payload = parsed.data;
+  const supabase = getSupabaseAdmin();
+  const idKey = req.headers['idempotency-key'] || payload.job_id;
+  payload.job_id = idKey;
 
   try {
-    let data, error;
-    if (mode === 'upsert') {
-      ({ data, error } = await supabase
-        .from('jobs')
-        .upsert(payload, { onConflict: 'job_id' })
-        .select()
-        .single());
-    } else {
-      ({ data, error } = await supabase
-        .from('jobs')
-        .insert(payload)
-        .select()
-        .single());
+    const { data: existing } = await supabase
+      .from('jobs')
+      .select('*')
+      .eq('job_id', idKey)
+      .maybeSingle();
+    if (existing) {
+      return res.status(200).json({ ok: true, job: existing });
     }
-
-    if (error) throw error;
-    return res.status(200).json(data);
   } catch (err) {
-    console.error('submit-job error', err);
-    return res.status(500).json({ error: 'database_error' });
+    console.error('submit-job select', { diagId, stage: 'supabase_insert', error: err.message });
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('jobs')
+      .insert(payload)
+      .select()
+      .single();
+    if (error) {
+      console.error('submit-job insert', { diagId, stage: 'supabase_insert', error: error.message });
+      return res.status(400).json({
+        ok: false,
+        diag_id: diagId,
+        stage: 'supabase_insert',
+        message: 'Database insert error',
+        hints: [],
+        supabase: { code: error.code, details: error.details, hint: error.hint },
+      });
+    }
+    return res.status(200).json({ ok: true, job: data });
+  } catch (err) {
+    console.error('submit-job unknown', { diagId, stage: 'unknown', error: err.message });
+    return res.status(500).json({
+      ok: false,
+      diag_id: diagId,
+      stage: 'unknown',
+      message: 'Unexpected error',
+      hints: [],
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add env helper with masking and validation
- expose diagnostic env-check endpoint
- harden submit-job with schema validation, idempotency and structured errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check api/_lib/env.js`
- `node --check api/_lib/supabaseAdmin.js`
- `node --check api/env-check.js`
- `node --check api/submit-job.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab36da01e08327aca03a9ff88d27ca