### PR TITLE
Fix image manual scaling persists

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -1166,6 +1166,8 @@ async function onConfirmSubmit() {
                       const h = Math.max(MIN_H, Math.min(newBox.height, MAX_H));
                       return { ...newBox, width: w, height: h };
                     }}
+                    onTransformStart={onTransformStart}
+                    onTransform={onTransform}
                     onTransformEnd={onTransformEnd}
                   />
                 </>


### PR DESCRIPTION
## Summary
- ensure Transformer updates image state on manual resize

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b25fb917908327a478a2832fb6a2ec