### PR TITLE
feat: add real cropping and cart flow

### DIFF
--- a/api/create-cart-link.js
+++ b/api/create-cart-link.js
@@ -144,17 +144,20 @@ export default async function handler(req, res) {
       'items[0][properties][pdf_url]': job.pdf_url,
       // si te preocupa la longitud, puedes comentar uno de los dos URLs
     };
-    const cartUrl = `${pubBase}/cart/add?${qs(props)}&return_to=%2Fcart`;
+    const cartUrlFollow = `${pubBase}/cart/add?${qs(props)}&return_to=%2Fcart`;
+    const checkoutUrlNow = `${pubBase}/cart/add?${qs(props)}&return_to=%2Fcheckout`;
 
     // 4) Guardar y devolver
-    await supa.from('jobs').update({ cart_url: cartUrl }).eq('id', job.id);
+    await supa.from('jobs').update({ cart_url: cartUrlFollow }).eq('id', job.id);
 
     return res.status(200).json({
       ok: true,
       job_id: job.job_id,
       product_id: productId,
       variant_id: variantId,
-      cart_url: cartUrl
+      cart_url: cartUrlFollow,
+      cart_url_follow: cartUrlFollow,
+      checkout_url_now: checkoutUrlNow,
     });
   } catch (e) {
     console.error('create_cart_link_error', e);

--- a/mgm-front/src/components/OptionsStep.jsx
+++ b/mgm-front/src/components/OptionsStep.jsx
@@ -16,22 +16,6 @@ const Form = z.object({
   bg: z.string().optional()
 });
 
-// --- Helpers locales (sin tocar tu estructura de carpetas) ---
-function canonicalizeSupabaseUploadsUrl(input) {
-  if (!input) return input;
-  try {
-    const u = new URL(input);
-    // normaliza rutas firmadas a canónica /uploads/
-    let p = u.pathname
-      .replace('/storage/v1/object/upload/sign/uploads/', '/storage/v1/object/uploads/')
-      .replace('/storage/v1/object/sign/uploads/', '/storage/v1/object/uploads/');
-    // quita query (?token=...)
-    return `${u.origin}${p}`;
-  } catch {
-    return input;
-  }
-}
-
 export default function OptionsStep({ uploaded, onSubmitted }) {
   const [material, setMaterial] = useState('Classic');
   const [sizeMode, setSizeMode] = useState('standard');

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -4,6 +4,8 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from './App.jsx';
 import Home from './pages/Home.jsx';
 import Confirm from './pages/Confirm.jsx';
+import Creating from './pages/Creating.jsx';
+import Result from './pages/Result.jsx';
 import './globals.css';
 
 const router = createBrowserRouter([
@@ -11,7 +13,9 @@ const router = createBrowserRouter([
     element: <App />,
     children: [
       { path: '/', element: <Home /> },
-      { path: '/confirm', element: <Confirm /> }
+      { path: '/confirm', element: <Confirm /> },
+      { path: '/creating/:jobId', element: <Creating /> },
+      { path: '/result/:jobId', element: <Result /> }
     ]
   }
 ]);

--- a/mgm-front/src/pages/Creating.jsx
+++ b/mgm-front/src/pages/Creating.jsx
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import LoadingOverlay from '../components/LoadingOverlay';
+import { pollJobAndCreateCart } from '../lib/pollJobAndCreateCart';
+
+export default function Creating() {
+  const { jobId } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const render = location.state?.render;
+  const apiBase = import.meta.env.VITE_API_BASE || 'https://mgm-api.vercel.app';
+
+  useEffect(() => {
+    let cancelled = false;
+    async function run() {
+      try {
+        await fetch(`${apiBase}/api/finalize-assets`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(render ? { job_id: jobId, render } : { job_id: jobId })
+        }).catch(() => {});
+
+        const res = await pollJobAndCreateCart(apiBase, jobId);
+        if (!cancelled) {
+          navigate(`/result/${jobId}`, {
+            state: {
+              cart_url_follow: res?.raw?.cart_url_follow || res?.raw?.cart_url,
+              checkout_url_now: res?.raw?.checkout_url_now
+            }
+          });
+        }
+      } catch {
+        if (!cancelled) navigate(`/result/${jobId}`);
+      }
+    }
+    if (jobId) run();
+    return () => { cancelled = true; };
+  }, [apiBase, jobId, render, navigate]);
+
+  return (
+    <div>
+      <LoadingOverlay show messages={["Creando tu pedido…"]} />
+      <button onClick={() => navigate('/')}>Cancelar</button>
+    </div>
+  );
+}

--- a/mgm-front/src/pages/Result.jsx
+++ b/mgm-front/src/pages/Result.jsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+
+export default function Result() {
+  const { jobId } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const apiBase = import.meta.env.VITE_API_BASE || 'https://mgm-api.vercel.app';
+
+  const [urls, setUrls] = useState({
+    cart_url_follow: location.state?.cart_url_follow,
+    checkout_url_now: location.state?.checkout_url_now,
+  });
+  const [job, setJob] = useState(null);
+
+  useEffect(() => {
+    async function fetchJob() {
+      try {
+        const res = await fetch(`${apiBase}/api/job-status?job_id=${encodeURIComponent(jobId)}`);
+        const j = await res.json();
+        if (res.ok && j.ok) setJob(j.job);
+      } catch { /* ignore */ }
+    }
+    fetchJob();
+  }, [apiBase, jobId]);
+
+  useEffect(() => {
+    if (!urls.cart_url_follow || !urls.checkout_url_now) {
+      async function ensureUrls() {
+        try {
+          const res = await fetch(`${apiBase}/api/create-cart-link`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ job_id: jobId }),
+          });
+          const j = await res.json();
+          if (res.ok) {
+            setUrls({
+              cart_url_follow: j.cart_url_follow || j.cart_url,
+              checkout_url_now: j.checkout_url_now,
+            });
+          }
+        } catch { /* ignore */ }
+      }
+      ensureUrls();
+    }
+  }, [urls, apiBase, jobId]);
+
+  if (!urls.cart_url_follow || !urls.checkout_url_now) {
+    return <p>Preparando tu carrito…</p>;
+  }
+
+  return (
+    <div>
+      {job?.preview_url && (
+        <img src={job.preview_url} alt="preview" style={{ maxWidth: '300px' }} />
+      )}
+      <div>
+        <button onClick={() => { window.location.href = urls.cart_url_follow; }}>
+          Agregar al carrito y seguir comprando
+        </button>
+        <button onClick={() => { window.location.href = urls.checkout_url_now; }}>
+          Pagar ahora
+        </button>
+        <button onClick={() => { window.open(urls.cart_url_follow, '_blank', 'noopener'); navigate('/'); }}>
+          Crear otro
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- support real crop/render in finalize-assets with mock 1080 output
- extend create-cart-link to return checkout and cart URLs
- add Creating and Result pages with new flow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd mgm-front && npm test` *(fails: Missing script: "test")*
- `cd mgm-front && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abb40d65a88327a008e39e7a756215