### PR TITLE
feat: customer design listing and legal pages

### DIFF
--- a/api/_lib/userToken.js
+++ b/api/_lib/userToken.js
@@ -1,0 +1,24 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+const TTL_MS = 15 * 60 * 1000; // 15 minutes
+const SECRET = process.env.USER_JWT_SECRET || 'dev-secret';
+
+export function createUserToken(email) {
+  const ts = Date.now().toString();
+  const h = createHmac('sha256', SECRET).update(`${email}.${ts}`).digest('hex');
+  return `${ts}.${h}`;
+}
+
+export function verifyUserToken(email, token) {
+  try {
+    const [ts, sig] = String(token || '').split('.');
+    if (!ts || !sig) return false;
+    const tsNum = Number(ts);
+    if (!Number.isFinite(tsNum)) return false;
+    if (Date.now() - tsNum > TTL_MS) return false;
+    const h = createHmac('sha256', SECRET).update(`${email}.${ts}`).digest('hex');
+    return timingSafeEqual(Buffer.from(h), Buffer.from(sig));
+  } catch {
+    return false;
+  }
+}

--- a/api/submit-job.js
+++ b/api/submit-job.js
@@ -62,6 +62,8 @@ async function handler(req, res) {
     price_currency: z.string().optional(),
     notes: z.string().optional(),
     source: z.string().optional(),
+    legal_version: z.string().optional(),
+    legal_accepted_at: z.string().datetime().optional(),
   });
 
   const parsed = schema.safeParse(body);
@@ -99,6 +101,8 @@ async function handler(req, res) {
     price_currency: input.price_currency ?? null,
     notes: input.notes ?? null,
     source: input.source ?? 'api',
+    legal_version: input.legal_version ?? null,
+    legal_accepted_at: input.legal_accepted_at ?? null,
   };
 
   // TODO: remove when `design_name` column exists in DB (see supabase/migrations/2025-08-25_add_design_name.sql)

--- a/api/user/jobs.js
+++ b/api/user/jobs.js
@@ -1,0 +1,39 @@
+import { randomUUID } from 'node:crypto';
+import { cors } from '../_lib/cors.js';
+import { withObservability } from '../_lib/observability.js';
+import getSupabaseAdmin from '../_lib/supabaseAdmin.js';
+import { verifyUserToken } from '../_lib/userToken.js';
+
+async function handler(req, res) {
+  const diagId = randomUUID();
+  res.setHeader('X-Diag-Id', diagId);
+  if (cors(req, res)) return;
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ ok: false, diag_id: diagId, message: 'method_not_allowed' });
+  }
+  const { q, email: emailParam, token, page = '1', page_size = '20' } = req.query || {};
+  const email = q || emailParam;
+  if (!email) return res.status(400).json({ ok: false, diag_id: diagId, message: 'missing_email' });
+  if (!verifyUserToken(email, token)) {
+    return res.status(401).json({ ok: false, diag_id: diagId, message: 'invalid_token' });
+  }
+  const pageNum = parseInt(page, 10) || 1;
+  const sizeNum = parseInt(page_size, 10) || 20;
+  const from = (pageNum - 1) * sizeNum;
+  const to = from + sizeNum - 1;
+  const supa = getSupabaseAdmin();
+  const { data, error } = await supa
+    .from('jobs')
+    .select('job_id,created_at,design_name,material,w_cm,h_cm,status,preview_url,shopify_product_url,cart_url,checkout_url,legal_version')
+    .eq('customer_email', email)
+    .order('created_at', { ascending: false })
+    .range(from, to);
+  if (error) {
+    console.error('user/jobs', { diagId, error: error.message });
+    return res.status(500).json({ ok: false, diag_id: diagId, message: 'db_error' });
+  }
+  return res.status(200).json({ ok: true, diag_id: diagId, jobs: data || [] });
+}
+
+export default withObservability(handler);

--- a/api/user/login-link.js
+++ b/api/user/login-link.js
@@ -1,0 +1,26 @@
+import { randomUUID } from 'node:crypto';
+import { cors } from '../_lib/cors.js';
+import { withObservability } from '../_lib/observability.js';
+import { createUserToken } from '../_lib/userToken.js';
+
+async function handler(req, res) {
+  const diagId = randomUUID();
+  res.setHeader('X-Diag-Id', diagId);
+  if (cors(req, res)) return;
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ ok: false, diag_id: diagId, message: 'method_not_allowed' });
+  }
+  const { email } = req.body || {};
+  if (!email) return res.status(400).json({ ok: false, diag_id: diagId, message: 'missing_email' });
+  const token = createUserToken(email);
+  const base = process.env.PUBLIC_BASE_URL || '';
+  const link = `${base}/mis-disenos?token=${encodeURIComponent(token)}&email=${encodeURIComponent(email)}`;
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('[login-link]', link);
+  }
+  // En producción enviar email aquí
+  return res.status(200).json({ ok: true, diag_id: diagId });
+}
+
+export default withObservability(handler);

--- a/mgm-front/src/App.jsx
+++ b/mgm-front/src/App.jsx
@@ -11,6 +11,13 @@ export default function App() {
       <main className={styles.main}>
         <Outlet />
       </main>
+      <footer className={styles.footer}>
+        <a href="/legal/terminos">Términos</a> ·{' '}
+        <a href="/legal/privacidad">Privacidad</a> ·{' '}
+        <a href="/legal/contenido">Contenido</a> ·{' '}
+        <a href="/legal/devoluciones">Devoluciones</a> ·{' '}
+        <a href="/legal/dmca">DMCA</a>
+      </footer>
     </div>
   );
 }

--- a/mgm-front/src/App.module.css
+++ b/mgm-front/src/App.module.css
@@ -18,4 +18,14 @@
   padding: 16px;
 }
 
+.footer {
+  padding: 16px;
+  text-align: center;
+  background: #f0f0f0;
+}
+
+.footer a {
+  margin: 0 4px;
+}
+
 html, body { overflow-x: auto; }

--- a/mgm-front/src/components/DesignList.jsx
+++ b/mgm-front/src/components/DesignList.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+export default function DesignList({ jobs = [], onAddToCart }) {
+  if (!jobs.length) {
+    return (
+      <p>
+        Todavía no tenés diseños, ¡creá uno! <a href="/">Ir al editor</a>
+      </p>
+    );
+  }
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Mockup</th>
+          <th>Nombre</th>
+          <th>Medida</th>
+          <th>Material</th>
+          <th>Fecha</th>
+          <th>Estado</th>
+          <th>Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        {jobs.map(job => (
+          <tr key={job.job_id}>
+            <td>{job.preview_url && (<img src={job.preview_url} alt={job.design_name} style={{ width: 80 }} />)}</td>
+            <td>{job.design_name || '-'}</td>
+            <td>
+              {job.w_cm}×{job.h_cm}
+            </td>
+            <td>{job.material}</td>
+            <td>{job.created_at ? new Date(job.created_at).toLocaleDateString() : ''}</td>
+            <td>{job.status}</td>
+            <td>
+              {job.shopify_product_url && (
+                <a href={job.shopify_product_url} target="_blank" rel="noopener noreferrer">
+                  Ver en tienda
+                </a>
+              )}{' '}
+              {job.cart_url ? (
+                <a href={job.cart_url} target="_blank" rel="noopener noreferrer">
+                  Agregar al carrito
+                </a>
+              ) : (
+                <button type="button" onClick={() => onAddToCart?.(job.job_id)}>
+                  Agregar al carrito
+                </button>
+              )}{' '}
+              {job.preview_url && (
+                <a href={job.preview_url} target="_blank" rel="noopener noreferrer">
+                  Ver mockup
+                </a>
+              )}
+              {!job.legal_version && (
+                <span style={{ display: 'block', color: 'red' }}>
+                  Acepta términos antes de comprar
+                </span>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/mgm-front/src/lib/checkoutFlow.ts
+++ b/mgm-front/src/lib/checkoutFlow.ts
@@ -19,6 +19,8 @@ export interface SubmitJobBody {
   design_name?: string;
   notes?: string;
   source?: string;
+  legal_version?: string;
+  legal_accepted_at?: string;
 }
 
 export async function submitJob(apiBase: string, body: SubmitJobBody): Promise<any> {

--- a/mgm-front/src/lib/jobPayload.js
+++ b/mgm-front/src/lib/jobPayload.js
@@ -84,6 +84,8 @@ export function buildSubmitJobBody(input) {
     price_currency: input?.price?.currency || undefined,
     notes: input?.notes || '',
     source: input?.source || 'front',
+    legal_version: input?.legal_version || undefined,
+    legal_accepted_at: input?.legal_accepted_at || undefined,
   };
 }
 

--- a/mgm-front/src/lib/userStore.js
+++ b/mgm-front/src/lib/userStore.js
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+const EMAIL_KEY = 'customer_email';
+const TOKEN_KEY = 'user_token';
+
+export function useUserStore() {
+  const [email, setEmail] = useState(() => {
+    try {
+      return localStorage.getItem(EMAIL_KEY) || '';
+    } catch {
+      return '';
+    }
+  });
+  const [token, setToken] = useState(() => {
+    try {
+      return localStorage.getItem(TOKEN_KEY) || '';
+    } catch {
+      return '';
+    }
+  });
+
+  useEffect(() => {
+    try {
+      if (email) localStorage.setItem(EMAIL_KEY, email);
+      else localStorage.removeItem(EMAIL_KEY);
+    } catch {}
+  }, [email]);
+
+  useEffect(() => {
+    try {
+      if (token) localStorage.setItem(TOKEN_KEY, token);
+      else localStorage.removeItem(TOKEN_KEY);
+    } catch {}
+  }, [token]);
+
+  return { email, setEmail, token, setToken };
+}
+
+export default useUserStore;

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -6,6 +6,12 @@ import Home from './pages/Home.jsx';
 import Confirm from './pages/Confirm.jsx';
 import Result from './pages/Result.jsx';
 import Admin from './pages/Admin.jsx';
+import MisDisenos from './pages/MisDisenos.jsx';
+import Terminos from './pages/legal/Terminos.jsx';
+import Privacidad from './pages/legal/Privacidad.jsx';
+import Contenido from './pages/legal/Contenido.jsx';
+import Devoluciones from './pages/legal/Devoluciones.jsx';
+import DMCA from './pages/legal/DMCA.jsx';
 import DevRenderPreview from './pages/DevRenderPreview.jsx';
 import DevCanvasPreview from './pages/DevCanvasPreview.jsx';
 import ErrorPage from './ErrorPage.jsx';
@@ -23,7 +29,13 @@ const routes = [
       { path: '/', element: <Home /> },
       { path: '/confirm', element: <Confirm /> },
       { path: '/result/:jobId', element: <Result /> },
-      { path: '/admin', element: <Admin /> }
+      { path: '/admin', element: <Admin /> },
+      { path: '/mis-disenos', element: <MisDisenos /> },
+      { path: '/legal/terminos', element: <Terminos /> },
+      { path: '/legal/privacidad', element: <Privacidad /> },
+      { path: '/legal/contenido', element: <Contenido /> },
+      { path: '/legal/devoluciones', element: <Devoluciones /> },
+      { path: '/legal/dmca', element: <DMCA /> }
     ]
   }
 ];

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -20,6 +20,7 @@ import { dlog } from '../lib/debug';
 import styles from './Home.module.css';
 
 console.assert(Number.isFinite(PX_PER_CM), '[export] PX_PER_CM inválido', PX_PER_CM);
+const LEGAL_VERSION = import.meta.env.PUBLIC_LEGAL_VERSION || '2025-01-01';
 
 export default function Home() {
 
@@ -60,6 +61,7 @@ export default function Home() {
   const [layout, setLayout] = useState(null);
   const [designName, setDesignName] = useState('');
   const [ackLow, setAckLow] = useState(false);
+  const [legalAccepted, setLegalAccepted] = useState(false);
   const [err, setErr] = useState('');
   const [busy, setBusy] = useState(false);
   const [jobId, setJobId] = useState(null);
@@ -206,6 +208,8 @@ export default function Home() {
         price: { amount: priceAmount, currency: priceCurrency },
         design_name: designName,
         source: 'web',
+        legal_version: LEGAL_VERSION,
+        legal_accepted_at: new Date().toISOString(),
       });
 
       // 6) prevalidar sin pegarle a la API
@@ -303,7 +307,19 @@ export default function Home() {
         )}
 
         {uploaded && (
-          <button className={styles.continueButton} disabled={busy || priceAmount <= 0} onClick={handleContinue}>
+          <label className={styles.ackLabel}>
+            <input
+              type="checkbox"
+              checked={legalAccepted}
+              onChange={e => setLegalAccepted(e.target.checked)}
+            />{' '}
+            Acepto los <a href="/legal/terminos" target="_blank" rel="noopener noreferrer">Términos</a> y la{' '}
+            <a href="/legal/contenido" target="_blank" rel="noopener noreferrer">Política de Contenidos</a>
+          </label>
+        )}
+
+        {uploaded && (
+          <button className={styles.continueButton} disabled={busy || priceAmount <= 0 || !legalAccepted} onClick={handleContinue}>
             Continuar
           </button>
         )}

--- a/mgm-front/src/pages/MisDisenos.jsx
+++ b/mgm-front/src/pages/MisDisenos.jsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import DesignList from '../components/DesignList.jsx';
+import { useUserStore } from '../lib/userStore.js';
+import { createCartLink } from '../lib/checkoutFlow';
+
+export default function MisDisenos() {
+  const { email, setEmail, token, setToken } = useUserStore();
+  const [jobs, setJobs] = useState([]);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState('');
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const t = params.get('token');
+    const e = params.get('email');
+    if (t) setToken(t);
+    if (e) setEmail(e);
+  }, [setEmail, setToken]);
+
+  async function fetchJobs() {
+    if (!email || !token) return;
+    setBusy(true);
+    setErr('');
+    try {
+      const res = await fetch(`/api/user/jobs?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}&page=1&page_size=20`);
+      if (res.status === 401 || res.status === 403) {
+        setErr('Acceso no autorizado');
+        setToken('');
+        return;
+      }
+      const data = await res.json();
+      if (res.ok) setJobs(data.jobs || []);
+      else setErr(data.message || 'Error al cargar');
+    } catch (e) {
+      setErr(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  useEffect(() => {
+    if (email && token) fetchJobs();
+  }, [email, token]);
+
+  async function handleSendLink() {
+    if (!email) return;
+    setBusy(true);
+    setErr('');
+    try {
+      const res = await fetch('/api/user/login-link', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setErr(data.message || 'Error');
+      } else {
+        alert('Revisa tu email o consola para el link de acceso.');
+      }
+    } catch (e) {
+      setErr(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleAddToCart(jobId) {
+    try {
+      const cart = await createCartLink('', jobId);
+      const url = cart.checkout_url || cart.cart_url;
+      if (url) window.open(url, '_blank');
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  return (
+    <div>
+      <h1>Mis diseños</h1>
+      {!token && (
+        <div>
+          <input
+            type="email"
+            placeholder="tu@email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+          />
+          <button type="button" onClick={handleSendLink} disabled={busy}>
+            Enviar link
+          </button>
+        </div>
+      )}
+      {token && (
+        <div>
+          <button type="button" onClick={fetchJobs} disabled={busy}>
+            Ver mis diseños
+          </button>
+        </div>
+      )}
+      {err && <p className="errorText">{err}</p>}
+      {busy && <p>Cargando…</p>}
+      <DesignList jobs={jobs} onAddToCart={handleAddToCart} />
+    </div>
+  );
+}

--- a/mgm-front/src/pages/legal/Contenido.jsx
+++ b/mgm-front/src/pages/legal/Contenido.jsx
@@ -1,0 +1,16 @@
+import LegalLayout from './LegalLayout.jsx';
+
+export default function Contenido() {
+  return (
+    <LegalLayout
+      title="Política de contenidos"
+      description="Qué contenidos se permiten"
+      canonical="/legal/contenido"
+    >
+      <section>
+        <p>No se permiten contenidos ilegales, violentos o que infrinjan derechos de terceros. Nos reservamos el derecho de rechazar cualquier diseño.</p>
+        <p>Si detectamos contenido sospechoso podremos revisar manualmente y cancelar el pedido.</p>
+      </section>
+    </LegalLayout>
+  );
+}

--- a/mgm-front/src/pages/legal/DMCA.jsx
+++ b/mgm-front/src/pages/legal/DMCA.jsx
@@ -1,0 +1,15 @@
+import LegalLayout from './LegalLayout.jsx';
+
+export default function DMCA() {
+  return (
+    <LegalLayout
+      title="DMCA"
+      description="Procedimiento para reportar infracciones"
+      canonical="/legal/dmca"
+    >
+      <section>
+        <p>Si creés que algún contenido infringe tus derechos de autor, enviá un aviso con los datos de contacto, descripción de la obra y la URL afectada. Revisaremos y actuaremos rápidamente.</p>
+      </section>
+    </LegalLayout>
+  );
+}

--- a/mgm-front/src/pages/legal/Devoluciones.jsx
+++ b/mgm-front/src/pages/legal/Devoluciones.jsx
@@ -1,0 +1,16 @@
+import LegalLayout from './LegalLayout.jsx';
+
+export default function Devoluciones() {
+  return (
+    <LegalLayout
+      title="Devoluciones"
+      description="Política de devoluciones"
+      canonical="/legal/devoluciones"
+    >
+      <section>
+        <p>Los productos personalizados no tienen devolución salvo defectos de fabricación.</p>
+        <p>Si tu producto llega dañado o con errores, contactanos dentro de los 7 días con fotos para gestionar la reposición.</p>
+      </section>
+    </LegalLayout>
+  );
+}

--- a/mgm-front/src/pages/legal/LegalLayout.jsx
+++ b/mgm-front/src/pages/legal/LegalLayout.jsx
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+
+const COMPANY = import.meta.env.PUBLIC_COMPANY_NAME || 'MGM Gamers';
+const CONTACT = import.meta.env.PUBLIC_CONTACT_EMAIL || 'info@example.com';
+const ADDRESS = import.meta.env.PUBLIC_ADDRESS || 'Dirección no disponible';
+const LEGAL_VERSION = import.meta.env.PUBLIC_LEGAL_VERSION || '2025-01-01';
+
+export default function LegalLayout({ title, description, canonical, children }) {
+  useEffect(() => {
+    document.title = title;
+    let meta = document.querySelector('meta[name="description"]');
+    if (!meta) {
+      meta = document.createElement('meta');
+      meta.name = 'description';
+      document.head.appendChild(meta);
+    }
+    if (description) meta.content = description;
+    let link = document.querySelector('link[rel="canonical"]');
+    if (!link) {
+      link = document.createElement('link');
+      link.rel = 'canonical';
+      document.head.appendChild(link);
+    }
+    if (canonical) link.href = window.location.origin + canonical;
+  }, [title, description, canonical]);
+
+  return (
+    <main>
+      <h1>{title}</h1>
+      <p>Última actualización: {LEGAL_VERSION}</p>
+      <p>
+        {COMPANY} · {ADDRESS} · {CONTACT}
+      </p>
+      {children}
+    </main>
+  );
+}

--- a/mgm-front/src/pages/legal/Privacidad.jsx
+++ b/mgm-front/src/pages/legal/Privacidad.jsx
@@ -1,0 +1,20 @@
+import LegalLayout from './LegalLayout.jsx';
+
+export default function Privacidad() {
+  return (
+    <LegalLayout
+      title="Política de privacidad"
+      description="Cómo manejamos tus datos"
+      canonical="/legal/privacidad"
+    >
+      <section>
+        <h2>Datos que recolectamos</h2>
+        <p>Recopilamos tu email, diseños e información de medidas para poder fabricar y vender tu producto.</p>
+        <h2>Uso de datos</h2>
+        <p>Utilizamos estos datos sólo para producir tus pedidos y mejorar el servicio. Podés solicitar el borrado escribiéndonos.</p>
+        <h2>Retención</h2>
+        <p>Los archivos de diseños no pagados se conservan hasta 30 días.</p>
+      </section>
+    </LegalLayout>
+  );
+}

--- a/mgm-front/src/pages/legal/Terminos.jsx
+++ b/mgm-front/src/pages/legal/Terminos.jsx
@@ -1,0 +1,28 @@
+import LegalLayout from './LegalLayout.jsx';
+
+export default function Terminos() {
+  return (
+    <LegalLayout
+      title="Términos de uso"
+      description="Condiciones para utilizar el servicio"
+      canonical="/legal/terminos"
+    >
+      <section>
+        <h2>Uso del servicio</h2>
+        <p>
+          El uso del editor y de los servicios de fabricación implica tu aceptación de estos
+          términos. Conservás la propiedad de tus imágenes y nos otorgás una licencia limitada
+          para producir el producto y generar mockups.
+        </p>
+        <h2>Limitación de responsabilidad</h2>
+        <p>
+          No somos responsables por daños indirectos o pérdidas de datos. El servicio se ofrece
+          "tal cual" sin garantías adicionales.
+        </p>
+        <h2>Ley aplicable</h2>
+        <p>Estos términos se rigen por las leyes de Argentina. Para cualquier consulta:
+          contactanos.</p>
+      </section>
+    </LegalLayout>
+  );
+}

--- a/supabase/migrations/2025-08-30_add_legal_fields.sql
+++ b/supabase/migrations/2025-08-30_add_legal_fields.sql
@@ -1,0 +1,4 @@
+-- Agrega columnas para registrar aceptación de términos
+alter table public.jobs
+  add column if not exists legal_version text,
+  add column if not exists legal_accepted_at timestamptz;


### PR DESCRIPTION
## Summary
- add "Mis diseños" page with token auth and design table
- capture legal acceptance and add policy pages with footer links
- expose user jobs and login-link endpoints with HMAC tokens

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm test` (root, fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68b27f792d208327b731c7e32251e11e