### PR TITLE
fix cors preflight and add canvas preview

### DIFF
--- a/api/_lib/cors.js
+++ b/api/_lib/cors.js
@@ -9,27 +9,23 @@ export function cors(req, res) {
       .filter(Boolean)
       .map(s => s.replace(/\/$/, '')); // sin barra final
 
-    // Siempre informar qué variamos
-    res.setHeader('Vary', 'Origin');
-
     // Métodos / headers permitidos
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Idempotency-Key');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      'Content-Type, Idempotency-Key, X-Diag-Id'
+    );
     // Exponer diag al front para debug
     res.setHeader('Access-Control-Expose-Headers', 'X-Diag-Id');
 
-    const isDev = process.env.NODE_ENV !== 'production';
-
     if (allowed.length === 0) {
-      // Sin lista -> en dev: *, en prod: eco del origin (si viene), o *
-      res.setHeader('Access-Control-Allow-Origin', isDev ? '*' : (origin || '*'));
+      // Lista vacía -> permitir todos
+      res.setHeader('Access-Control-Allow-Origin', '*');
     } else if (origin && allowed.includes(origin)) {
       res.setHeader('Access-Control-Allow-Origin', origin);
-    } else if (isDev && origin.startsWith('http://localhost:')) {
-      // fallback dev para cualquier puerto local
-      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('Vary', 'Origin');
     }
-    // Si no matchea y es prod: no seteamos ACAO (el navegador bloqueará)
+    // Si no matchea: no seteamos ACAO (el navegador bloqueará)
 
     if (req.method === 'OPTIONS') {
       res.status(204).end();
@@ -38,10 +34,12 @@ export function cors(req, res) {
     return false;
   } catch (e) {
     // Incluso si algo falla, respondemos preflight
-    res.setHeader('Vary', 'Origin');
     res.setHeader('Access-Control-Allow-Origin', origin || '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Idempotency-Key');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      'Content-Type, Idempotency-Key, X-Diag-Id'
+    );
     res.setHeader('Access-Control-Expose-Headers', 'X-Diag-Id');
     res.status(204).end();
     return true;

--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -129,6 +129,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
 
   // viewport
   const wrapRef = useRef(null);
+  const stageRef = useRef(null);
   const [wrapSize, setWrapSize] = useState({ w: 960, h: 540 });
   useEffect(() => {
     const ro = new ResizeObserver(() => {
@@ -700,6 +701,23 @@ const quality = useMemo(() => {
         bleed_mm: bleedMm,
       };
     },
+    exportVisibleCanvas: () => {
+      if (!stageRef.current) return null;
+      const pixelRatio = window.devicePixelRatio || 1;
+      const stageCanvas = stageRef.current.toCanvas({ pixelRatio });
+      const k = baseScale * viewScale * pixelRatio;
+      const x = bleedCm * k;
+      const y = bleedCm * k;
+      const w = wCm * k;
+      const h = hCm * k;
+      const out = document.createElement('canvas');
+      out.width = Math.round(w);
+      out.height = Math.round(h);
+      out
+        .getContext('2d')
+        .drawImage(stageCanvas, x, y, w, h, 0, 0, Math.round(w), Math.round(h));
+      return out;
+    }
   }));
 
   // popover color
@@ -835,6 +853,7 @@ async function onConfirmSubmit() {
           className={styles.undoButton}
         >↺</button>
         <Stage
+          ref={stageRef}
           width={wrapSize.w}
           height={wrapSize.h}
           scaleX={baseScale * viewScale}

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -7,6 +7,7 @@ import Confirm from './pages/Confirm.jsx';
 import Creating from './pages/Creating.jsx';
 import Result from './pages/Result.jsx';
 import DevRenderPreview from './pages/DevRenderPreview.jsx';
+import DevCanvasPreview from './pages/DevCanvasPreview.jsx';
 import './globals.css';
 
 const routes = [
@@ -23,6 +24,7 @@ const routes = [
 
 if (import.meta.env.DEV) {
   routes[0].children.push({ path: '/dev/render-preview', element: <DevRenderPreview /> });
+  routes[0].children.push({ path: '/dev/canvas-preview', element: <DevCanvasPreview /> });
 }
 
 const router = createBrowserRouter(routes);

--- a/mgm-front/src/pages/Creating.jsx
+++ b/mgm-front/src/pages/Creating.jsx
@@ -9,6 +9,7 @@ export default function Creating() {
   const location = useLocation();
   const render = location.state?.render;
   const render_v2 = location.state?.render_v2;
+  const skipFinalize = location.state?.skipFinalize;
   const apiBase = import.meta.env.VITE_API_BASE || 'https://mgm-api.vercel.app';
 
   const [needsRetry, setNeedsRetry] = useState(false);
@@ -64,12 +65,13 @@ export default function Creating() {
   }, [apiBase, jobId, render, render_v2, navigate]);
 
   useEffect(() => {
-    if (jobId) run();
-  }, [jobId, run]);
+    if (jobId && !skipFinalize) run();
+  }, [jobId, run, skipFinalize]);
 
   return (
     <div>
-      <LoadingOverlay show={!needsRetry} messages={["Creando tu pedido…"]} />
+      <LoadingOverlay show={!needsRetry && !skipFinalize} messages={["Creando tu pedido…"]} />
+      {skipFinalize && <p>Modo sólo previsualización: finalize-assets no fue llamado.</p>}
       {needsRetry && (
         <button
           onClick={() => {

--- a/mgm-front/src/pages/DevCanvasPreview.jsx
+++ b/mgm-front/src/pages/DevCanvasPreview.jsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+export default function DevCanvasPreview() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const jobId = location.state?.jobId || window.__previewData?.jobId;
+  const render_v2 = window.__previewData?.render_v2;
+  const [imgUrl, setImgUrl] = useState(null);
+  const [onlyPreview, setOnlyPreview] = useState(false);
+
+  function exportPng() {
+    const canvas = window.__previewData?.canvas;
+    if (!canvas) return;
+    const url = canvas.toDataURL('image/png');
+    setImgUrl(url);
+  }
+
+  function download() {
+    if (!imgUrl) return;
+    const a = document.createElement('a');
+    a.href = imgUrl;
+    a.download = 'canvas.png';
+    a.click();
+  }
+
+  function continueFlow() {
+    navigate(`/creating/${jobId}`, { state: { render_v2, skipFinalize: onlyPreview } });
+  }
+
+  console.log('[PREVIEW DEBUG]', {
+    render_v2,
+    canvas_px: render_v2?.canvas_px,
+    place_px: render_v2?.place_px,
+    rotate_deg: render_v2?.rotate_deg,
+    w_cm: render_v2?.w_cm,
+    h_cm: render_v2?.h_cm,
+    bleed_mm: render_v2?.bleed_mm,
+  });
+
+  return (
+    <div style={{ padding: '10px' }}>
+      <h3>Canvas Preview</h3>
+      <button onClick={exportPng}>Exportar lienzo (PNG)</button>
+      {imgUrl && (
+        <div>
+          <img src={imgUrl} alt="preview" style={{ maxWidth: '100%' }} />
+          <div><button onClick={download}>Descargar PNG</button></div>
+        </div>
+      )}
+      {render_v2 && (
+        <div style={{ display: 'flex', gap: '20px', marginTop: '10px' }}>
+          <pre style={{ whiteSpace: 'pre-wrap' }}>
+            {JSON.stringify(render_v2, null, 2)}
+          </pre>
+          <div>
+            <p>{`canvas_px: ${JSON.stringify(render_v2.canvas_px)}`}</p>
+            <p>{`place_px: ${JSON.stringify(render_v2.place_px)}`}</p>
+            <p>{`rotate_deg: ${render_v2.rotate_deg}`}</p>
+            <p>{`w_cm: ${render_v2.w_cm}`}</p>
+            <p>{`h_cm: ${render_v2.h_cm}`}</p>
+            <p>{`bleed_mm: ${render_v2.bleed_mm}`}</p>
+          </div>
+        </div>
+      )}
+      <label style={{ display: 'block', marginTop: '10px' }}>
+        <input type="checkbox" checked={onlyPreview} onChange={e => setOnlyPreview(e.target.checked)} />{' '}
+        Sólo previsualizar (no llamar API)
+      </label>
+      <div style={{ marginTop: '10px' }}>
+        <button onClick={continueFlow}>Continuar con API (finalize-assets)</button>
+      </div>
+    </div>
+  );
+}

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -120,6 +120,12 @@ export default function Home() {
   async function handleAfterSubmit(jobId) {
     const render = canvasRef.current?.getRenderDescriptor?.();
     const render_v2 = canvasRef.current?.getRenderDescriptorV2?.();
+    if (import.meta.env.DEV) {
+      const canvas = canvasRef.current?.exportVisibleCanvas?.();
+      window.__previewData = { canvas, render_v2, jobId };
+      navigate('/dev/canvas-preview', { state: { jobId } });
+      return;
+    }
     navigate(`/creating/${jobId}`, { state: { render, render_v2 } });
   }
 


### PR DESCRIPTION
## Summary
- ensure API preflight always sets CORS headers and handles OPTIONS
- expose editor canvas and add dev-only canvas preview route

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm test` (mgm-front) *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af5e3c7d548327911e0eba10afa0f3