### PR TITLE
feat: export pad as printable document

### DIFF
--- a/mgm-front/src/pages/DevCanvasPreview.jsx
+++ b/mgm-front/src/pages/DevCanvasPreview.jsx
@@ -7,24 +7,30 @@ export default function DevCanvasPreview() {
   const jobId = location.state?.jobId || window.__previewData?.jobId;
   const render_v2 = window.__previewData?.render_v2;
   const [imgUrl, setImgUrl] = useState(null);
+  const [pdfUrl, setPdfUrl] = useState(null);
   const [onlyPreview, setOnlyPreview] = useState(false);
 
-  function exportPng() {
-    const canvas = window.__previewData?.canvas;
-    if (!canvas) return;
-    const url = canvas.toDataURL('image/png');
-    setImgUrl(url);
+  async function exportDoc() {
+    const fn = window.__previewData?.exportPadDocument;
+    if (!fn) return;
+    const res = await fn();
+    if (res?.jpegBlob) {
+      setImgUrl(URL.createObjectURL(res.jpegBlob));
+    }
+    if (res?.pdfBlob) {
+      setPdfUrl(URL.createObjectURL(res.pdfBlob));
+    }
   }
 
   useEffect(() => {
-    exportPng();
+    exportDoc();
   }, []);
 
-  function download() {
-    if (!imgUrl) return;
+  function downloadPdf() {
+    if (!pdfUrl) return;
     const a = document.createElement('a');
-    a.href = imgUrl;
-    a.download = 'canvas.png';
+    a.href = pdfUrl;
+    a.download = 'canvas.pdf';
     a.click();
   }
 
@@ -50,12 +56,14 @@ export default function DevCanvasPreview() {
   return (
     <div style={{ padding: '10px' }}>
       <h3>Canvas Preview</h3>
-      <button onClick={exportPng}>Exportar lienzo (PNG)</button>
+      <button onClick={exportDoc}>Exportar lienzo (PNG/PDF)</button>
       {imgUrl && (
         <div>
           <img src={imgUrl} alt="preview" style={{ maxWidth: '100%' }} />
-          <div><button onClick={download}>Descargar PNG</button></div>
         </div>
+      )}
+      {pdfUrl && (
+        <div><button onClick={downloadPdf}>Descargar PDF</button></div>
       )}
       {render_v2 && (
         <div style={{ display: 'flex', gap: '20px', marginTop: '10px' }}>

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -122,7 +122,8 @@ export default function Home() {
     const render_v2 = canvasRef.current?.getRenderDescriptorV2?.();
     if (import.meta.env.DEV) {
       const canvas = canvasRef.current?.exportPadCanvas?.();
-      window.__previewData = { canvas, render_v2, jobId };
+      const exportPadDocument = canvasRef.current?.exportPadDocument;
+      window.__previewData = { canvas, render_v2, jobId, exportPadDocument };
       navigate('/dev/canvas-preview', { state: { jobId } });
       return;
     }


### PR DESCRIPTION
## Summary
- add `exportPadDocument` to render pad at 300 dpi with 1 cm margins and PDF output
- pass printable exporter to dev preview and wire export button
- expose export API via `EditorCanvas` for future integration

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afaaae431c8327bb89ecec17b9f68e