### PR TITLE
fix: prevent render loop in editor layout

### DIFF
--- a/mgm-front/src/components/SizeControls.jsx
+++ b/mgm-front/src/components/SizeControls.jsx
@@ -25,7 +25,8 @@ export default function SizeControls({ material, size, onChange, locked = false 
       setHText('40');
       onChange({ w: 50, h: 40 });
     }
-  }, [material, onChange]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [material]);
 
   const clamp = (val, min, max) => Math.max(min, Math.min(max, val));
   const applySize = () => {


### PR DESCRIPTION
## Summary
- avoid layout feedback loops in canvas by guarding updates
- clean UploadStep object URL handling and size controls effect
- convert stray logs to debug helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b239d7451883278fa020ee728f49b7