### PR TITLE
feat: add print export and mockup download

### DIFF
--- a/mgm-front/src/pages/DevCanvasPreview.jsx
+++ b/mgm-front/src/pages/DevCanvasPreview.jsx
@@ -6,26 +6,98 @@ export default function DevCanvasPreview() {
   const location = useLocation();
   const jobId = location.state?.jobId || window.__previewData?.jobId;
   const render_v2 = window.__previewData?.render_v2;
+  const padBlob = window.__previewData?.padBlob;
   const [imgUrl, setImgUrl] = useState(null);
   const [onlyPreview, setOnlyPreview] = useState(false);
 
-  function exportPng() {
-    const canvas = window.__previewData?.canvas;
-    if (!canvas) return;
-    const url = canvas.toDataURL('image/png');
-    setImgUrl(url);
+  useEffect(() => {
+    if (padBlob) {
+      const url = URL.createObjectURL(padBlob);
+      setImgUrl(url);
+      return () => URL.revokeObjectURL(url);
+    }
+  }, [padBlob]);
+
+  async function exportPadDocument() {
+    if (!padBlob || !render_v2) return;
+    const w_cm = render_v2.w_cm;
+    const h_cm = render_v2.h_cm;
+    const out_w_cm = w_cm + 2;
+    const out_h_cm = h_cm + 2;
+    const dpi = 300;
+    const inner_w_px = Math.round((w_cm * dpi) / 2.54);
+    const inner_h_px = Math.round((h_cm * dpi) / 2.54);
+    const out_w_px = Math.round((out_w_cm * dpi) / 2.54);
+    const out_h_px = Math.round((out_h_cm * dpi) / 2.54);
+    const margin_px = Math.round((1 * dpi) / 2.54);
+    const pad_px = render_v2.pad_px;
+    const pixelRatioX = inner_w_px / pad_px.w;
+    const pixelRatioY = inner_h_px / pad_px.h;
+    const pixelRatio = Math.min(pixelRatioX, pixelRatioY);
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = out_w_px;
+      canvas.height = out_h_px;
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(0, 0, out_w_px, out_h_px);
+      ctx.drawImage(img, margin_px, margin_px, inner_w_px, inner_h_px);
+      const debug = {
+        w_cm, h_cm, out_w_cm, out_h_cm,
+        inner_w_px, inner_h_px, out_w_px, out_h_px,
+        pad_px, pixelRatioX, pixelRatioY, pixelRatio, margin_px,
+      };
+      console.log('[EXPORT DOC DEBUG]', debug);
+      canvas.toBlob((b) => {
+        if (!b) return;
+        const url = URL.createObjectURL(b);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `print-${out_w_cm}x${out_h_cm}.jpg`;
+        a.click();
+        URL.revokeObjectURL(url);
+      }, 'image/jpeg', 0.99);
+    };
+    img.src = URL.createObjectURL(padBlob);
   }
 
-  useEffect(() => {
-    exportPng();
-  }, []);
-
-  function download() {
-    if (!imgUrl) return;
-    const a = document.createElement('a');
-    a.href = imgUrl;
-    a.download = 'canvas.png';
-    a.click();
+  async function downloadMockup() {
+    if (!padBlob) return;
+    const img = new Image();
+    img.onload = () => {
+      const sourceBitmap = { w: img.width, h: img.height };
+      const target = { w: 1080, h: 1080 };
+      const scale = Math.min(target.w / sourceBitmap.w, target.h / sourceBitmap.h);
+      const drawW = Math.round(sourceBitmap.w * scale);
+      const drawH = Math.round(sourceBitmap.h * scale);
+      const drawX = Math.round((target.w - drawW) / 2);
+      const drawY = Math.round((target.h - drawH) / 2);
+      const canvas = document.createElement('canvas');
+      canvas.width = target.w;
+      canvas.height = target.h;
+      const ctx = canvas.getContext('2d');
+      ctx.clearRect(0, 0, target.w, target.h);
+      ctx.imageSmoothingQuality = 'high';
+      ctx.drawImage(img, drawX, drawY, drawW, drawH);
+      console.log('[MOCKUP DEBUG]', {
+        sourceBitmap,
+        target,
+        scale,
+        drawX,
+        drawY,
+      });
+      canvas.toBlob((b) => {
+        if (!b) return;
+        const url = URL.createObjectURL(b);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'mock-1080.png';
+        a.click();
+        URL.revokeObjectURL(url);
+      }, 'image/png');
+    };
+    img.src = URL.createObjectURL(padBlob);
   }
 
   function continueFlow() {
@@ -50,11 +122,11 @@ export default function DevCanvasPreview() {
   return (
     <div style={{ padding: '10px' }}>
       <h3>Canvas Preview</h3>
-      <button onClick={exportPng}>Exportar lienzo (PNG)</button>
+      <button onClick={exportPadDocument}>Exportar lienzo</button>
       {imgUrl && (
         <div>
           <img src={imgUrl} alt="preview" style={{ maxWidth: '100%' }} />
-          <div><button onClick={download}>Descargar PNG</button></div>
+          <div><button onClick={downloadMockup}>Descargar PNG</button></div>
         </div>
       )}
       {render_v2 && (

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -121,8 +121,8 @@ export default function Home() {
     const render = canvasRef.current?.getRenderDescriptor?.();
     const render_v2 = canvasRef.current?.getRenderDescriptorV2?.();
     if (import.meta.env.DEV) {
-      const canvas = canvasRef.current?.exportPadCanvas?.();
-      window.__previewData = { canvas, render_v2, jobId };
+      const padBlob = await canvasRef.current?.exportPadAsBlob?.();
+      window.__previewData = { padBlob, render_v2, jobId };
       navigate('/dev/canvas-preview', { state: { jobId } });
       return;
     }


### PR DESCRIPTION
## Summary
- generate pad blob in dev preview for rendering
- allow exporting high-DPI print with margin
- add 1080x1080 mockup download

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afaf1414148327995315062343bbf9