### PR TITLE
Use query param for confirm navigation

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -128,7 +128,7 @@ export default function Home() {
       const job = await submitJobApi(API_BASE, submitBody);
 
       // 8) navegar a confirm
-      navigate(`/confirm/${job.job_id}`);
+      navigate(`/confirm?job_id=${job.job_id}`);
     } catch (e) {
       console.error(e);
       setErr(String(e?.message || e));


### PR DESCRIPTION
## Summary
- fix confirm navigation to use job_id query parameter

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: no-unused-vars, no-undef)


------
https://chatgpt.com/codex/tasks/task_e_68ab9e9940308327843a46466932f137