### PR TITLE
feat: add Sentry error tracking

### DIFF
--- a/api/_lib/observability.js
+++ b/api/_lib/observability.js
@@ -1,0 +1,31 @@
+import * as Sentry from '@sentry/node';
+
+let initialized = false;
+
+function init() {
+  if (initialized || !process.env.SENTRY_DSN_API) return;
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN_API,
+    environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
+    tracesSampleRate: 1.0,
+  });
+  initialized = true;
+}
+
+export function withObservability(handler) {
+  init();
+  return async function (req, res) {
+    try {
+      await handler(req, res);
+    } catch (err) {
+      const diagId = res.getHeader && res.getHeader('X-Diag-Id');
+      Sentry.withScope((scope) => {
+        if (diagId) scope.setTag('diag_id', diagId);
+        scope.setTag('stage', 'handler');
+        Sentry.captureException(err);
+      });
+      console.error('unhandled_error', { diagId, err });
+      res.status(500).json({ ok: false, diag_id: diagId, stage: 'handler', message: 'internal_error' });
+    }
+  };
+}

--- a/api/create-cart-link.js
+++ b/api/create-cart-link.js
@@ -4,6 +4,7 @@ import crypto from 'node:crypto';
 import { supa } from '../lib/supa.js';
 import { shopifyAdmin, shopifyAdminGraphQL } from '../lib/shopify.js';
 import { cors } from './_lib/cors.js';
+import { withObservability } from './_lib/observability.js';
 
 function slugify(s){ return String(s).toLowerCase().trim()
   .replace(/\s+/g,'-').replace(/[^a-z0-9-]/g,'').replace(/-+/g,'-').replace(/^-|-$/g,''); }
@@ -16,7 +17,7 @@ function qs(obj) {
   return Object.entries(obj).map(([k,v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v ?? '')}`).join('&');
 }
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const diagId = crypto.randomUUID?.() ?? require('node:crypto').randomUUID();
   res.setHeader('X-Diag-Id', String(diagId));
 
@@ -210,4 +211,6 @@ export default async function handler(req, res) {
     return res.status(500).json({ error: 'create_cart_link_failed', detail: String(e?.message || e) });
   }
 }
+
+export default withObservability(handler);
 

--- a/api/submit-job.js
+++ b/api/submit-job.js
@@ -4,8 +4,9 @@ import { z } from 'zod';
 import { cors } from './_lib/cors.js';
 import getSupabaseAdmin from './_lib/supabaseAdmin.js';
 import { getEnv } from './_lib/env.js';
+import { withObservability } from './_lib/observability.js';
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const diagId = randomUUID();
   res.setHeader('X-Diag-Id', diagId);
 
@@ -166,3 +167,5 @@ export default async function handler(req, res) {
       .json({ ok: false, diag_id: diagId, stage: 'unknown', message: 'Unexpected error' });
   }
 }
+
+export default withObservability(handler);

--- a/api/upload-url.js
+++ b/api/upload-url.js
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { supa } from '../lib/supa.js';
 import { cors } from './_lib/cors.js';
 import { buildObjectKey } from './_lib/slug.js';
+import { withObservability } from './_lib/observability.js';
 
 const BodySchema = z.object({
   design_name: z.string().min(1),
@@ -20,7 +21,7 @@ const BodySchema = z.object({
 const MAX_MB = Number(process.env.MAX_UPLOAD_MB || 40);
 const LIMITS = { Classic: { maxW: 140, maxH: 100 }, PRO: { maxW: 120, maxH: 60 } };
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const diagId = crypto.randomUUID?.() ?? require('node:crypto').randomUUID();
   res.setHeader('X-Diag-Id', String(diagId));
 
@@ -93,3 +94,5 @@ export default async function handler(req, res) {
     return res.status(500).json({ error: 'internal_error' });
   }
 }
+
+export default withObservability(handler);

--- a/mgm-front/package.json
+++ b/mgm-front/package.json
@@ -19,7 +19,8 @@
     "react-konva": "^19.0.7",
     "react-router-dom": "^7.8.0",
     "use-image": "^1.1.4",
-    "zod": "^4.0.17"
+    "zod": "^4.0.17",
+    "@sentry/react": "^8.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/mgm-front/src/components/AppErrorBoundary.jsx
+++ b/mgm-front/src/components/AppErrorBoundary.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { ErrorBoundary } from '@sentry/react';
+import { getDiagContext } from '../lib/diagContext';
+
+function Fallback({ error, resetError }) {
+  const ctx = getDiagContext();
+  const diag = ctx.diag_id || error?.message?.match(/diag:([^\s]+)/)?.[1];
+  const stage = ctx.stage || error?.message?.match(/stage:([^\s]+)/)?.[1];
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center' }}>
+      <h1>Ocurrió un error</h1>
+      {diag && <p>diag_id: {diag}</p>}
+      {stage && <p>stage: {stage}</p>}
+      <button onClick={resetError}>Reintentar</button>
+    </div>
+  );
+}
+
+export default function AppErrorBoundary({ children }) {
+  return (
+    <ErrorBoundary
+      fallback={Fallback}
+      beforeCapture={(scope, error) => {
+        const ctx = getDiagContext();
+        if (ctx.diag_id) scope.setTag('diag_id', ctx.diag_id);
+        if (ctx.stage) scope.setTag('stage', ctx.stage);
+        if (ctx.job_id) scope.setTag('job_id', ctx.job_id);
+        const msgDiag = error?.message?.match(/diag:([^\s]+)/)?.[1];
+        if (msgDiag) scope.setTag('diag_id', msgDiag);
+        const msgStage = error?.message?.match(/stage:([^\s]+)/)?.[1];
+        if (msgStage) scope.setTag('stage', msgStage);
+      }}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/mgm-front/src/lib/checkoutFlow.ts
+++ b/mgm-front/src/lib/checkoutFlow.ts
@@ -1,4 +1,5 @@
 import { dlog } from './debug';
+import { setDiagContext } from './diagContext';
 
 export interface SubmitJobBody {
   job_id: string;
@@ -34,8 +35,10 @@ export async function submitJob(apiBase: string, body: SubmitJobBody): Promise<a
   let data: any = null;
   try { data = await res.json(); } catch {}
   if (!res.ok) {
+    setDiagContext({ diag_id: diagId, stage: 'submit', job_id: body.job_id });
     throw new Error(`submit ${res.status} diag:${diagId} stage:submit`);
   }
+  setDiagContext({ diag_id: diagId, job_id: data?.job?.job_id || body.job_id });
   dlog('[submit-job OK]', { diagId, job: data?.job });
   return data?.job;
 }
@@ -85,8 +88,10 @@ export async function createCartLink(apiBase: string, jobId: string): Promise<an
   let data: any = null;
   try { data = await res.json(); } catch {}
   if (!res.ok) {
+    setDiagContext({ diag_id: diagId, stage: 'cart', job_id: jobId });
     throw new Error(`cart ${res.status} diag:${diagId} stage:cart`);
   }
+  setDiagContext({ diag_id: diagId, job_id: jobId });
   dlog('[create-cart-link OK]', { diagId, cart: data });
   return data;
 }

--- a/mgm-front/src/lib/diagContext.ts
+++ b/mgm-front/src/lib/diagContext.ts
@@ -1,0 +1,15 @@
+export interface DiagContext {
+  diag_id?: string;
+  stage?: string;
+  job_id?: string;
+}
+
+const ctx: DiagContext = {};
+
+export function setDiagContext(partial: DiagContext) {
+  Object.assign(ctx, partial);
+}
+
+export function getDiagContext(): DiagContext {
+  return ctx;
+}

--- a/mgm-front/src/lib/submitJob.ts
+++ b/mgm-front/src/lib/submitJob.ts
@@ -1,5 +1,6 @@
 // src/lib/submitJob.ts
 import { dlog } from './debug';
+import { setDiagContext } from './diagContext';
 export interface SubmitJobBody {
   job_id: string;
   material: string;
@@ -36,6 +37,7 @@ export async function submitJob(apiBase: string, body: SubmitJobBody): Promise<a
   try { data = await res.json(); } catch {}
 
   if (!res.ok) {
+    setDiagContext({ diag_id: diagId, stage: data?.stage, job_id: body.job_id });
     console.error('[submit-job FAILED]', {
       status: res.status,
       diagId,
@@ -49,6 +51,7 @@ export async function submitJob(apiBase: string, body: SubmitJobBody): Promise<a
     );
   }
 
+  setDiagContext({ diag_id: diagId, job_id: data?.job?.job_id || body.job_id });
   dlog('[submit-job OK]', { diagId, job: data?.job });
   return data?.job;
 }

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -8,7 +8,11 @@ import Result from './pages/Result.jsx';
 import DevRenderPreview from './pages/DevRenderPreview.jsx';
 import DevCanvasPreview from './pages/DevCanvasPreview.jsx';
 import ErrorPage from './ErrorPage.jsx';
+import AppErrorBoundary from './components/AppErrorBoundary.jsx';
+import { initSentry } from './sentry';
 import './globals.css';
+
+initSentry();
 
 const routes = [
   {
@@ -31,6 +35,8 @@ const router = createBrowserRouter(routes);
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <AppErrorBoundary>
+      <RouterProvider router={router} />
+    </AppErrorBoundary>
   </React.StrictMode>
 );

--- a/mgm-front/src/sentry.ts
+++ b/mgm-front/src/sentry.ts
@@ -1,0 +1,23 @@
+import * as Sentry from '@sentry/react';
+import { getDiagContext } from './lib/diagContext';
+
+export function initSentry() {
+  const dsn = import.meta.env.VITE_SENTRY_DSN_FRONT;
+  if (!dsn) return;
+
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.VITE_SENTRY_ENV || import.meta.env.MODE,
+    integrations: [new Sentry.BrowserTracing()],
+    tracesSampleRate: 1.0,
+    beforeSend(event) {
+      const ctx = getDiagContext();
+      if (ctx.diag_id) event.tags = { ...event.tags, diag_id: ctx.diag_id };
+      if (ctx.stage) event.tags = { ...event.tags, stage: ctx.stage };
+      if (ctx.job_id) event.tags = { ...event.tags, job_id: ctx.job_id };
+      return event;
+    },
+  });
+}
+
+export { Sentry };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.54.0",
+    "@sentry/node": "^8.0.0",
     "nanoid": "^5.1.5",
     "pdf-lib": "^1.17.1",
     "sharp": "^0.34.3",


### PR DESCRIPTION
## Summary
- integrate Sentry on frontend with global error boundary and diag context
- capture diag_id and stage in API handlers via observability wrapper

## Testing
- `npm run lint --prefix mgm-front`
- `npm run build --prefix mgm-front` *(fails: Cannot find module '@sentry/react')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b27516efb4832794437f5ddfa76de7