### PR TITLE
feat: admin job search and downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,20 @@ La aplicación utiliza dos buckets de Supabase Storage:
 
 * `uploads`: privado, almacena los archivos originales subidos por el usuario.
 * `outputs`: público, recibe los archivos generados (`preview.jpg`, `print.jpg` y `file.pdf`) por `/api/finalize-assets`.
+
+## Admin search de jobs
+
+El endpoint `GET /api/admin/search-jobs` permite buscar trabajos por `job_id`,
+`design_name`, `customer_email` o `file_hash`. Requiere enviar el header
+`Authorization: Bearer ${WORKER_TOKEN}` y solo responde a los orígenes
+permitidos por CORS.
+
+Variables de entorno adicionales:
+
+```
+WORKER_TOKEN=tu_token_secreto
+```
+
+El frontend incluye una página en `/admin` donde se puede pegar el token una
+sola vez (se guarda en `localStorage`) y realizar búsquedas, paginar y descargar
+los archivos listos para impresión.

--- a/api/admin/search-jobs.js
+++ b/api/admin/search-jobs.js
@@ -1,0 +1,128 @@
+import crypto from 'node:crypto';
+import { supa } from '../../lib/supa.js';
+import { cors } from '../_lib/cors.js';
+import { parseSupabasePath } from '../../lib/storage.js';
+
+export default async function handler(req, res) {
+  const diagId = crypto.randomUUID?.() ?? require('node:crypto').randomUUID();
+  res.setHeader('X-Diag-Id', String(diagId));
+
+  if (cors(req, res)) return;
+
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'method_not_allowed', diag_id: diagId });
+  }
+
+  const auth = req.headers.authorization || '';
+  const token = auth.startsWith('Bearer ') ? auth.slice(7) : '';
+  if (!token || token !== process.env.WORKER_TOKEN) {
+    return res.status(401).json({ error: 'unauthorized', diag_id: diagId });
+  }
+
+  const {
+    q = '',
+    status,
+    date_from,
+    date_to,
+    page = '1',
+    page_size = '25',
+    has_pdf,
+  } = req.query;
+
+  const pageNum = Math.max(1, parseInt(page, 10) || 1);
+  const pageSize = Math.min(100, parseInt(page_size, 10) || 25);
+  const offset = (pageNum - 1) * pageSize;
+
+  const term = String(q).replace(/%/g, '').trim();
+
+  function applyFilters(qb) {
+    if (term) {
+      qb = qb.or(
+        `job_id.ilike.%${term}%,design_name.ilike.%${term}%,customer_email.ilike.%${term}%,file_hash.ilike.%${term}%`
+      );
+    }
+    if (status) qb = qb.eq('status', status);
+    if (date_from) qb = qb.gte('created_at', date_from);
+    if (date_to) qb = qb.lte('created_at', date_to);
+    if (has_pdf === 'true') qb = qb.not('pdf_url', 'is', null);
+    return qb;
+  }
+
+  try {
+    const listQuery = applyFilters(
+      supa
+        .from('jobs')
+        .select(
+          'id,created_at,job_id,design_name,material,w_cm,h_cm,customer_email,status,pdf_url,print_jpg_url,preview_url,shopify_product_url'
+        )
+        .order('created_at', { ascending: false })
+        .range(offset, offset + pageSize - 1)
+    );
+    const { data, error } = await listQuery;
+    if (error) throw error;
+
+    const countQuery = applyFilters(
+      supa.from('jobs').select('id', { count: 'exact', head: true })
+    );
+    const { count, error: countError } = await countQuery;
+    if (countError) throw countError;
+
+    const results = await Promise.all(
+      data.map(async row => {
+        const out = {
+          id: row.id,
+          created_at: row.created_at,
+          job_id: row.job_id,
+          design_name: row.design_name,
+          material: row.material,
+          w_cm: row.w_cm,
+          h_cm: row.h_cm,
+          customer_email: row.customer_email,
+          status: row.status,
+          preview_url: row.preview_url,
+          shopify_product_url: row.shopify_product_url,
+        };
+
+        async function maybeSigned(original, targetKey) {
+          if (!original) return;
+          try {
+            const { bucket, path } = parseSupabasePath(original);
+            if (bucket === 'uploads') {
+              const { data: signed, error: signErr } = await supa.storage
+                .from(bucket)
+                .createSignedUrl(path, 300);
+              if (signErr) throw signErr;
+              out[targetKey] = signed.signedUrl;
+            } else {
+              out[targetKey] = original;
+            }
+          } catch {
+            out[targetKey] = original;
+          }
+        }
+
+        await Promise.all([
+          maybeSigned(row.pdf_url, 'pdf_download_url'),
+          maybeSigned(row.print_jpg_url, 'print_jpg_download_url'),
+        ]);
+
+        return out;
+      })
+    );
+
+    console.log(JSON.stringify({ stage: 'admin_search', diag_id: diagId, page: pageNum, term, status }));
+
+    return res.status(200).json({
+      ok: true,
+      diag_id: diagId,
+      page: pageNum,
+      page_size: pageSize,
+      total: count || 0,
+      results,
+    });
+  } catch (e) {
+    console.error('admin_search', diagId, e);
+    return res.status(500).json({ error: 'search_failed', diag_id: diagId });
+  }
+}

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -11,3 +11,15 @@ export function parseSupabaseObject(url){
   if (!m) throw new Error('invalid_supabase_storage_url');
   return { visibility: m[1], bucket: m[2], key: m[3] };
 }
+
+// Extrae bucket y path de una URL de Supabase Storage. Soporta
+// variantes firmadas como /object/sign/ y /object/upload/sign/ y las
+// normaliza a /object/.
+export function parseSupabasePath(url) {
+  const normalized = url
+    .replace('/object/sign/', '/object/')
+    .replace('/object/upload/sign/', '/object/');
+  const m = normalized.match(/\/storage\/v1\/object\/([^/]+)\/(.+)$/);
+  if (!m) throw new Error('invalid_supabase_storage_url');
+  return { bucket: m[1], path: m[2] };
+}

--- a/mgm-front/src/hooks/useAdminToken.js
+++ b/mgm-front/src/hooks/useAdminToken.js
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+
+const LS_KEY = 'mgm_admin_token';
+
+export function useAdminToken() {
+  const [token, setToken] = useState(() => localStorage.getItem(LS_KEY) || '');
+
+  const saveToken = t => {
+    localStorage.setItem(LS_KEY, t);
+    setToken(t);
+  };
+
+  const clearToken = () => {
+    localStorage.removeItem(LS_KEY);
+    setToken('');
+  };
+
+  return { token, saveToken, clearToken };
+}

--- a/mgm-front/src/lib/adminClient.js
+++ b/mgm-front/src/lib/adminClient.js
@@ -1,0 +1,15 @@
+const API_BASE = (import.meta.env.VITE_API_BASE || '').replace(/\/$/, '');
+
+export async function searchJobs(token, params = {}) {
+  const url = new URL(`${API_BASE}/api/admin/search-jobs`);
+  Object.entries(params).forEach(([k, v]) => {
+    if (v !== undefined && v !== null && v !== '') {
+      url.searchParams.set(k, v);
+    }
+  });
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const data = await res.json().catch(() => ({}));
+  return { res, data };
+}

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -5,6 +5,7 @@ import App from './App.jsx';
 import Home from './pages/Home.jsx';
 import Confirm from './pages/Confirm.jsx';
 import Result from './pages/Result.jsx';
+import Admin from './pages/Admin.jsx';
 import DevRenderPreview from './pages/DevRenderPreview.jsx';
 import DevCanvasPreview from './pages/DevCanvasPreview.jsx';
 import ErrorPage from './ErrorPage.jsx';
@@ -21,7 +22,8 @@ const routes = [
     children: [
       { path: '/', element: <Home /> },
       { path: '/confirm', element: <Confirm /> },
-      { path: '/result/:jobId', element: <Result /> }
+      { path: '/result/:jobId', element: <Result /> },
+      { path: '/admin', element: <Admin /> }
     ]
   }
 ];

--- a/mgm-front/src/pages/Admin.jsx
+++ b/mgm-front/src/pages/Admin.jsx
@@ -1,0 +1,178 @@
+import { useEffect, useRef, useState } from 'react';
+import { useAdminToken } from '../hooks/useAdminToken';
+import { searchJobs } from '../lib/adminClient';
+import styles from './Admin.module.css';
+
+export default function Admin() {
+  const { token, saveToken, clearToken } = useAdminToken();
+  const [tokenInput, setTokenInput] = useState('');
+  const [q, setQ] = useState('');
+  const [status, setStatus] = useState('');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [hasPdf, setHasPdf] = useState(false);
+  const [results, setResults] = useState([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [searchTime, setSearchTime] = useState(0);
+
+  const searchRef = useRef(null);
+  const pageSize = 25;
+
+  useEffect(() => {
+    function handleKey(e) {
+      if (e.key === '/' && document.activeElement !== searchRef.current) {
+        e.preventDefault();
+        searchRef.current?.focus();
+      } else if (e.key === 'Escape') {
+        setQ('');
+        searchRef.current?.focus();
+      } else if (e.key === 'Enter' && document.activeElement === searchRef.current) {
+        doSearch(1);
+      }
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  });
+
+  async function doSearch(p) {
+    if (!token) return;
+    setLoading(true);
+    setError('');
+    const t0 = performance.now();
+    const { res, data } = await searchJobs(token, {
+      q,
+      status,
+      date_from: dateFrom,
+      date_to: dateTo,
+      has_pdf: hasPdf ? 'true' : undefined,
+      page: p,
+    });
+    const elapsed = performance.now() - t0;
+    setSearchTime(Math.round(elapsed));
+    if (res.status === 401) {
+      clearToken();
+      alert('Token inválido');
+      setLoading(false);
+      return;
+    }
+    if (!res.ok) {
+      setError(`${data.error || 'error'} diag_id=${data.diag_id || '-'}`);
+      setLoading(false);
+      return;
+    }
+    setResults(data.results || []);
+    setTotal(data.total || 0);
+    setPage(data.page || p);
+    setLoading(false);
+  }
+
+  if (!token) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.tokenPrompt}>
+          <input
+            value={tokenInput}
+            onChange={e => setTokenInput(e.target.value)}
+            placeholder="Admin Token"
+          />
+          <button onClick={() => saveToken(tokenInput.trim())}>Guardar</button>
+        </div>
+      </div>
+    );
+  }
+
+  const totalPages = Math.ceil(total / pageSize) || 1;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.searchBar}>
+        <input
+          ref={searchRef}
+          value={q}
+          onChange={e => setQ(e.target.value)}
+          placeholder="Buscar"
+        />
+        <input
+          value={status}
+          onChange={e => setStatus(e.target.value)}
+          placeholder="status"
+        />
+        <input type="date" value={dateFrom} onChange={e => setDateFrom(e.target.value)} />
+        <input type="date" value={dateTo} onChange={e => setDateTo(e.target.value)} />
+        <label>
+          <input
+            type="checkbox"
+            checked={hasPdf}
+            onChange={e => setHasPdf(e.target.checked)}
+          />
+          con PDF
+        </label>
+        <button onClick={() => doSearch(1)}>Buscar</button>
+      </div>
+      {loading && <div>Buscando...</div>}
+      <div>
+        {total} resultados{searchTime ? ` en ${searchTime}ms` : ''}
+      </div>
+      {error && <div className={styles.error}>{error}</div>}
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Fecha</th>
+            <th>Job ID</th>
+            <th>Diseño</th>
+            <th>Medida</th>
+            <th>Material</th>
+            <th>Cliente</th>
+            <th>Status</th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          {results.map(r => (
+            <tr key={r.id}>
+              <td>{new Date(r.created_at).toLocaleString()}</td>
+              <td>
+                {r.job_id}
+                <button onClick={() => navigator.clipboard.writeText(r.job_id)}>📋</button>
+              </td>
+              <td>{r.design_name}</td>
+              <td>{r.w_cm}×{r.h_cm}</td>
+              <td>{r.material}</td>
+              <td>{r.customer_email}</td>
+              <td>{r.status}</td>
+              <td className={styles.actions}>
+                {r.pdf_download_url && (
+                  <a href={r.pdf_download_url} target="_blank" rel="noreferrer" download>PDF</a>
+                )}
+                {r.print_jpg_download_url && (
+                  <a href={r.print_jpg_download_url} target="_blank" rel="noreferrer" download>JPG</a>
+                )}
+                {r.preview_url && (
+                  <a href={r.preview_url} target="_blank" rel="noreferrer">Preview</a>
+                )}
+                {r.shopify_product_url && (
+                  <a href={r.shopify_product_url} target="_blank" rel="noreferrer">Shopify</a>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className={styles.pagination}>
+        <button disabled={page <= 1} onClick={() => doSearch(page - 1)}>
+          Anterior
+        </button>
+        <span>
+          {page}/{totalPages}
+        </span>
+        <button disabled={page >= totalPages} onClick={() => doSearch(page + 1)}>
+          Siguiente
+        </button>
+        <button onClick={clearToken}>Cambiar token</button>
+      </div>
+    </div>
+  );
+}

--- a/mgm-front/src/pages/Admin.module.css
+++ b/mgm-front/src/pages/Admin.module.css
@@ -1,0 +1,8 @@
+.container { padding: 1rem; }
+.searchBar { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1rem; }
+.table { width: 100%; border-collapse: collapse; }
+.table th, .table td { border: 1px solid #ddd; padding: 0.25rem 0.5rem; }
+.actions a { margin-right: 0.5rem; }
+.pagination { margin-top: 1rem; display: flex; gap: 0.5rem; }
+.error { color: red; margin-top: 0.5rem; }
+.tokenPrompt { margin: 2rem 0; }


### PR DESCRIPTION
## Summary
- add `parseSupabasePath` helper for normalized Supabase paths
- implement secured `GET /api/admin/search-jobs` to filter jobs and return signed download URLs
- create `/admin` page with token storage, search UI and PDF/JPG download actions
- document worker token and admin search usage

## Testing
- `npm test` *(missing script)*
- `cd mgm-front && npm test` *(missing script)*
- `cd mgm-front && npm run lint` *(cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68b27d3d039c832793ea7c97f12bffb9