### PR TITLE
feat: export pad at print resolution

### DIFF
--- a/api/_lib/composeImage.ts
+++ b/api/_lib/composeImage.ts
@@ -100,10 +100,10 @@ export async function composeImage({ render_v2, srcBuf }: { render_v2: any; srcB
     .png()
     .toBuffer();
 
-  const printBuf = await sharp(composed)
-    .flatten({ background: bgHex })
-    .jpeg({ quality: 92 })
-    .toBuffer();
+    const printBuf = await sharp(composed)
+      .flatten({ background: bgHex })
+      .png()
+      .toBuffer();
 
   const innerBuf = await sharp(composed)
     .extract({ left: bleed_px, top: bleed_px, width: inner_w_px, height: inner_h_px })


### PR DESCRIPTION
## Summary
- export pad canvas without guides or corner masks
- upload print-ready PNG and 1080px mockup to structured Supabase paths
- log render diagnostics for precise scaling

## Testing
- `npm test` (fails: Missing script)
- `npm test` (mgm-front; fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afa1185350832795f53a842fc5a4bb