### PR TITLE
fix finalize-assets CORS preflight and add canvas preview

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,2 +1,3 @@
+ALLOWED_ORIGINS=http://localhost:5173,https://mgm-api.vercel.app
 SUPABASE_URL=https://vxkewodclwozoennpqqv.supabase.co
 SUPABASE_SERVICE_ROLE=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ4a2V3b2RjbHdvem9lbm5wcXF2Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NDc4OTM0MywiZXhwIjoyMDcwMzY1MzQzfQ.d9G6-p1Q5tv6jvtTofVeOhd9E7pX-sC5gMCcDYfVjZk

--- a/api/_lib/cors.js
+++ b/api/_lib/cors.js
@@ -10,7 +10,7 @@ export function cors(req, res) {
       .map(s => s.replace(/\/$/, '')); // sin barra final
 
     // Métodos / headers permitidos
-    res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader(
       'Access-Control-Allow-Headers',
       'Content-Type, Idempotency-Key, X-Diag-Id'
@@ -35,7 +35,7 @@ export function cors(req, res) {
   } catch (e) {
     // Incluso si algo falla, respondemos preflight
     res.setHeader('Access-Control-Allow-Origin', origin || '*');
-    res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader(
       'Access-Control-Allow-Headers',
       'Content-Type, Idempotency-Key, X-Diag-Id'

--- a/api/cors-diagnose.js
+++ b/api/cors-diagnose.js
@@ -1,0 +1,17 @@
+import { cors } from './_lib/cors.js';
+
+export default function handler(req, res) {
+  const ended = cors(req, res);
+
+  const origin = (req.headers.origin || '').replace(/\/$/, '');
+  const allowed = (process.env.ALLOWED_ORIGINS || '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+    .map(s => s.replace(/\/$/, ''));
+  console.log('[cors-diagnose]', { origin, allowed });
+
+  if (!ended) {
+    res.status(204).end();
+  }
+}

--- a/api/finalize-assets.js
+++ b/api/finalize-assets.js
@@ -31,9 +31,9 @@ function isPosFinite(n) {
 }
 
 export default async function handler(req, res) {
+  if (cors(req, res)) return;
   const diagId = crypto.randomUUID?.() ?? crypto.randomUUID();
   res.setHeader('X-Diag-Id', String(diagId));
-  if (cors(req, res)) return;
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
     return err(res, 405, {

--- a/mgm-front/src/pages/DevCanvasPreview.jsx
+++ b/mgm-front/src/pages/DevCanvasPreview.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 export default function DevCanvasPreview() {
@@ -15,6 +15,10 @@ export default function DevCanvasPreview() {
     const url = canvas.toDataURL('image/png');
     setImgUrl(url);
   }
+
+  useEffect(() => {
+    exportPng();
+  }, []);
 
   function download() {
     if (!imgUrl) return;
@@ -65,10 +69,10 @@ export default function DevCanvasPreview() {
       )}
       <label style={{ display: 'block', marginTop: '10px' }}>
         <input type="checkbox" checked={onlyPreview} onChange={e => setOnlyPreview(e.target.checked)} />{' '}
-        Sólo previsualizar (no llamar API)
+        Sólo visualizar (no llamar API)
       </label>
       <div style={{ marginTop: '10px' }}>
-        <button onClick={continueFlow}>Continuar con API (finalize-assets)</button>
+        <button onClick={continueFlow}>Continuar (llamar finalize-assets)</button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- normalize CORS middleware and allow GET, POST, OPTIONS; add diagnostic endpoint and env sample
- call CORS before all logic in finalize-assets
- auto-export editor canvas preview for dev validation

## Testing
- `npm test` (fails: Missing script)
- `npm test` (mgm-front) (fails: Missing script)
- `npm run lint` (mgm-front)
- `node --input-type=module - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68af66a475e48327894d95b8d165a7a1