### PR TITLE
feat: make cart link idempotent

### DIFF
--- a/api/create-cart-link.js
+++ b/api/create-cart-link.js
@@ -1,15 +1,17 @@
 // /api/create-cart-link.js
-// Crea (o reutiliza) un producto/variante y devuelve un link que agrega el ítem al carrito con properties.
+// Endpoint idempotente para crear/reutilizar producto y variante en Shopify.
 import crypto from 'node:crypto';
 import { supa } from '../lib/supa.js';
-import { shopifyAdmin } from '../lib/shopify.js';
+import { shopifyAdmin, shopifyAdminGraphQL } from '../lib/shopify.js';
 import { cors } from './_lib/cors.js';
 
-function sizeLabel(w, h) {
-  return `${Number(w)}x${Number(h)} cm`;
-}
-function slugify(s){ return s.toString().toLowerCase().trim()
+function slugify(s){ return String(s).toLowerCase().trim()
   .replace(/\s+/g,'-').replace(/[^a-z0-9-]/g,'').replace(/-+/g,'-').replace(/^-|-$/g,''); }
+function parseDesignNameFromNotes(notes) {
+  if (!notes) return null;
+  const m = String(notes).match(/design_name\s*[:=]\s*([^|]+)$/i);
+  return m ? m[1].trim() : null;
+}
 function qs(obj) {
   return Object.entries(obj).map(([k,v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v ?? '')}`).join('&');
 }
@@ -29,138 +31,195 @@ export default async function handler(req, res) {
     const { job_id } = req.body || {};
     if (!job_id) return res.status(400).json({ error: 'missing_job_id' });
 
-    // 1) Cargar job (necesita assets y precio)
+    // 1) Cargar job
     const { data: job, error } = await supa.from('jobs').select('*').eq('job_id', job_id).single();
     if (error || !job) return res.status(404).json({ error: 'job_not_found' });
     if (!job.print_jpg_url || !job.pdf_url) return res.status(409).json({ error: 'assets_not_ready' });
     if (!job.price_amount || job.price_amount <= 0) return res.status(400).json({ error: 'invalid_price' });
 
-    // 2) Buscar/crear PRODUCTO y VARIANTE
+    const dn = job.design_name || parseDesignNameFromNotes(job.notes) || 'Personalizado';
+    const w = Number(job.w_cm), h = Number(job.h_cm);
+    const mat = String(job.material || 'Classic');
+    const designSlug = slugify(dn);
+    const job8 = String(job.job_id).replace(/[^a-z0-9]/ig,'').slice(0,8) || 'custom';
+
+    const title = `Mousepad ${dn} ${w}x${h} ${mat} | PERSONALIZADO`;
+    const handle = `mousepad-${designSlug}-${w}x${h}-${mat.toLowerCase()}-${job8}`;
+
+    const optMaterial = mat;
+    const optSize = `${w}x${h} cm`;
+    const baseTags = `custom-upload,job:${job.job_id},material:${optMaterial},size:${optSize}`;
+
     let productId = job.shopify_product_id || null;
     let variantId = job.shopify_variant_id || null;
-    const optMaterial = job.material;
-    const optSize = sizeLabel(job.w_cm, job.h_cm);
 
-    async function ensureProductAndVariant() {
-      // Si ya tenemos product + variant guardados, listo
-      if (productId && variantId) return;
+    // 2) Si ya hay IDs en DB, reutilizar
+    if (productId && variantId) {
+      // Construir URLs y devolver
+      const pubBase = process.env.SHOPIFY_PUBLIC_BASE || `https://${process.env.SHOPIFY_STORE_DOMAIN}`;
+      const props = {
+        'items[0][id]': variantId,
+        'items[0][quantity]': 1,
+        'items[0][properties][jobId]': job.job_id,
+        'items[0][properties][material]': optMaterial,
+        'items[0][properties][size_cm]': `${w}x${h}`,
+        'items[0][properties][print_jpg_url]': job.print_jpg_url,
+        'items[0][properties][pdf_url]': job.pdf_url,
+      };
+      const query = qs(props);
+      const cart_url_follow  = `${pubBase}/cart/add?${query}&return_to=%2Fcart`;
+      const checkout_url_now = `${pubBase}/cart/add?${query}&return_to=%2Fcheckout`;
+      const cart_plain = `${pubBase}/cart`;
+      const checkout_plain = `${pubBase}/checkout`;
 
-      if (!productId && job.is_public && job.preview_url) {
-        // Si es público y no hay product: crear uno sencillo con 1 variante
-        const hash8 = (job.file_hash || '').slice(0,8) || 'custom';
-        const handle = `${slugify(job.design_name || job.notes || 'diseno')}-${hash8}`;
-        const title = `Mousepad "${job.design_name || 'Diseño'}" Medida ${optSize} ${optMaterial} | PERSONALIZADO`;
-        const payload = {
-          product: {
-            title,
-            body_html: `<p>Diseño personalizado subido por un cliente.</p>`,
-            handle,
-            tags: `custom-upload,hash:${hash8},material:${optMaterial},size:${optSize}`,
-            images: job.preview_url ? [{ src: job.preview_url }] : [],
-            options: [{ name: 'Material' }, { name: 'Tamaño' }],
-            variants: [{
-              option1: optMaterial,
-              option2: optSize,
-              price: Number(job.price_amount).toFixed(2),
-              sku: `MP-${optMaterial === 'Classic' ? 'CL':'PR'}-${String(Number(job.w_cm)).padStart(3,'0')}x${String(Number(job.h_cm)).padStart(3,'0')}`
-            }],
-            status: 'active'
-          }
-        };
-        const { product } = await shopifyAdmin(`/products.json`, { method: 'POST', body: JSON.stringify(payload) });
-        productId = String(product.id);
-        variantId = String(product.variants?.[0]?.id || '');
-      }
+      await supa.from('jobs').update({ cart_url: cart_url_follow }).eq('id', job.id);
 
-      // Si hay productId pero falta la variante exacta, crear variante
-      if (productId && !variantId) {
-        // Traer producto para ver si existe esa variante
-        const { product } = await shopifyAdmin(`/products/${productId}.json`, { method: 'GET' });
-        const found = (product.variants || []).find(v =>
-          (v.option1 === optMaterial) && (v.option2 === optSize)
-        );
-        if (found) {
-          variantId = String(found.id);
-        } else {
-          const payloadVar = {
-            variant: {
-              option1: optMaterial,
-              option2: optSize,
-              price: Number(job.price_amount).toFixed(2),
-              sku: `MP-${optMaterial === 'Classic' ? 'CL':'PR'}-${String(Number(job.w_cm)).padStart(3,'0')}x${String(Number(job.h_cm)).padStart(3,'0')}`
-            }
-          };
-          const { variant } = await shopifyAdmin(`/products/${productId}/variants.json`, { method: 'POST', body: JSON.stringify(payloadVar) });
-          variantId = String(variant.id);
-        }
-      }
-
-      // Si no teníamos producto (privado): crear producto “oculto” con 1 variante (visible pero sin enlazar)
-      if (!productId) {
-        const handle = `personalizado-${slugify(job.job_id)}`;
-        const title = `Mousepad "${job.design_name || 'Personalizado'}" Medida ${optSize} ${optMaterial} | PERSONALIZADO`;
-        const payload = {
-          product: {
-            title,
-            body_html: `<p>Diseño personalizado.</p>`,
-            handle,
-            tags: `custom-upload,job:${job.job_id},material:${optMaterial},size:${optSize}`,
-            images: job.preview_url ? [{ src: job.preview_url }] : [],
-            options: [{ name: 'Material' }, { name: 'Tamaño' }],
-            variants: [{
-              option1: optMaterial,
-              option2: optSize,
-              price: Number(job.price_amount).toFixed(2),
-              sku: `MP-${optMaterial === 'Classic' ? 'CL':'PR'}-${String(Number(job.w_cm)).padStart(3,'0')}x${String(Number(job.h_cm)).padStart(3,'0')}`
-            }],
-            status: 'active'
-          }
-        };
-        const { product } = await shopifyAdmin(`/products.json`, { method: 'POST', body: JSON.stringify(payload) });
-        productId = String(product.id);
-        variantId = String(product.variants?.[0]?.id || '');
-      }
-
-      // Guardar en DB
-      await supa.from('jobs').update({
-        shopify_product_id: productId,
-        shopify_variant_id: variantId
-      }).eq('id', job.id);
+      return res.status(200).json({
+        ok: true,
+        job_id: job.job_id,
+        product_id: productId,
+        variant_id: variantId,
+        cart_url: cart_url_follow,
+        cart_url_follow,
+        checkout_url_now,
+        cart_plain,
+        checkout_plain,
+      });
     }
 
-    await ensureProductAndVariant();
+    // 3) Buscar en Shopify antes de crear
+    const qByTag = `\nquery($q: String!) {\n  products(first: 1, query: $q) {\n    edges { node { id handle title variants(first: 50) { edges { node { id option1 option2 } } } } }\n  }\n}`;
+    const qByHandle = `\nquery($h: String!) {\n  products(first: 1, query: $h) {\n    edges { node { id handle title variants(first: 50) { edges { node { id option1 option2 } } } } }\n  }\n}`;
+
+    async function findProduct() {
+      let q = `tag:'job:${job.job_id}'`;
+      let r = await shopifyAdminGraphQL(qByTag, { q });
+      let edge = r?.data?.products?.edges?.[0];
+      if (edge) return edge.node;
+
+      q = `handle:${handle}`;
+      r = await shopifyAdminGraphQL(qByHandle, { h: q });
+      edge = r?.data?.products?.edges?.[0];
+      return edge?.node || null;
+    }
+
+    const found = await findProduct();
+    if (found) {
+      productId = String(found.id).replace('gid://shopify/Product/','');
+      const v = (found.variants?.edges || []).map(e => e.node)
+        .find(v => v.option1 === optMaterial && v.option2 === optSize);
+      if (v) variantId = String(v.id).replace('gid://shopify/ProductVariant/','');
+    }
+
+    // 4) Crear sólo si no existe
+    if (!productId) {
+      const payload = {
+        product: {
+          title,
+          handle,
+          body_html: `<p>Diseño personalizado subido por el cliente.</p>`,
+          tags: baseTags,
+          images: job.preview_url ? [{ src: job.preview_url }] : [],
+          options: [{ name: 'Material' }, { name: 'Tamaño' }],
+          variants: [{
+            option1: optMaterial,
+            option2: optSize,
+            price: Number(job.price_amount).toFixed(2),
+            sku: `MP-${optMaterial === 'Classic' ? 'CL':'PR'}-${String(w).padStart(3,'0')}x${String(h).padStart(3,'0')}`
+          }],
+          status: 'active'
+        }
+      };
+      try {
+        const { product } = await shopifyAdmin(`/products.json`, { method:'POST', body: JSON.stringify(payload) });
+        productId = String(product.id);
+        variantId = String(product.variants?.[0]?.id || '');
+      } catch (e) {
+        const msg = String(e?.message || '');
+        if (msg.includes('422') || msg.toLowerCase().includes('handle')) {
+          const again = await findProduct();
+          if (again) {
+            productId = String(again.id).replace('gid://shopify/Product/','');
+            const v = (again.variants?.edges || []).map(e => e.node)
+              .find(v => v.option1 === optMaterial && v.option2 === optSize);
+            if (v) variantId = String(v.id).replace('gid://shopify/ProductVariant/','');
+          } else {
+            throw e;
+          }
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    // si existe product pero falta variante exacta, crear variante
+    if (productId && !variantId) {
+      const { product } = await shopifyAdmin(`/products/${productId}.json`, { method:'GET' });
+      const foundVar = (product.variants || []).find(v =>
+        (v.option1 === optMaterial) && (v.option2 === optSize)
+      );
+      if (foundVar) {
+        variantId = String(foundVar.id);
+      } else {
+        const payloadVar = { variant: {
+          option1: optMaterial,
+          option2: optSize,
+          price: Number(job.price_amount).toFixed(2),
+          sku: `MP-${optMaterial === 'Classic' ? 'CL':'PR'}-${String(w).padStart(3,'0')}x${String(h).padStart(3,'0')}`
+        }};
+        const { variant } = await shopifyAdmin(`/products/${productId}/variants.json`, { method:'POST', body: JSON.stringify(payloadVar) });
+        variantId = String(variant.id);
+      }
+    }
+
+    // Guardar en DB con update condicional
+    if (productId) {
+      await supa.from('jobs')
+        .update({ shopify_product_id: productId })
+        .eq('id', job.id)
+        .is('shopify_product_id', null);
+    }
+    if (variantId) {
+      await supa.from('jobs')
+        .update({ shopify_variant_id: variantId })
+        .eq('id', job.id)
+        .is('shopify_variant_id', null);
+    }
     if (!variantId) return res.status(500).json({ error: 'missing_variant_id' });
 
-    // 3) Construir el permalink para agregar al carrito con properties y volver a /cart
+    // Construir URLs
     const pubBase = process.env.SHOPIFY_PUBLIC_BASE || `https://${process.env.SHOPIFY_STORE_DOMAIN}`;
-    // Usamos /cart/add con items[0] para poder pasar properties y redirigir a /cart
     const props = {
       'items[0][id]': variantId,
       'items[0][quantity]': 1,
       'items[0][properties][jobId]': job.job_id,
-      'items[0][properties][material]': job.material,
-      'items[0][properties][size_cm]': `${Number(job.w_cm)}x${Number(job.h_cm)}`,
+      'items[0][properties][material]': optMaterial,
+      'items[0][properties][size_cm]': `${w}x${h}`,
       'items[0][properties][print_jpg_url]': job.print_jpg_url,
       'items[0][properties][pdf_url]': job.pdf_url,
-      // si te preocupa la longitud, puedes comentar uno de los dos URLs
     };
-    const cartUrlFollow = `${pubBase}/cart/add?${qs(props)}&return_to=%2Fcart`;
-    const checkoutUrlNow = `${pubBase}/cart/add?${qs(props)}&return_to=%2Fcheckout`;
+    const query = qs(props);
+    const cart_url_follow  = `${pubBase}/cart/add?${query}&return_to=%2Fcart`;
+    const checkout_url_now = `${pubBase}/cart/add?${query}&return_to=%2Fcheckout`;
+    const cart_plain = `${pubBase}/cart`;
+    const checkout_plain = `${pubBase}/checkout`;
 
-    // 4) Guardar y devolver
-    await supa.from('jobs').update({ cart_url: cartUrlFollow }).eq('id', job.id);
+    await supa.from('jobs').update({ cart_url: cart_url_follow }).eq('id', job.id);
 
     return res.status(200).json({
       ok: true,
       job_id: job.job_id,
       product_id: productId,
       variant_id: variantId,
-      cart_url: cartUrlFollow,
-      cart_url_follow: cartUrlFollow,
-      checkout_url_now: checkoutUrlNow,
+      cart_url: cart_url_follow,
+      cart_url_follow,
+      checkout_url_now,
+      cart_plain,
+      checkout_plain,
     });
   } catch (e) {
     console.error('create_cart_link_error', e);
     return res.status(500).json({ error: 'create_cart_link_failed', detail: String(e?.message || e) });
   }
 }
+

--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -33,3 +33,38 @@ export async function shopifyAdmin(path, init = {}, idemKey) {
   }
   return json;
 }
+
+/**
+ * shopifyAdminGraphQL
+ * Realiza una consulta GraphQL contra la Admin API de Shopify.
+ *
+ * @param {string} query - Consulta GraphQL
+ * @param {object} variables - Variables para la consulta
+ * @param {string} [idemKey] - opcional, para controlar la idempotencia
+ */
+export async function shopifyAdminGraphQL(query, variables = {}, idemKey) {
+  const base = `https://${process.env.SHOPIFY_STORE_DOMAIN}/admin/api/2024-07/graphql.json`;
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-Shopify-Access-Token': process.env.SHOPIFY_ADMIN_TOKEN,
+    'X-Shopify-Idempotency-Key': idemKey || randomUUID(),
+  };
+
+  const res = await fetch(base, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query, variables }),
+  });
+  const text = await res.text();
+
+  let json = null;
+  try { json = text ? JSON.parse(text) : null; } catch { /* no-op */ }
+
+  if (!res.ok) {
+    const err = new Error(`shopify ${res.status}: ${text || res.statusText}`);
+    err.status = res.status;
+    err.body = text;
+    throw err;
+  }
+  return json;
+}

--- a/mgm-front/src/pages/Result.jsx
+++ b/mgm-front/src/pages/Result.jsx
@@ -10,8 +10,11 @@ export default function Result() {
   const [urls, setUrls] = useState({
     cart_url_follow: location.state?.cart_url_follow,
     checkout_url_now: location.state?.checkout_url_now,
+    cart_plain: location.state?.cart_plain,
+    checkout_plain: location.state?.checkout_plain,
   });
   const [job, setJob] = useState(null);
+  const [added, setAdded] = useState(() => localStorage.getItem(`MGM_jobAdded:${jobId}`) === 'true');
 
   useEffect(() => {
     async function fetchJob() {
@@ -38,6 +41,8 @@ export default function Result() {
             setUrls({
               cart_url_follow: j.cart_url_follow || j.cart_url,
               checkout_url_now: j.checkout_url_now,
+              cart_plain: j.cart_plain,
+              checkout_plain: j.checkout_plain,
             });
           }
         } catch { /* ignore */ }
@@ -50,19 +55,28 @@ export default function Result() {
     return <p>Preparando tu carrito…</p>;
   }
 
+  const hrefCart = added ? urls.cart_plain : urls.cart_url_follow;
+  const hrefCheckout = added ? urls.checkout_plain : urls.checkout_url_now;
+  const openNew = (u) => window.open(u, '_blank', 'noopener,noreferrer');
+
   return (
     <div>
       {job?.preview_url && (
         <img src={job.preview_url} alt="preview" style={{ maxWidth: '300px' }} />
       )}
       <div>
-        <button onClick={() => { window.location.href = urls.cart_url_follow; }}>
+        <button onClick={() => { openNew(hrefCart); localStorage.setItem(`MGM_jobAdded:${jobId}`,'true'); setAdded(true); }}>
           Agregar al carrito y seguir comprando
         </button>
-        <button onClick={() => { window.location.href = urls.checkout_url_now; }}>
+        <button onClick={() => { openNew(hrefCheckout); localStorage.setItem(`MGM_jobAdded:${jobId}`,'true'); setAdded(true); }}>
           Pagar ahora
         </button>
-        <button onClick={() => { window.open(urls.cart_url_follow, '_blank', 'noopener'); navigate('/'); }}>
+        <button onClick={() => {
+          openNew(hrefCart);
+          localStorage.setItem(`MGM_jobAdded:${jobId}`,'true');
+          setAdded(true);
+          navigate('/');
+        }}>
           Crear otro
         </button>
       </div>


### PR DESCRIPTION
## Summary
- ensure `/api/create-cart-link` is idempotent per job and reuse Shopify products/variants
- expose `shopifyAdminGraphQL` for product lookups
- update result page buttons to open cart/checkout in new tabs without duplicating items

## Testing
- `npm test` (fails: Missing script: "test")
- `cd mgm-front && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68abc80e9d5883278930ef074dbe49da