### PR TITLE
fix: guard scale gesture latest access

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -539,8 +539,9 @@ const EditorCanvas = forwardRef(function EditorCanvas(
       }
       return;
     }
-    if (scaleGestureRef.current.latest) {
-      setImgTx((tx) => ({ ...tx, ...scaleGestureRef.current.latest }));
+    const latest = scaleGestureRef.current?.latest;
+    if (latest) {
+      setImgTx((tx) => ({ ...tx, ...latest }));
     }
     scaleGestureRef.current = null;
     const next = normalizeIntoBounds();


### PR DESCRIPTION
## Summary
- avoid crash when `scaleGestureRef` is null by guarding access to `latest`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b26e46b11c83278a81ad8e6d89f272