### PR TITLE
fix: break cycles and centralize export scale (PX_PER_CM)

### DIFF
--- a/mgm-front/src/lib/export-consts.ts
+++ b/mgm-front/src/lib/export-consts.ts
@@ -1,0 +1,2 @@
+export const PX_PER_CM = 300 / 2.54;
+export const MOCKUP_BASE_PX = 1080;

--- a/mgm-front/src/lib/mockup.ts
+++ b/mgm-front/src/lib/mockup.ts
@@ -1,6 +1,7 @@
 import { dlog } from './debug';
+import { MOCKUP_BASE_PX } from '@/lib/export-consts';
 
-const CANVAS = 1080;
+console.assert(Number.isFinite(MOCKUP_BASE_PX), '[export] MOCKUP_BASE_PX inválido', MOCKUP_BASE_PX);
 
 function pathRoundedRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, rad: number) {
   const rr = Math.min(rad, w / 2, h / 2);
@@ -20,9 +21,9 @@ function pathRoundedRect(ctx: CanvasRenderingContext2D, x: number, y: number, w:
 export async function renderMockup1080(canvas: HTMLCanvasElement, src: ImageBitmap | Blob | HTMLImageElement, w_cm: number, h_cm: number, material: string) {
   const ctx = canvas.getContext('2d');
   if (!ctx) throw new Error('2d context');
-  canvas.width = CANVAS;
-  canvas.height = CANVAS;
-  ctx.clearRect(0,0,CANVAS,CANVAS);
+  canvas.width = MOCKUP_BASE_PX;
+  canvas.height = MOCKUP_BASE_PX;
+  ctx.clearRect(0,0,MOCKUP_BASE_PX,MOCKUP_BASE_PX);
   ctx.globalAlpha = 1;
   ctx.globalCompositeOperation = 'source-over';
   ctx.filter = 'none';
@@ -55,15 +56,15 @@ export async function renderMockup1080(canvas: HTMLCanvasElement, src: ImageBitm
   let target_h = Math.max(1, Math.round(h_cm * pxPerCm));
 
   const MIN_MARGIN = 80;
-  const avail = CANVAS - 2 * MIN_MARGIN;
+  const avail = MOCKUP_BASE_PX - 2 * MIN_MARGIN;
   if (target_w > avail || target_h > avail) {
     const s = Math.min(avail / target_w, avail / target_h);
     target_w = Math.max(1, Math.round(target_w * s));
     target_h = Math.max(1, Math.round(target_h * s));
   }
 
-  const dx = Math.round((CANVAS - target_w) / 2);
-  const dy = Math.round((CANVAS - target_h) / 2);
+  const dx = Math.round((MOCKUP_BASE_PX - target_w) / 2);
+  const dy = Math.round((MOCKUP_BASE_PX - target_h) / 2);
   const r = Math.max(12, Math.min(Math.min(target_w, target_h) * 0.02, 20));
 
   dlog('[MOCKUP DEBUG]', { w_cm, h_cm, t, pxPerCm, target_w, target_h, dx, dy });

--- a/mgm-front/src/pages/DevCanvasPreview.jsx
+++ b/mgm-front/src/pages/DevCanvasPreview.jsx
@@ -4,6 +4,9 @@ import { PDFDocument } from 'pdf-lib';
 import { buildExportBaseName } from '../lib/filename';
 import { renderMockup1080, downloadBlob } from '../lib/mockup';
 import { dlog } from '../lib/debug';
+import { PX_PER_CM } from '@/lib/export-consts';
+
+console.assert(Number.isFinite(PX_PER_CM), '[export] PX_PER_CM inválido', PX_PER_CM);
 
 export default function DevCanvasPreview() {
   const navigate = useNavigate();
@@ -30,9 +33,8 @@ export default function DevCanvasPreview() {
     const out_w_cm = w_cm + 2;
     const out_h_cm = h_cm + 2;
     const baseName = buildExportBaseName(designName, w_cm, h_cm);
-    const dpi = 300;
-    const out_w_px = Math.round((out_w_cm * dpi) / 2.54);
-    const out_h_px = Math.round((out_h_cm * dpi) / 2.54);
+    const out_w_px = Math.round(out_w_cm * PX_PER_CM);
+    const out_h_px = Math.round(out_h_cm * PX_PER_CM);
     const img = new Image();
     img.onload = async () => {
       const canvas = document.createElement('canvas');

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -12,11 +12,14 @@ import DebugPanel from '../components/DebugPanel';
 import { LIMITS, STANDARD } from '../lib/material.js';
 
 import { dpiLevel } from '../lib/dpi';
+import { PX_PER_CM } from '@/lib/export-consts';
 import { sha256Hex } from '../lib/hash.js';
 import { buildSubmitJobBody, prevalidateSubmitBody } from '../lib/jobPayload.js';
 import { submitJob as submitJobApi } from '../lib/submitJob.js';
 import { DEBUG, dlog } from '../lib/debug';
 import styles from './Home.module.css';
+
+console.assert(Number.isFinite(PX_PER_CM), '[export] PX_PER_CM inválido', PX_PER_CM);
 
 export default function Home() {
 
@@ -212,7 +215,7 @@ export default function Home() {
         size: { w: sizeCm.w, h: sizeCm.h, bleed_mm: 3 },
         fit_mode: 'cover',
         bg: '#ffffff',
-        dpi: 300,
+        dpi: Math.round(PX_PER_CM * 2.54),
         uploads: { canonical: file_original_url },
         file_hash,
         price: { amount: priceAmount, currency: priceCurrency },
@@ -281,7 +284,6 @@ export default function Home() {
           imageFile={uploaded?.file}
           sizeCm={sizeCm}
           bleedMm={3}
-          dpi={300}
           onLayoutChange={setLayout}
         />
 


### PR DESCRIPTION
## Summary
- centralize PX_PER_CM and mockup base size in new export-consts module
- remove exportScale TDZ in EditorCanvas and use viewPxPerCm + PX_PER_CM conversions
- adjust mockup, home and dev preview to import PX_PER_CM and MOCKUP_BASE_PX

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b2249a7f688327879e56e290708241