### PR TITLE
Restore direct checkout flow

### DIFF
--- a/mgm-front/src/lib/checkoutFlow.ts
+++ b/mgm-front/src/lib/checkoutFlow.ts
@@ -1,0 +1,81 @@
+import { submitJob } from './submitJob';
+import { dlog } from './debug';
+
+export interface JobStatus {
+  job_id: string;
+  status?: string;
+  price_amount?: number | null;
+  price_currency?: string | null;
+  print_jpg_url?: string | null;
+  pdf_url?: string | null;
+  preview_url?: string | null;
+}
+
+async function sleep(ms:number){ return new Promise(r=>setTimeout(r, ms)); }
+
+export async function finalizeAssetsOrPoll(apiBase:string, jobId:string, opts?:{ render?:any; render_v2?:any; maxAttempts?:number; intervalMs?:number; onTick?:(attempt:number, job?:JobStatus)=>void; }){
+  const base = (apiBase || '').replace(/\/$/, '');
+  const body = opts?.render_v2 ? { job_id: jobId, render_v2: opts.render_v2 } :
+               opts?.render ? { job_id: jobId, render: opts.render } :
+               { job_id: jobId };
+  try {
+    const resp = await fetch(`${base}/api/finalize-assets`, {
+      method:'POST',
+      headers:{ 'Content-Type':'application/json' },
+      body: JSON.stringify(body)
+    });
+    dlog('finalize diag', resp.headers.get('X-Diag-Id'));
+  } catch(e) {
+    console.warn('[finalize-assets warn]', e);
+  }
+
+  const maxAttempts = opts?.maxAttempts ?? 45;
+  const intervalMs = opts?.intervalMs ?? 2000;
+  let last: JobStatus | undefined;
+  for (let i=1;i<=maxAttempts;i++) {
+    try {
+      const res = await fetch(`${base}/api/job-status?job_id=${encodeURIComponent(jobId)}`);
+      if (res.ok) {
+        const j = await res.json();
+        if (j?.ok) {
+          last = j.job as JobStatus;
+          opts?.onTick?.(i, last);
+          if (last.print_jpg_url && last.pdf_url && last.preview_url && last.price_amount) break;
+        }
+      }
+    } catch(err) {
+      console.warn('[job-status warn]', err);
+    }
+    await sleep(intervalMs);
+  }
+  return last;
+}
+
+export async function createCartLink(apiBase:string, jobId:string){
+  const base = (apiBase || '').replace(/\/$/, '');
+  const res = await fetch(`${base}/api/create-cart-link`, {
+    method:'POST',
+    headers:{ 'Content-Type':'application/json' },
+    body: JSON.stringify({ job_id: jobId })
+  });
+  const j = await res.json();
+  if (!res.ok) {
+    const code = j?.error || 'unknown';
+    const diag = res.headers.get('X-Diag-Id') || '';
+    throw new Error(`create-cart-link ${code} diag:${diag}`);
+  }
+  return j;
+}
+
+export async function checkoutFlow(apiBase:string, submitBody:any, finalizeOpts?:{ render?:any; render_v2?:any; onTick?:(stage:string)=>void; }){
+  const job = await submitJob(apiBase, submitBody);
+  const jobId = job?.job_id || submitBody.job_id;
+  finalizeOpts?.onTick?.('finalize');
+  const finalJob = await finalizeAssetsOrPoll(apiBase, jobId, { render: finalizeOpts?.render, render_v2: finalizeOpts?.render_v2 });
+  finalizeOpts?.onTick?.('cart');
+  const cart = await createCartLink(apiBase, jobId);
+  return { job_id: jobId, preview_url: finalJob?.preview_url, ...cart };
+}
+
+export default checkoutFlow;
+

--- a/mgm-front/src/pages/Result.jsx
+++ b/mgm-front/src/pages/Result.jsx
@@ -1,103 +1,56 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 export default function Result() {
   const { jobId } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
-  const apiBase = import.meta.env.VITE_API_BASE || 'https://mgm-api.vercel.app';
 
-  const [urls, setUrls] = useState({
-    cart_url_follow: location.state?.cart_url_follow,
-    checkout_url_now: location.state?.checkout_url_now,
+  const previewUrl = location.state?.preview_url;
+  const urls = {
+    cart_url: location.state?.cart_url,
+    checkout_url: location.state?.checkout_url || location.state?.cart_url,
     cart_plain: location.state?.cart_plain,
     checkout_plain: location.state?.checkout_plain,
-  });
-  const [job, setJob] = useState(null);
+  };
+  const [disabled, setDisabled] = useState(false);
   const [added, setAdded] = useState(() => localStorage.getItem(`MGM_jobAdded:${jobId}`) === 'true');
 
-  useEffect(() => {
-    async function fetchJob() {
-      try {
-        const res = await fetch(`${apiBase}/api/job-status?job_id=${encodeURIComponent(jobId)}`);
-        const j = await res.json();
-        if (res.ok && j.ok) setJob(j.job);
-      } catch { /* ignore */ }
-    }
-    fetchJob();
-  }, [apiBase, jobId]);
+  const cartUrl = added ? urls.cart_plain || urls.cart_url : urls.cart_url;
+  const checkoutUrl = added ? urls.checkout_plain || urls.checkout_url : urls.checkout_url;
 
-  useEffect(() => {
-    if (!urls.cart_url_follow || !urls.checkout_url_now) {
-      async function ensureUrls() {
-        try {
-          const res = await fetch(`${apiBase}/api/create-cart-link`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ job_id: jobId }),
-          });
-          const j = await res.json();
-          if (res.ok) {
-            setUrls({
-              cart_url_follow: j.cart_url_follow || j.cart_url,
-              checkout_url_now: j.checkout_url_now,
-              cart_plain: j.cart_plain,
-              checkout_plain: j.checkout_plain,
-            });
-          }
-        } catch { /* ignore */ }
-      }
-      ensureUrls();
+  function open(url, mark) {
+    if (!url) return;
+    setDisabled(true);
+    window.open(url, '_blank', 'noopener,noreferrer');
+    if (mark && !added) {
+      localStorage.setItem(`MGM_jobAdded:${jobId}`, 'true');
+      setAdded(true);
     }
-  }, [urls, apiBase, jobId]);
-
-  if (!urls.cart_url_follow || !urls.checkout_url_now) {
-    return <p>Preparando tu carrito…</p>;
+    setTimeout(() => setDisabled(false), 500);
   }
 
-  const hrefCart = added ? urls.cart_plain : urls.cart_url_follow;
-  const hrefCheckout = added ? urls.checkout_plain : urls.checkout_url_now;
-
   return (
-    <div>
-      {job?.preview_url && (
-        <img src={job.preview_url} alt="preview" style={{ maxWidth: '300px' }} />
+    <div style={{ textAlign: 'center' }}>
+      {previewUrl && (
+        <img src={previewUrl} alt="preview" style={{ maxWidth: '300px' }} />
       )}
-      <div>
-        <a
-          href={hrefCart}
-          target="_blank"
-          rel="noopener"
-          onClick={() => {
-            localStorage.setItem(`MGM_jobAdded:${jobId}`, 'true');
-            setAdded(true);
-          }}
-        >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', marginTop: '20px' }}>
+        <button disabled={disabled} onClick={() => open(cartUrl, true)}>
           Agregar al carrito y seguir comprando
-        </a>
-        <a
-          href={hrefCheckout}
-          target="_blank"
-          rel="noopener"
-          onClick={() => {
-            localStorage.setItem(`MGM_jobAdded:${jobId}`, 'true');
-            setAdded(true);
-          }}
-        >
+        </button>
+        <button disabled={disabled} onClick={() => open(checkoutUrl, true)}>
           Pagar ahora
-        </a>
-        <a
-          href={hrefCart}
-          target="_blank"
-          rel="noopener"
+        </button>
+        <button
+          disabled={disabled}
           onClick={() => {
-            localStorage.setItem(`MGM_jobAdded:${jobId}`, 'true');
-            setAdded(true);
+            open(cartUrl, true);
             navigate('/');
           }}
         >
           Crear otro
-        </a>
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- orchestrate submit → finalize → cart via new `checkoutFlow`
- call flow directly from editor and navigate to result with mockup and cart links
- show mockup with add-to-cart/checkout options that open once in new tab

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b24b0991a8832793edc22a4b7f68c9