### PR TITLE
Fix design_name insert when schema column missing

### DIFF
--- a/api/submit-job.js
+++ b/api/submit-job.js
@@ -96,10 +96,13 @@ export default async function handler(req, res) {
     file_hash: input.file_hash ?? null,
     price_amount: input.price_amount ?? null,
     price_currency: input.price_currency ?? null,
-    design_name: input.design_name ?? null,
     notes: input.notes ?? null,
     source: input.source ?? 'api',
   };
+
+  if (input.design_name !== undefined) {
+    payloadInsert.design_name = input.design_name;
+  }
 
   const supabase = getSupabaseAdmin();
 

--- a/mgm-front/src/lib/submitJob.ts
+++ b/mgm-front/src/lib/submitJob.ts
@@ -14,6 +14,7 @@ export interface SubmitJobBody {
   file_hash?: string;
   price_amount?: number;
   price_currency?: string;
+  design_name?: string;
   notes?: string;
   source?: string;
 }


### PR DESCRIPTION
## Summary
- allow clients to pass an optional `design_name` when submitting jobs
- send `design_name` to Supabase only if provided to avoid schema cache errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd mgm-front && npm test` *(fails: Missing script "test")*
- `cd mgm-front && npm run lint` *(fails: 21 problems (13 errors, 8 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68aba674f724832798d917e160079e7b