### PR TITLE
Add dev render preview and dry-run endpoint

### DIFF
--- a/api/_lib/composeImage.ts
+++ b/api/_lib/composeImage.ts
@@ -1,0 +1,110 @@
+import sharp from 'sharp';
+
+export type ComposeResult = {
+  innerBuf: Buffer;
+  printBuf: Buffer;
+  debug: Record<string, any>;
+};
+
+const DPI = 300;
+
+export async function composeImage({ render_v2, srcBuf }: { render_v2: any; srcBuf: Buffer; }): Promise<ComposeResult> {
+  const c = render_v2.canvas_px;
+  const p = render_v2.place_px;
+  const bleed_cm = (render_v2.bleed_mm || 0) / 10;
+  const inner_w_px = Math.round((render_v2.w_cm * DPI) / 2.54);
+  const inner_h_px = Math.round((render_v2.h_cm * DPI) / 2.54);
+  const bleed_px = Math.round((bleed_cm * DPI) / 2.54);
+  const out_w_px = inner_w_px + 2 * bleed_px;
+  const out_h_px = inner_h_px + 2 * bleed_px;
+  const scaleX = inner_w_px / c.w;
+  const scaleY = inner_h_px / c.h;
+  const scale = Math.min(scaleX, scaleY);
+  const targetW = Math.round(p.w * scale);
+  const targetH = Math.round(p.h * scale);
+  let destX = bleed_px + Math.round(p.x * scale);
+  let destY = bleed_px + Math.round(p.y * scale);
+
+  const srcRot = await sharp(srcBuf)
+    .rotate(render_v2.rotate_deg ?? 0)
+    .toBuffer();
+  const resized = await sharp(srcRot)
+    .resize({ width: targetW, height: targetH, fit: 'fill' })
+    .toBuffer();
+
+  const cutLeft = Math.max(0, -destX);
+  const cutTop = Math.max(0, -destY);
+  const cutRight = Math.max(0, destX + targetW - out_w_px);
+  const cutBottom = Math.max(0, destY + targetH - out_h_px);
+
+  const clipX = cutLeft;
+  const clipY = cutTop;
+  const clipW = targetW - cutLeft - cutRight;
+  const clipH = targetH - cutTop - cutBottom;
+  if (clipW <= 0 || clipH <= 0) {
+    const debug = {
+      inner_w_px,
+      inner_h_px,
+      out_w_px,
+      out_h_px,
+      bleed_px,
+      scaleX,
+      scaleY,
+      scale,
+      place: p,
+      dest: { x: destX, y: destY },
+      targetW,
+      targetH,
+      clip: { x: clipX, y: clipY, w: clipW, h: clipH },
+    };
+    const err: any = new Error('invalid_bbox');
+    err.debug = debug;
+    throw err;
+  }
+
+  const layer = await sharp(resized)
+    .extract({ left: clipX, top: clipY, width: clipW, height: clipH })
+    .toBuffer();
+
+  destX = Math.max(0, destX);
+  destY = Math.max(0, destY);
+
+  const bgHex =
+    render_v2.fit_mode === 'contain' && render_v2.bg_hex
+      ? render_v2.bg_hex
+      : '#000000';
+  const base = await sharp({
+    create: { width: out_w_px, height: out_h_px, channels: 3, background: bgHex },
+  })
+    .png()
+    .toBuffer();
+  const printBuf = await sharp(base)
+    .composite([{ input: layer, left: destX, top: destY }])
+    .jpeg({ quality: 92 })
+    .toBuffer();
+
+  const innerBuf = await sharp(printBuf)
+    .extract({ left: bleed_px, top: bleed_px, width: inner_w_px, height: inner_h_px })
+    .toBuffer();
+
+  const debug = {
+    inner_w_px,
+    inner_h_px,
+    out_w_px,
+    out_h_px,
+    bleed_px,
+    scaleX,
+    scaleY,
+    scale,
+    place: p,
+    dest: { x: destX, y: destY },
+    targetW,
+    targetH,
+    clip: { x: clipX, y: clipY, w: clipW, h: clipH },
+  };
+
+  return { innerBuf, printBuf, debug };
+}
+
+export default composeImage;
+

--- a/api/render-dryrun.js
+++ b/api/render-dryrun.js
@@ -1,0 +1,63 @@
+import crypto from 'node:crypto';
+import { cors } from './_lib/cors.js';
+import getSupabaseAdmin from './_lib/supabaseAdmin.js';
+import composeImage from './_lib/composeImage.ts';
+
+function err(res, status, { diag_id, stage, message, debug = {} }) {
+  return res.status(status).json({ ok: false, diag_id, stage, message, debug });
+}
+
+function parseUploadsObjectKey(url = '') {
+  const idx = url.indexOf('/uploads/');
+  return idx >= 0 ? url.slice(idx + '/uploads/'.length) : '';
+}
+
+export default async function handler(req, res) {
+  const diagId = crypto.randomUUID?.() ?? crypto.randomUUID();
+  res.setHeader('X-Diag-Id', String(diagId));
+  if (cors(req, res)) return;
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return err(res, 405, { diag_id: diagId, stage: 'method', message: 'method_not_allowed' });
+  }
+
+  let body;
+  try {
+    body = typeof req.body === 'string' ? JSON.parse(req.body || '{}') : req.body || {};
+  } catch {
+    return err(res, 400, { diag_id: diagId, stage: 'parse', message: 'bad_json' });
+  }
+  const { render_v2, file_original_url, file_data } = body;
+  if (!render_v2 || (!file_original_url && !file_data)) {
+    return err(res, 400, { diag_id: diagId, stage: 'validate', message: 'missing_fields' });
+  }
+
+  let srcBuf;
+  if (file_data) {
+    try {
+      srcBuf = Buffer.from(file_data, 'base64');
+    } catch {
+      return err(res, 400, { diag_id: diagId, stage: 'validate', message: 'bad_file_data' });
+    }
+  } else {
+    const objectKey = parseUploadsObjectKey(file_original_url);
+    const supa = getSupabaseAdmin();
+    const { data, error } = await supa.storage.from('uploads').download(objectKey);
+    if (error) {
+      return err(res, 502, { diag_id: diagId, stage: 'download_src', message: 'download_failed', debug: { objectKey, error: error.message } });
+    }
+    srcBuf = Buffer.from(await data.arrayBuffer());
+  }
+
+  try {
+    const { innerBuf, printBuf, debug } = await composeImage({ render_v2, srcBuf });
+    const inner = `data:image/png;base64,${innerBuf.toString('base64')}`;
+    const print = `data:image/jpeg;base64,${printBuf.toString('base64')}`;
+    return res.status(200).json({ ok: true, inner, print, debug });
+  } catch (e) {
+    if (e?.message === 'invalid_bbox') {
+      return err(res, 400, { diag_id: diagId, stage: 'compose', message: 'invalid_bbox', debug: e.debug || {} });
+    }
+    return err(res, 500, { diag_id: diagId, stage: 'compose', message: 'compose_failed', debug: { error: e.message } });
+  }
+}

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -6,9 +6,10 @@ import Home from './pages/Home.jsx';
 import Confirm from './pages/Confirm.jsx';
 import Creating from './pages/Creating.jsx';
 import Result from './pages/Result.jsx';
+import DevRenderPreview from './pages/DevRenderPreview.jsx';
 import './globals.css';
 
-const router = createBrowserRouter([
+const routes = [
   {
     element: <App />,
     children: [
@@ -18,7 +19,13 @@ const router = createBrowserRouter([
       { path: '/result/:jobId', element: <Result /> }
     ]
   }
-]);
+];
+
+if (import.meta.env.DEV) {
+  routes[0].children.push({ path: '/dev/render-preview', element: <DevRenderPreview /> });
+}
+
+const router = createBrowserRouter(routes);
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/mgm-front/src/pages/DevRenderPreview.jsx
+++ b/mgm-front/src/pages/DevRenderPreview.jsx
@@ -1,0 +1,167 @@
+import { useState, useRef, useEffect } from 'react';
+
+export default function DevRenderPreview() {
+  const [file, setFile] = useState(null);
+  const [renderText, setRenderText] = useState('');
+  const [renderObj, setRenderObj] = useState(null);
+  const [serverInner, setServerInner] = useState('');
+  const [serverPrint, setServerPrint] = useState('');
+  const [debug, setDebug] = useState(null);
+  const [showGuides, setShowGuides] = useState(false);
+  const [showBleed, setShowBleed] = useState(false);
+  const [diffPct, setDiffPct] = useState(null);
+
+  const canvasRef = useRef(null);
+  const diffRef = useRef(null);
+
+  useEffect(() => {
+    try { setRenderObj(renderText ? JSON.parse(renderText) : null); } catch { /* ignore */ }
+  }, [renderText]);
+
+  useEffect(() => { drawLocal(); }, [file, renderObj, showGuides]);
+
+  async function drawLocal() {
+    if (!file || !renderObj || !canvasRef.current) return;
+    const img = new Image();
+    img.onload = () => {
+      const { canvas_px, place_px, rotate_deg, fit_mode, bg_hex } = renderObj;
+      const canvas = canvasRef.current;
+      canvas.width = canvas_px.w;
+      canvas.height = canvas_px.h;
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = fit_mode === 'contain' && bg_hex ? bg_hex : '#000';
+      ctx.fillRect(0,0,canvas.width,canvas.height);
+      ctx.save();
+      const { x, y, w, h } = place_px;
+      ctx.translate(x + w/2, y + h/2);
+      ctx.rotate(((rotate_deg || 0) * Math.PI) / 180);
+      ctx.drawImage(img, -w/2, -h/2, w, h);
+      ctx.restore();
+      if (showGuides) {
+        ctx.strokeStyle = '#00f';
+        ctx.lineWidth = 1;
+        ctx.strokeRect(0,0,canvas.width,canvas.height);
+        ctx.strokeStyle = '#0f0';
+        ctx.strokeRect(x,y,w,h);
+      }
+    };
+    img.src = URL.createObjectURL(file);
+  }
+
+  async function handleServer() {
+    if (!file || !renderObj) return;
+    const buf = await file.arrayBuffer();
+    const b64 = btoa(String.fromCharCode(...new Uint8Array(buf)));
+    const res = await fetch(`${import.meta.env.VITE_API_BASE}/api/render-dryrun`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ render_v2: renderObj, file_data: b64 })
+    });
+    const json = await res.json();
+    if (json.ok) {
+      setServerInner(json.inner);
+      setServerPrint(json.print);
+      setDebug(json.debug);
+    }
+  }
+
+  function compare() {
+    if (!serverInner || !canvasRef.current) return;
+    const img = new Image();
+    img.onload = () => {
+      const w = canvasRef.current.width;
+      const h = canvasRef.current.height;
+      const diffCanvas = diffRef.current;
+      diffCanvas.width = w; diffCanvas.height = h;
+      const ctxA = canvasRef.current.getContext('2d');
+      const dataA = ctxA.getImageData(0,0,w,h).data;
+      const temp = document.createElement('canvas');
+      temp.width = w; temp.height = h;
+      const tctx = temp.getContext('2d');
+      tctx.drawImage(img,0,0,w,h);
+      const dataB = tctx.getImageData(0,0,w,h).data;
+      const diffCtx = diffCanvas.getContext('2d');
+      const diffData = diffCtx.createImageData(w,h);
+      let mse=0;
+      for(let i=0;i<dataA.length;i+=4){
+        const dr=dataA[i]-dataB[i];
+        const dg=dataA[i+1]-dataB[i+1];
+        const db=dataA[i+2]-dataB[i+2];
+        const err=(dr*dr+dg*dg+db*db)/3;
+        mse+=err;
+        const val=Math.min(255, Math.sqrt(err));
+        diffData.data[i]=val; diffData.data[i+1]=0; diffData.data[i+2]=0; diffData.data[i+3]=255;
+      }
+      diffCtx.putImageData(diffData,0,0);
+      mse/= (w*h*255*255);
+      setDiffPct(mse*100);
+    };
+    img.src = serverInner;
+  }
+
+  async function finalize() {
+    if (!renderObj) return;
+    const jobId = prompt('job_id?');
+    if (!jobId) return;
+    const res = await fetch(`${import.meta.env.VITE_API_BASE}/api/finalize-assets`, {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ job_id: jobId, render_v2: renderObj })
+    });
+    const json = await res.json();
+    if (!json.ok) alert(JSON.stringify(json));
+    else alert('ok');
+  }
+
+  function download() {
+    const url = canvasRef.current.toDataURL('image/png');
+    const a = document.createElement('a');
+    a.href = url; a.download = 'render.png'; a.click();
+  }
+
+  return (
+    <div style={{ display:'flex', gap:'10px' }}>
+      <div style={{ flex:1 }}>
+        <h3>Canvas local</h3>
+        <input type="file" onChange={e=>setFile(e.target.files[0])} />
+        <textarea rows={10} cols={30} value={renderText} onChange={e=>setRenderText(e.target.value)} placeholder="render_v2 JSON" />
+        <div>
+          <label><input type="checkbox" checked={showGuides} onChange={e=>setShowGuides(e.target.checked)} /> mostrar guías</label>
+        </div>
+        <canvas ref={canvasRef} style={{border:'1px solid #ccc'}} />
+        <button onClick={download}>Sólo descargar PNG</button>
+      </div>
+      <div style={{ flex:1 }}>
+        <h3>Server dry-run</h3>
+        <button onClick={handleServer}>Render (server)</button>
+        {serverInner && (
+          <div style={{ position:'relative', display:'inline-block' }}>
+            <img src={showBleed ? serverPrint : serverInner} alt="server" style={{ maxWidth:'100%' }} />
+            {showBleed && debug && (
+              <div style={{position:'absolute', left: debug.bleed_px, top: debug.bleed_px, width: debug.inner_w_px, height: debug.inner_h_px, boxShadow:'0 0 0 1px red inset', pointerEvents:'none'}} />
+            )}
+          </div>
+        )}
+        <div>
+          <label><input type="checkbox" checked={showBleed} onChange={e=>setShowBleed(e.target.checked)} /> Mostrar bleed</label>
+        </div>
+        {debug && (
+          <table>
+            <tbody>
+              {Object.entries(debug).map(([k,v])=> (
+                <tr key={k}><td>{k}</td><td>{typeof v === 'object' ? JSON.stringify(v) : String(v)}</td></tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+      <div style={{ flex:1 }}>
+        <h3>Diff</h3>
+        <button onClick={compare}>Comparar</button>
+        {diffPct!=null && (<p>{`MSE ${(diffPct).toFixed(3)}% ${diffPct < 1 ? 'PASS' : 'FAIL'}`}</p>)}
+        <canvas ref={diffRef} style={{border:'1px solid #ccc'}} />
+        <button onClick={finalize}>Usar este render y subir</button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- factor image composition into shared module
- add `/api/render-dryrun` endpoint for server-side preview
- introduce `/dev/render-preview` page for canvas vs server comparison

## Testing
- `npm --prefix mgm-front run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae6f7d466c83279f6b130f2a9b855e