### PR TITLE
Use transfer price for Shopify variants

### DIFF
--- a/mgm-front/src/components/Calculadora.jsx
+++ b/mgm-front/src/components/Calculadora.jsx
@@ -28,7 +28,8 @@ const Calculadora = ({ width, height, material, setPrice }) => {
   if (mode === "Glasspad") {
     const transferPrice = GLASSPAD_TRANSFER_PRICE;               // $110.000 con transferencia
     const normalFromTransfer = Math.round(transferPrice * 1.25); // +25% → $137.500 lista
-    if (typeof setPrice === "function") setPrice(normalFromTransfer);
+    // Enviamos transferencia al backend
+    if (typeof setPrice === "function") setPrice(transferPrice);
 
     return (
       <div>
@@ -105,7 +106,10 @@ const Calculadora = ({ width, height, material, setPrice }) => {
   const transferWithExtra = isClassic ? transferBase + 2000 : transferBase;
   const normalFromTransfer = Math.round(transferWithExtra / 0.8);
 
-  if (typeof setPrice === "function") setPrice(normalFromTransfer);
+  // Enviamos transferencia (con extra para Classic) al backend
+  if (typeof setPrice === "function") {
+    setPrice(transferWithExtra);
+  }
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- Pass transfer amount from calculator so Shopify variants use transfer pricing
- Compute list price at +25% in API and set Shopify variant `price`/`compare_at_price`
- Log pricing details for debugging

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd mgm-front && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ad350898388327937e041f981336b9