### PR TITLE
feat: add price calculator and glasspad sizing

### DIFF
--- a/mgm-front/src/components/Calculadora.jsx
+++ b/mgm-front/src/components/Calculadora.jsx
@@ -1,0 +1,118 @@
+import React from "react";
+
+const rolloData = {
+  Pro:    { width: 125, pricePerMeter: 36145, multiplier: 3.2, baselineArea: 0.26 },
+  Clasic: { width: 140, pricePerMeter: 23820, multiplier: 2.7, baselineArea: 0.36 },
+};
+
+const GLASSPAD_TRANSFER_PRICE = 110000; // con transferencia (fijo)
+
+function formatARS(n) {
+  return n.toLocaleString("es-AR", { maximumFractionDigits: 0, minimumFractionDigits: 0 });
+}
+
+// Mapea materiales del UI a los keys internos de la calculadora
+function mapMode(material) {
+  if (!material) return "";
+  const m = String(material).toLowerCase();
+  if (m === "pro") return "Pro";
+  if (m === "classic") return "Clasic";
+  if (m === "glasspad") return "Glasspad";
+  return material; // fallback
+}
+
+const Calculadora = ({ width, height, material, setPrice }) => {
+  const mode = mapMode(material);
+
+  // --- Glasspad: precio fijo ---
+  if (mode === "Glasspad") {
+    const transferPrice = GLASSPAD_TRANSFER_PRICE;               // $110.000 con transferencia
+    const normalFromTransfer = Math.round(transferPrice * 1.25); // +25% → $137.500 lista
+    if (typeof setPrice === "function") setPrice(normalFromTransfer);
+
+    return (
+      <div>
+        <p className="p-calcu">${formatARS(normalFromTransfer)}</p>
+        <p className="minitext">20% OFF con transferencia: {formatARS(transferPrice)}</p>
+      </div>
+    );
+  }
+
+  // --- Pro / Clasic ---
+  if (!rolloData[mode]) {
+    if (typeof setPrice === "function") setPrice(0);
+    return <p>Modo no válido</p>;
+  }
+
+  const { width: rolloWidth, pricePerMeter, multiplier, baselineArea } = rolloData[mode];
+  const rolloWidthM = rolloWidth / 100;
+
+  const normalizedWidthCm  = Number(width)  || 0;
+  const normalizedHeightCm = Number(height) || 0;
+
+  const pieceWidthM  = normalizedWidthCm / 100;
+  const pieceHeightM = normalizedHeightCm / 100;
+
+  const unitsHorizontal =
+    Math.floor(rolloWidthM / pieceWidthM) * Math.floor(1 / pieceHeightM);
+  const unitsRotated =
+    Math.floor(rolloWidthM / pieceHeightM) * Math.max(Math.floor(1 / pieceWidthM), 1);
+  const unitsPerMeter = Math.max(unitsHorizontal, unitsRotated, 1);
+
+  const defaultPricePerUnit = pricePerMeter / unitsPerMeter;
+
+  // Modelo rotado si conviene
+  const useRotatedModel =
+    !(pieceWidthM === 1.4 && pieceHeightM === 1) &&
+    pieceWidthM > 1 &&
+    pieceWidthM < rolloWidthM;
+
+  let finalCostPerUnit;
+  if (useRotatedModel) {
+    const piecesPerRow = Math.floor(rolloWidthM / pieceHeightM);
+    const baseCostPerUnit = pricePerMeter / piecesPerRow;
+    const extraCost = ((pieceWidthM - 1) * pricePerMeter) / piecesPerRow;
+    finalCostPerUnit = baseCostPerUnit + extraCost;
+  } else {
+    finalCostPerUnit = defaultPricePerUnit;
+  }
+
+  const yieldPrice = finalCostPerUnit * multiplier;
+  const costPerM2  = pricePerMeter / rolloWidthM;
+  const area       = pieceWidthM * pieceHeightM;
+  const areaPrice  = area * costPerM2 * multiplier;
+
+  let baseFinalPrice = Math.min(yieldPrice, areaPrice);
+
+  const surchargeFactor = 5000;
+  const extraArea = Math.max(0, area - baselineArea);
+  const areaSurcharge = surchargeFactor * extraArea;
+
+  // recargos menores
+  if (normalizedWidthCm < 40 && normalizedHeightCm < 40) {
+    baseFinalPrice *= 1.3;
+  }
+
+  const roundTo500 = (p) => Math.ceil(p / 500) * 500;
+  const basePriceRounded = roundTo500(baseFinalPrice + areaSurcharge);
+
+  // Lista (tarjeta) = transferencia * 1.25; transferencia = lista * 0.8
+  let clientFinalPrice = Math.round(basePriceRounded * 1.25);
+
+  // Ajuste transferencia: +$2.000 para Classic
+  const isClassic = mode === "Clasic";
+  const transferBase = Math.round(clientFinalPrice * 0.8);
+  const transferWithExtra = isClassic ? transferBase + 2000 : transferBase;
+  const normalFromTransfer = Math.round(transferWithExtra / 0.8);
+
+  if (typeof setPrice === "function") setPrice(normalFromTransfer);
+
+  return (
+    <div>
+      <p className="p-calcu">${formatARS(normalFromTransfer)}</p>
+      <p className="minitext">20% OFF con transferencia: {formatARS(transferWithExtra)}</p>
+    </div>
+  );
+};
+
+export default Calculadora;

--- a/mgm-front/src/components/SizeControls.jsx
+++ b/mgm-front/src/components/SizeControls.jsx
@@ -10,9 +10,9 @@ import { LIMITS, STANDARD } from '../lib/material.js';
  * - mode: 'standard' | 'custom'
  * - onChange: ({ material, mode, w, h }) => void
  */
-export default function SizeControls({ material, size, mode, onChange }) {
-  const limits = LIMITS[material];
-  const standard = STANDARD[material];
+export default function SizeControls({ material, size, mode, onChange, locked = false }) {
+  const limits = LIMITS[material] || { maxW: size.w, maxH: size.h };
+  const standard = STANDARD[material] || [];
   const currentValue = `${size.w}x${size.h}`;
 
   const options = useMemo(
@@ -32,6 +32,7 @@ export default function SizeControls({ material, size, mode, onChange }) {
         >
           <option>Classic</option>
           <option>PRO</option>
+          <option>Glasspad</option>
         </select>
       </label>
 
@@ -39,6 +40,7 @@ export default function SizeControls({ material, size, mode, onChange }) {
         <select
           value={mode}
           onChange={(e) => onChange({ mode: e.target.value })}
+          disabled={locked}
         >
           <option value="standard">Estándar</option>
           <option value="custom">Personalizado</option>
@@ -53,6 +55,7 @@ export default function SizeControls({ material, size, mode, onChange }) {
               const [w, h] = e.target.value.split('x').map(Number);
               onChange({ mode: 'standard', w, h });
             }}
+            disabled={locked}
           >
             {options.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
           </select>
@@ -66,6 +69,7 @@ export default function SizeControls({ material, size, mode, onChange }) {
                 const w = Math.max(1, Math.min(limits.maxW, Number(e.target.value) || 0));
                 onChange({ w, h: size.h });
               }}
+              disabled={locked}
             />
           </label>
           <label>Alto (cm)
@@ -75,12 +79,18 @@ export default function SizeControls({ material, size, mode, onChange }) {
                 const h = Math.max(1, Math.min(limits.maxH, Number(e.target.value) || 0));
                 onChange({ w: size.w, h });
               }}
+              disabled={locked}
             />
           </label>
-          <small className={styles.helper}>
-            Máximo {limits.maxW}×{limits.maxH} cm para {material}
-          </small>
+          {!locked && (
+            <small className={styles.helper}>
+              Máximo {limits.maxW}×{limits.maxH} cm para {material}
+            </small>
+          )}
         </>
+      )}
+      {locked && (
+        <small className={styles.helper}>Medida fija 50×40 cm</small>
       )}
     </div>
   );

--- a/mgm-front/src/globals.css
+++ b/mgm-front/src/globals.css
@@ -54,3 +54,15 @@ button:hover:not(:disabled) {
 .errorText {
   color: crimson;
 }
+
+.p-calcu {
+  font-size: 1.4em;
+  font-weight: bold;
+  margin: 8px 0 0;
+}
+
+.minitext {
+  font-size: 0.8em;
+  color: #9ca3af;
+  margin: 0;
+}

--- a/mgm-front/src/lib/material.js
+++ b/mgm-front/src/lib/material.js
@@ -1,6 +1,7 @@
 export const LIMITS = {
   Classic: { maxW: 140, maxH: 100 },
   PRO: { maxW: 120, maxH: 60 },
+  Glasspad: { maxW: 50, maxH: 40 },
 };
 
 export const STANDARD = {
@@ -16,5 +17,8 @@ export const STANDARD = {
     { w: 50, h: 40 },
     { w: 90, h: 40 },
     { w: 120, h: 60 },
+  ],
+  Glasspad: [
+    { w: 50, h: 40 },
   ],
 };


### PR DESCRIPTION
## Summary
- add `Calculadora` component for pricing
- lock Glasspad dimensions and integrate calculator into Home
- send calculated price in submit payload

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad2f32f3dc8327b33eb789e6dc63d2