### PR TITLE
Add global error page for React router

### DIFF
--- a/mgm-front/src/ErrorPage.jsx
+++ b/mgm-front/src/ErrorPage.jsx
@@ -1,0 +1,17 @@
+import { useRouteError } from 'react-router-dom';
+
+export default function ErrorPage() {
+  const error = useRouteError();
+  console.error(error);
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center' }}>
+      <h1>Oops!</h1>
+      <p>Lo sentimos, ha ocurrido un error inesperado.</p>
+      {error && (
+        <pre style={{ whiteSpace: 'pre-wrap', color: '#b91c1c' }}>
+          {error.statusText || error.message}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -8,11 +8,13 @@ import Creating from './pages/Creating.jsx';
 import Result from './pages/Result.jsx';
 import DevRenderPreview from './pages/DevRenderPreview.jsx';
 import DevCanvasPreview from './pages/DevCanvasPreview.jsx';
+import ErrorPage from './ErrorPage.jsx';
 import './globals.css';
 
 const routes = [
   {
     element: <App />,
+    errorElement: <ErrorPage />,
     children: [
       { path: '/', element: <Home /> },
       { path: '/confirm', element: <Confirm /> },


### PR DESCRIPTION
## Summary
- add an error page component to show messages from React Router
- wire the new error page into the router so unexpected errors render gracefully

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b23345127c83278647e94565368820