### PR TITLE
fix: remove self import in submitJob

### DIFF
--- a/mgm-front/src/lib/submitJob.ts
+++ b/mgm-front/src/lib/submitJob.ts
@@ -1,4 +1,3 @@
-import { submitJob } from '@/lib/submitJob';      // o '../lib/submitJob'
 // src/lib/submitJob.ts
 export interface SubmitJobBody {
   job_id: string;


### PR DESCRIPTION
## Summary
- remove accidental self-import from submitJob

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: no-unused-vars, no-undef)


------
https://chatgpt.com/codex/tasks/task_e_68ab8d5a6fd08327ab4418d9a3d240d2