### PR TITLE
Crop exports to pad area for accurate print mapping

### DIFF
--- a/api/_lib/composeImage.ts
+++ b/api/_lib/composeImage.ts
@@ -10,6 +10,7 @@ const DPI = 300;
 
 export async function composeImage({ render_v2, srcBuf }: { render_v2: any; srcBuf: Buffer; }): Promise<ComposeResult> {
   const c = render_v2.canvas_px;
+  const pad = render_v2.pad_px;
   const p = render_v2.place_px;
   const bleed_cm = (render_v2.bleed_mm || 0) / 10;
   const inner_w_px = Math.round((render_v2.w_cm * DPI) / 2.54);
@@ -17,13 +18,14 @@ export async function composeImage({ render_v2, srcBuf }: { render_v2: any; srcB
   const bleed_px = Math.round((bleed_cm * DPI) / 2.54);
   const out_w_px = inner_w_px + 2 * bleed_px;
   const out_h_px = inner_h_px + 2 * bleed_px;
-  const scaleX = inner_w_px / c.w;
-  const scaleY = inner_h_px / c.h;
+  const scaleX = inner_w_px / pad.w;
+  const scaleY = inner_h_px / pad.h;
   const scale = Math.min(scaleX, scaleY);
+  const place_rel = { x: p.x - pad.x, y: p.y - pad.y };
   const targetW = Math.round(p.w * scale);
   const targetH = Math.round(p.h * scale);
-  let destX = bleed_px + Math.round(p.x * scale);
-  let destY = bleed_px + Math.round(p.y * scale);
+  let destX = bleed_px + Math.round(place_rel.x * scale);
+  let destY = bleed_px + Math.round(place_rel.y * scale);
 
   const srcRot = await sharp(srcBuf)
     .rotate(render_v2.rotate_deg ?? 0)
@@ -43,6 +45,10 @@ export async function composeImage({ render_v2, srcBuf }: { render_v2: any; srcB
   const clipH = targetH - cutTop - cutBottom;
   if (clipW <= 0 || clipH <= 0) {
     const debug = {
+      canvas_px: c,
+      pad_px: pad,
+      place_px: p,
+      place_rel,
       inner_w_px,
       inner_h_px,
       out_w_px,
@@ -51,11 +57,14 @@ export async function composeImage({ render_v2, srcBuf }: { render_v2: any; srcB
       scaleX,
       scaleY,
       scale,
-      place: p,
-      dest: { x: destX, y: destY },
+      destX,
+      destY,
       targetW,
       targetH,
-      clip: { x: clipX, y: clipY, w: clipW, h: clipH },
+      clipX,
+      clipY,
+      clipW,
+      clipH,
     };
     const err: any = new Error('invalid_bbox');
     err.debug = debug;
@@ -74,20 +83,38 @@ export async function composeImage({ render_v2, srcBuf }: { render_v2: any; srcB
       ? render_v2.bg_hex
       : '#000000';
   const base = await sharp({
-    create: { width: out_w_px, height: out_h_px, channels: 3, background: bgHex },
+    create: { width: out_w_px, height: out_h_px, channels: 4, background: bgHex },
   })
     .png()
     .toBuffer();
-  const printBuf = await sharp(base)
+  let composed = await sharp(base)
     .composite([{ input: layer, left: destX, top: destY }])
+    .png()
+    .toBuffer();
+
+  const radiusScaled = Math.round((pad.radius_px || 0) * scale) + bleed_px;
+  const maskSvg = `<svg width="${out_w_px}" height="${out_h_px}" viewBox="0 0 ${out_w_px} ${out_h_px}"><rect x="0" y="0" width="${out_w_px}" height="${out_h_px}" rx="${radiusScaled}" ry="${radiusScaled}" fill="#fff"/></svg>`;
+  const mask = await sharp(Buffer.from(maskSvg)).png().toBuffer();
+  composed = await sharp(composed)
+    .composite([{ input: mask, blend: 'dest-in' }])
+    .png()
+    .toBuffer();
+
+  const printBuf = await sharp(composed)
+    .flatten({ background: bgHex })
     .jpeg({ quality: 92 })
     .toBuffer();
 
-  const innerBuf = await sharp(printBuf)
+  const innerBuf = await sharp(composed)
     .extract({ left: bleed_px, top: bleed_px, width: inner_w_px, height: inner_h_px })
+    .flatten({ background: bgHex })
     .toBuffer();
 
   const debug = {
+    canvas_px: c,
+    pad_px: pad,
+    place_px: p,
+    place_rel,
     inner_w_px,
     inner_h_px,
     out_w_px,
@@ -96,11 +123,14 @@ export async function composeImage({ render_v2, srcBuf }: { render_v2: any; srcB
     scaleX,
     scaleY,
     scale,
-    place: p,
-    dest: { x: destX, y: destY },
+    destX,
+    destY,
     targetW,
     targetH,
-    clip: { x: clipX, y: clipY, w: clipW, h: clipH },
+    clipX,
+    clipY,
+    clipW,
+    clipH,
   };
 
   return { innerBuf, printBuf, debug };

--- a/api/finalize-assets.js
+++ b/api/finalize-assets.js
@@ -60,12 +60,19 @@ export default async function handler(req, res) {
   }
 
   const { job_id, render_v2 } = body;
-  if (!job_id || !render_v2 || !render_v2.canvas_px || !render_v2.place_px) {
+  if (
+    !job_id ||
+    !render_v2 ||
+    !render_v2.canvas_px ||
+    !render_v2.place_px ||
+    !render_v2.pad_px
+  ) {
     debug = {
       has_job_id: !!job_id,
       has_render_v2: !!render_v2,
       has_canvas: !!render_v2?.canvas_px,
       has_place: !!render_v2?.place_px,
+      has_pad: !!render_v2?.pad_px,
     };
     return err(res, 400, {
       diag_id: diagId,
@@ -77,11 +84,22 @@ export default async function handler(req, res) {
 
   const c = render_v2.canvas_px;
   const p = render_v2.place_px;
+  const pad = render_v2.pad_px;
   const invalidField =
     !isPosFinite(c.w)
       ? ['canvas_px.w', c.w]
       : !isPosFinite(c.h)
       ? ['canvas_px.h', c.h]
+      : !Number.isFinite(pad.x)
+      ? ['pad_px.x', pad.x]
+      : !Number.isFinite(pad.y)
+      ? ['pad_px.y', pad.y]
+      : !isPosFinite(pad.w)
+      ? ['pad_px.w', pad.w]
+      : !isPosFinite(pad.h)
+      ? ['pad_px.h', pad.h]
+      : !isPosFinite(pad.radius_px)
+      ? ['pad_px.radius_px', pad.radius_px]
       : !Number.isFinite(p.x)
       ? ['place_px.x', p.x]
       : !Number.isFinite(p.y)
@@ -111,7 +129,9 @@ export default async function handler(req, res) {
       stage: 'validate',
       debug: {
         canvas: c,
+        pad,
         place: p,
+        place_rel: { x: p.x - pad.x, y: p.y - pad.y },
         w_cm: render_v2.w_cm,
         h_cm: render_v2.h_cm,
         bleed_mm: render_v2.bleed_mm,

--- a/mgm-front/src/pages/DevCanvasPreview.jsx
+++ b/mgm-front/src/pages/DevCanvasPreview.jsx
@@ -35,7 +35,12 @@ export default function DevCanvasPreview() {
   console.log('[PREVIEW DEBUG]', {
     render_v2,
     canvas_px: render_v2?.canvas_px,
+    pad_px: render_v2?.pad_px,
     place_px: render_v2?.place_px,
+    place_rel: render_v2?.place_px && render_v2?.pad_px ? {
+      x: render_v2.place_px.x - render_v2.pad_px.x,
+      y: render_v2.place_px.y - render_v2.pad_px.y,
+    } : undefined,
     rotate_deg: render_v2?.rotate_deg,
     w_cm: render_v2?.w_cm,
     h_cm: render_v2?.h_cm,
@@ -59,7 +64,9 @@ export default function DevCanvasPreview() {
           </pre>
           <div>
             <p>{`canvas_px: ${JSON.stringify(render_v2.canvas_px)}`}</p>
+            <p>{`pad_px: ${JSON.stringify(render_v2.pad_px)}`}</p>
             <p>{`place_px: ${JSON.stringify(render_v2.place_px)}`}</p>
+            <p>{`place_rel: ${JSON.stringify({ x: render_v2.place_px.x - render_v2.pad_px.x, y: render_v2.place_px.y - render_v2.pad_px.y })}`}</p>
             <p>{`rotate_deg: ${render_v2.rotate_deg}`}</p>
             <p>{`w_cm: ${render_v2.w_cm}`}</p>
             <p>{`h_cm: ${render_v2.h_cm}`}</p>

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -121,7 +121,7 @@ export default function Home() {
     const render = canvasRef.current?.getRenderDescriptor?.();
     const render_v2 = canvasRef.current?.getRenderDescriptorV2?.();
     if (import.meta.env.DEV) {
-      const canvas = canvasRef.current?.exportVisibleCanvas?.();
+      const canvas = canvasRef.current?.exportPadCanvas?.();
       window.__previewData = { canvas, render_v2, jobId };
       navigate('/dev/canvas-preview', { state: { jobId } });
       return;


### PR DESCRIPTION
## Summary
- expose `getPadRect` and `exportPadCanvas` to crop the visible pad and include pad metrics in `render_v2`
- show pad dimensions in dev preview and forward pad coordinates when creating jobs
- compute backend compositing based on `pad_px`, adjusting scaling, offsets, and applying rounded-corner masks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd mgm-front && npm test` *(fails: Missing script: "test")*
- `cd mgm-front && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af75ce140483279313c8312987f7da