### PR TITLE
Fix optional dotenv import to avoid CORS 500

### DIFF
--- a/api/_lib/env.js
+++ b/api/_lib/env.js
@@ -1,4 +1,10 @@
-import 'dotenv/config';
+// Load environment variables from .env in development.
+// If the optional dependency is not present, ignore the error.
+try {
+  await import('dotenv/config');
+} catch {
+  // no-op
+}
 
 export function mask(value = '') {
   if (!value) return '';


### PR DESCRIPTION
## Summary
- Avoid crashing when `dotenv` is not installed by importing it optionally in env loader

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e "import('./api/_lib/env.js').then(()=>console.log('loaded')).catch(err=>console.error('err',err))"`


------
https://chatgpt.com/codex/tasks/task_e_68ab3e94043083279b8a8704db02cd4f