### PR TITLE
Add SEO metadata, sitemap generation, and feature flags

### DIFF
--- a/mgm-front/index.html
+++ b/mgm-front/index.html
@@ -5,7 +5,17 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="stylesheet" href="/src/index.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+
+    <title>MGM Personalizados</title>
+    <meta name="description" content="Personaliza tu mousepad con MGM" />
+    <link rel="canonical" href="https://example.com/" />
+
+    <meta property="og:title" content="MGM Personalizados" />
+    <meta property="og:description" content="Crea tu mousepad personalizado" />
+    <meta property="og:url" content="https://example.com/" />
+    <meta property="og:image" content="https://example.com/preview.png" />
+
+    <link rel="preload" href="/src/main.jsx" as="script" />
     <style>
       #initial-spinner {
         position: fixed;
@@ -14,6 +24,26 @@
         transform: translate(-50%, -50%);
       }
     </style>
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "MGM GAMERS"
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": "Mousepad personalizado",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "ARS"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="root">

--- a/mgm-front/package.json
+++ b/mgm-front/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/generate-sitemap.js",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/mgm-front/scripts/generate-sitemap.js
+++ b/mgm-front/scripts/generate-sitemap.js
@@ -1,0 +1,14 @@
+import { writeFileSync } from 'fs';
+
+const baseUrl = 'https://example.com';
+const routes = ['/', '/confirm'];
+
+const urlset = routes
+  .map(route => `  <url><loc>${baseUrl}${route}</loc></url>`) 
+  .join('\n');
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urlset}\n</urlset>\n`;
+writeFileSync('dist/sitemap.xml', sitemap);
+
+const robots = `User-agent: *\nAllow: /\nSitemap: ${baseUrl}/sitemap.xml\n`;
+writeFileSync('dist/robots.txt', robots);

--- a/mgm-front/src/lib/flags.js
+++ b/mgm-front/src/lib/flags.js
@@ -1,0 +1,5 @@
+export const flags = {
+  useNewExportWorker: import.meta.env.VITE_FLAG_NEW_EXPORT_WORKER === 'true',
+  useNewMockupScale: import.meta.env.VITE_FLAG_NEW_MOCKUP_SCALE === 'true',
+  showAdvancedTools: import.meta.env.VITE_FLAG_SHOW_ADVANCED_TOOLS === 'true'
+};

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -7,6 +7,8 @@ import EditorCanvas from '../components/EditorCanvas';
 import SizeControls from '../components/SizeControls';
 import Calculadora from '../components/Calculadora';
 import LoadingOverlay from '../components/LoadingOverlay';
+import DebugPanel from '../components/DebugPanel';
+import { flags } from '../lib/flags';
 import { LIMITS, STANDARD } from '../lib/material.js';
 
 import { dpiLevel } from '../lib/dpi';
@@ -309,6 +311,7 @@ export default function Home() {
         {err && <p className={`errorText ${styles.error}`}>{err}</p>}
       </div>
       <LoadingOverlay show={busy} messages={["Guardando tu diseño…","Preparando archivos de impresión…","Creando producto en tienda…","Listo: abre tu carrito"]} />
+      {flags.showAdvancedTools && <DebugPanel data={{ layout, size, material }} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enhance HTML head with basic SEO and Open Graph metadata plus structured data
- generate sitemap.xml and robots.txt during build
- introduce simple feature flag utilities and expose debug panel under flag

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b278083b58832789606bb6796dc3fc