### PR TITLE
Add canvas color picker and sticky fit behavior

### DIFF
--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -96,6 +96,25 @@
   cursor: crosshair;
 }
 
+.pickOverlay {
+  position: fixed;
+  pointer-events: none;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.pickLabel {
+  padding: 2px 4px;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  color: #111827;
+}
+
 .toolbar {
   display: flex;
   gap: 8px;

--- a/mgm-front/src/components/OptionsStep.jsx
+++ b/mgm-front/src/components/OptionsStep.jsx
@@ -39,35 +39,22 @@ export default function OptionsStep({ uploaded, onSubmitted }) {
 
   useEffect(() => {
     if (material === 'Glasspad') {
-      setWText('50');
-      setHText('40');
+      applyPreset(50, 40);
     }
   }, [material]);
 
   const size = useMemo(() => ({ w: parseFloat(wText || '0'), h: parseFloat(hText || '0') }), [wText, hText]);
   const limits = LIMITS[material];
   const presets = STANDARD[material] || [];
-  const numPattern = /^[0-9]{0,3}(\.[0-9]{0,2})?$/;
-  const handleWChange = (e) => {
-    const v = e.target.value;
-    if (v === '' || numPattern.test(v)) setWText(v);
-  };
-  const handleHChange = (e) => {
-    const v = e.target.value;
-    if (v === '' || numPattern.test(v)) setHText(v);
-  };
   const clamp = (val, min, max) => Math.max(min, Math.min(max, val));
-  const handleWBlur = () => {
-    const num = clamp(parseFloat(wText || '0'), 1, limits.maxW);
-    setWText(num ? String(num) : '');
-  };
-  const handleHBlur = () => {
-    const num = clamp(parseFloat(hText || '0'), 1, limits.maxH);
-    setHText(num ? String(num) : '');
+  const applySize = (wVal = wText, hVal = hText) => {
+    const wNum = clamp(parseFloat(wVal || '0'), 1, limits.maxW);
+    const hNum = clamp(parseFloat(hVal || '0'), 1, limits.maxH);
+    setWText(String(wNum));
+    setHText(String(hNum));
   };
   const applyPreset = (w, h) => {
-    setWText(String(w));
-    setHText(String(h));
+    applySize(String(w), String(h));
   };
 
   // DPI estimado
@@ -159,21 +146,29 @@ export default function OptionsStep({ uploaded, onSubmitted }) {
       <div className={styles.gridMt8}>
         <label>Ancho (cm)
           <input
+            type="number"
+            step={1}
+            min={1}
+            max={limits.maxW}
             value={wText}
-            onChange={handleWChange}
-            onBlur={handleWBlur}
-            inputMode="decimal"
-            pattern="[0-9]*"
+            onChange={e=>setWText(e.target.value)}
+            onKeyDown={e=>e.key === 'Enter' && applySize()}
+            onBlur={applySize}
+            inputMode="numeric"
             disabled={material === 'Glasspad'}
           />
         </label>
         <label>Alto (cm)
           <input
+            type="number"
+            step={1}
+            min={1}
+            max={limits.maxH}
             value={hText}
-            onChange={handleHChange}
-            onBlur={handleHBlur}
-            inputMode="decimal"
-            pattern="[0-9]*"
+            onChange={e=>setHText(e.target.value)}
+            onKeyDown={e=>e.key === 'Enter' && applySize()}
+            onBlur={applySize}
+            inputMode="numeric"
             disabled={material === 'Glasspad'}
           />
         </label>

--- a/mgm-front/src/components/SizeControls.jsx
+++ b/mgm-front/src/components/SizeControls.jsx
@@ -27,26 +27,13 @@ export default function SizeControls({ material, size, onChange, locked = false 
     }
   }, [material, onChange]);
 
-  const numPattern = /^[0-9]{0,3}(\.[0-9]{0,2})?$/;
-
-  const handleWChange = (e) => {
-    const v = e.target.value;
-    if (v === '' || numPattern.test(v)) setWText(v);
-  };
-  const handleHChange = (e) => {
-    const v = e.target.value;
-    if (v === '' || numPattern.test(v)) setHText(v);
-  };
   const clamp = (val, min, max) => Math.max(min, Math.min(max, val));
-  const handleWBlur = () => {
-    const num = clamp(parseFloat(wText || '0'), 1, limits.maxW);
-    setWText(num ? String(num) : '');
-    onChange({ w: num, h: parseFloat(hText || size.h) });
-  };
-  const handleHBlur = () => {
-    const num = clamp(parseFloat(hText || '0'), 1, limits.maxH);
-    setHText(num ? String(num) : '');
-    onChange({ w: parseFloat(wText || size.w), h: num });
+  const applySize = () => {
+    const wNum = clamp(parseFloat(wText || '0'), 1, limits.maxW);
+    const hNum = clamp(parseFloat(hText || '0'), 1, limits.maxH);
+    setWText(String(wNum));
+    setHText(String(hNum));
+    onChange({ w: wNum, h: hNum });
   };
 
   const applyPreset = (w, h) => {
@@ -70,22 +57,30 @@ export default function SizeControls({ material, size, onChange, locked = false 
 
       <label>Ancho (cm)
         <input
+          type="number"
+          step={1}
+          min={1}
+          max={limits.maxW}
           value={wText}
-          onChange={handleWChange}
-          onBlur={handleWBlur}
-          inputMode="decimal"
-          pattern="[0-9]*"
+          onChange={e=>setWText(e.target.value)}
+          onKeyDown={e=>e.key === 'Enter' && applySize()}
+          onBlur={applySize}
+          inputMode="numeric"
           disabled={locked || material === 'Glasspad'}
         />
       </label>
 
       <label>Alto (cm)
         <input
+          type="number"
+          step={1}
+          min={1}
+          max={limits.maxH}
           value={hText}
-          onChange={handleHChange}
-          onBlur={handleHBlur}
-          inputMode="decimal"
-          pattern="[0-9]*"
+          onChange={e=>setHText(e.target.value)}
+          onKeyDown={e=>e.key === 'Enter' && applySize()}
+          onBlur={applySize}
+          inputMode="numeric"
           disabled={locked || material === 'Glasspad'}
         />
       </label>


### PR DESCRIPTION
## Summary
- add pixel-zoom color picker overlay as EyeDropper fallback
- reapply last fit mode or normalize image when size/material changes
- keep width/height inputs always visible with numeric editing and Enter to apply

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b124b5dcf083278a3deb960f428008