### PR TITLE
Add canvas eyedropper and sticky fit

### DIFF
--- a/mgm-front/src/components/ColorPopover.jsx
+++ b/mgm-front/src/components/ColorPopover.jsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from 'react';
+import { HexColorPicker, HexColorInput } from 'react-colorful';
+import styles from './EditorCanvas.module.css';
+
+export default function ColorPopover({ value, onChange, open, onClose, onPickFromCanvas }) {
+  const boxRef = useRef(null);
+  const previewRef = useRef(null);
+  const [hex, setHex] = useState(value || '#ffffff');
+
+  useEffect(() => setHex(value || '#ffffff'), [value]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e) => {
+      if (!boxRef.current) return;
+      if (!boxRef.current.contains(e.target)) onClose?.();
+    };
+    const onKey = (e) => { if (e.key === 'Escape') onClose?.(); };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (previewRef.current) previewRef.current.style.background = hex;
+  }, [hex]);
+
+  const swatches = [
+    '#ffffff','#000000','#f3f4f6','#e5e7eb','#d1d5db',
+    '#1f2937','#111827','#ff0000','#ff7f00','#ffb800',
+    '#ffe600','#00a859','#00c9a7','#00ccff','#0066ff',
+    '#6f42c1','#ff69b4','#8b4513','#808080','#333333'
+  ];
+
+  const handlePick = async () => {
+    try {
+      if (window.EyeDropper) {
+        const ed = new window.EyeDropper();
+        const { sRGBHex } = await ed.open();
+        onChange?.(sRGBHex);
+        return;
+      }
+    } catch {
+      // ignore
+    }
+    onPickFromCanvas?.();
+    onClose?.();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div ref={boxRef} className={styles.colorPopover}>
+      <HexColorPicker
+        color={hex}
+        onChange={(c)=>{ setHex(c); onChange?.(c); }}
+        className={styles.colorPicker}
+      />
+      <div className={styles.swatches}>
+        {swatches.map((c,i)=>(
+          <button
+            key={c}
+            title={c}
+            onClick={()=>{ setHex(c); onChange?.(c); }}
+            className={`${styles.swatch} ${styles['swatch'+i]}`}
+          />
+        ))}
+      </div>
+      <div className={styles.colorControls}>
+        <div ref={previewRef} className={styles.colorPreview} />
+        <HexColorInput
+          color={hex}
+          onChange={(c)=>{ const v = c.startsWith('#') ? c : `#${c}`; setHex(v); onChange?.(v); }}
+          prefixed
+          className={styles.hexInput}
+        />
+        <button
+          title="Elegir del lienzo"
+          onClick={handlePick}
+          className={styles.eyedropperButton}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 21l6.6-6.6" />
+            <path d="M8.5 2.5a3 3 0 0 1 4.2 4.2L7.5 12 4 8.5 8.5 2.5z" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -92,6 +92,10 @@
   cursor: pointer;
 }
 
+.picking {
+  cursor: crosshair;
+}
+
 .toolbar {
   display: flex;
   gap: 8px;

--- a/mgm-front/src/components/OptionsStep.module.css
+++ b/mgm-front/src/components/OptionsStep.module.css
@@ -19,6 +19,13 @@
   margin-top: 8px;
 }
 
+.presets {
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .dpiSection {
   margin-top: 12px;
 }

--- a/mgm-front/src/components/SizeControls.module.css
+++ b/mgm-front/src/components/SizeControls.module.css
@@ -1,8 +1,15 @@
 .container {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr;
   gap: 8px;
   margin-bottom: 10px;
+}
+
+.presets {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .helper {


### PR DESCRIPTION
## Summary
- add standalone ColorPopover with native EyeDropper and canvas fallback
- allow EditorCanvas to pick colors from pad and remember last fit mode
- simplify size controls and options to always show editable inputs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b11ea0c51883279e9a7d07eb356531