### PR TITLE
Improve CORS middleware and document allowed origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# MGM API
+
+## Configuración de CORS
+
+Establece la variable de entorno `ALLOWED_ORIGINS` como una lista separada por comas de orígenes sin barra final.
+
+En Vercel debe contener **exactamente**:
+
+```
+ALLOWED_ORIGINS=http://localhost:5173,https://<tu-front>.vercel.app
+```
+
+Reemplaza `<tu-front>` con el nombre de tu deploy del front-end en Vercel.

--- a/api/create-checkout.js
+++ b/api/create-checkout.js
@@ -1,6 +1,7 @@
 // /api/create-checkout.js
 import { supa } from '../lib/supa.js';
 import { shopifyAdmin } from '../lib/shopify.js';
+import { cors } from '../lib/cors.js';
 
 async function getInvoiceUrl(draftId) {
   // lee el draft y devuelve invoice_url si existe
@@ -9,6 +10,7 @@ async function getInvoiceUrl(draftId) {
 }
 
 export default async function handler(req, res) {
+  if (cors(req, res)) return;
   try {
     if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
     const { job_id } = req.body || {};

--- a/api/env-check.js
+++ b/api/env-check.js
@@ -1,6 +1,8 @@
 import { getEnv, mask } from './_lib/env.js';
+import { cors } from '../lib/cors.js';
 
 export default async function handler(req, res) {
+  if (cors(req, res)) return;
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');
     return res.status(405).json({ ok: false, error: 'method_not_allowed' });

--- a/api/worker-process.js
+++ b/api/worker-process.js
@@ -1,5 +1,6 @@
 // /api/worker-process.js  (dynamic import + pasos)
 import { supa } from '../lib/supa.js';
+import { cors } from '../lib/cors.js';
 
 async function readJson(req){
   const chunks=[]; for await (const c of req) chunks.push(c);
@@ -8,6 +9,7 @@ async function readJson(req){
 }
 
 export default async function handler(req, res) {
+  if (cors(req, res)) return;
   if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
   const auth = req.headers['authorization'] || '';
   if (auth !== `Bearer ${process.env.WORKER_TOKEN}`) {

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -3,35 +3,37 @@ export function cors(req, res) {
   const allowedEnv = process.env.ALLOWED_ORIGINS || '';
   const allowed = allowedEnv.split(',').map(s => s.trim().replace(/\/$/, '')).filter(Boolean);
   const originRaw = req.headers.origin || '';
-  const origin = originRaw.replace(/\/$/, ''); // sin barra final
+  const origin = originRaw.replace(/\/$/, '');
+  const isDev = (process.env.NODE_ENV !== 'production') && (process.env.VERCEL_ENV !== 'production');
 
-  let allowOrigin = '*';
-  let allowCreds = false;
-
+  let allowOrigin = '';
   if (allowed.length === 0) {
-    // desarrollo abierto
-    allowOrigin = '*';
-  } else if (allowed.includes(origin)) {
-    allowOrigin = origin;
-    allowCreds = true; // solo si devolvemos un origin específico
-  } else if (allowed.includes('*')) {
-    allowOrigin = '*';
+    allowOrigin = isDev ? '*' : origin;
   } else {
-    // Origen no permitido: corta preflight con 403 explícito
-    if (req.method === 'OPTIONS') {
-      res.status(403).json({ ok:false, error:'cors_origin_not_allowed', origin, allowed });
-      return true;
+    if (allowed.includes(origin)) {
+      allowOrigin = origin;
+    } else if (isDev && origin.startsWith('http://localhost:')) {
+      allowOrigin = origin;
     }
-    // Para requests no-OPTIONS, seguir sin CORS; el navegador bloqueará
   }
 
-  res.setHeader('Access-Control-Allow-Origin', allowOrigin);
   res.setHeader('Vary', 'Origin');
-  if (allowCreds) res.setHeader('Access-Control-Allow-Credentials', 'true');
-  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PATCH,PUT,DELETE,OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, Idempotency-Key');
   res.setHeader('Access-Control-Expose-Headers', 'X-Diag-Id');
+  if (allowOrigin) {
+    res.setHeader('Access-Control-Allow-Origin', allowOrigin);
+    if (allowOrigin !== '*') res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Idempotency-Key');
   res.setHeader('Access-Control-Max-Age', '86400');
+
+  if (!allowOrigin) {
+    if (req.method === 'OPTIONS') {
+      res.status(403).json({ ok:false, error:'cors_origin_not_allowed', origin });
+      return true;
+    }
+    return false;
+  }
 
   if (req.method === 'OPTIONS') { res.status(204).end(); return true; }
   return false;


### PR DESCRIPTION
## Summary
- refine CORS logic: normalized `ALLOWED_ORIGINS`, dynamic `Access-Control-Allow-Origin`, and expose diagnostic headers
- apply CORS middleware at start of all handlers
- document `ALLOWED_ORIGINS` format for Vercel

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab6f627ab08327b17eecb799672ce7