### PR TITLE
fix: stabilize canvas scaling around fixed anchor

### DIFF
--- a/mgm-front/src/lib/transform2d.js
+++ b/mgm-front/src/lib/transform2d.js
@@ -1,0 +1,40 @@
+export function screenToCanvas(pt, viewPos, scale) {
+  return { x: (pt.x - viewPos.x) / scale, y: (pt.y - viewPos.y) / scale };
+}
+
+export function canvasToLocal(p, transform) {
+  const { tx, ty, theta, sx, sy } = transform;
+  const cos = Math.cos(-theta);
+  const sin = Math.sin(-theta);
+  const dx = p.x - tx;
+  const dy = p.y - ty;
+  return {
+    x: (dx * cos - dy * sin) / sx,
+    y: (dx * sin + dy * cos) / sy,
+  };
+}
+
+export function localToCanvas(p, transform) {
+  const { tx, ty, theta, sx, sy } = transform;
+  const cos = Math.cos(theta);
+  const sin = Math.sin(theta);
+  const x = p.x * sx;
+  const y = p.y * sy;
+  return {
+    x: tx + x * cos - y * sin,
+    y: ty + x * sin + y * cos,
+  };
+}
+
+export function composeTransform({ tx, ty, theta, sx, sy }, anchor) {
+  const cos = Math.cos(theta);
+  const sin = Math.sin(theta);
+  return {
+    a: sx * cos,
+    b: sx * sin,
+    c: -sy * sin,
+    d: sy * cos,
+    e: tx + anchor.x - anchor.x * sx * cos + anchor.y * sy * sin,
+    f: ty + anchor.y - anchor.x * sx * sin - anchor.y * sy * cos,
+  };
+}


### PR DESCRIPTION
## Summary
- add transform utilities for screen/local/canvas conversions and matrix composition
- handle edge and corner scaling with fixed anchors and rAF updates
- provide optional transform debug overlay

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b282df5f288327818ab78825a1ef81