### PR TITLE
feat: pre-upload image moderation

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,8 @@
 ALLOWED_ORIGINS=http://localhost:5173,https://mgm-api.vercel.app
 SUPABASE_URL=https://vxkewodclwozoennpqqv.supabase.co
 SUPABASE_SERVICE_ROLE=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ4a2V3b2RjbHdvem9lbm5wcXF2Iiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NDc4OTM0MywiZXhwIjoyMDcwMzY1MzQzfQ.d9G6-p1Q5tv6jvtTofVeOhd9E7pX-sC5gMCcDYfVjZk
+MOD_PROVIDER=sightengine
+SIGHTENGINE_USER=
+SIGHTENGINE_KEY=
+MOD_NUDITY_BLOCK=0.85
+MOD_SEXY_BLOCK=0.9

--- a/README.md
+++ b/README.md
@@ -53,6 +53,25 @@ La aplicación utiliza dos buckets de Supabase Storage:
 * `uploads`: privado, almacena los archivos originales subidos por el usuario.
 * `outputs`: público, recibe los archivos generados (`preview.jpg`, `print.jpg` y `file.pdf`) por `/api/finalize-assets`.
 
+## Moderación de imágenes
+
+El endpoint `POST /api/moderate-image` analiza una miniatura (máx. 512px, JPEG) antes de subirla a
+Supabase. Requiere enviar un `multipart/form-data` con el campo `image` y responde:
+
+```
+{ ok: true, diag_id: "...", allow: true|false, reasons: ["real_nudity","hate_symbol"], scores: { ... }, provider: "sightengine" }
+```
+
+Variables de entorno relacionadas:
+
+```
+MOD_PROVIDER=sightengine
+SIGHTENGINE_USER=usuario
+SIGHTENGINE_KEY=clave
+MOD_NUDITY_BLOCK=0.85
+MOD_SEXY_BLOCK=0.9
+```
+
 ## Admin search de jobs
 
 El endpoint `GET /api/admin/search-jobs` permite buscar trabajos por `job_id`,

--- a/api/moderate-image.js
+++ b/api/moderate-image.js
@@ -1,0 +1,101 @@
+// /api/moderate-image.js
+// Recibe una miniatura y valida contenido usando Sightengine
+import crypto from 'node:crypto';
+import { cors } from './_lib/cors.js';
+import { withObservability } from './_lib/observability.js';
+
+const MAX_BYTES = 2 * 1024 * 1024;
+const rate = new Map();
+
+function rateLimit(ip) {
+  const now = Date.now();
+  const entry = rate.get(ip) || { count: 0, ts: now };
+  if (now - entry.ts > 60_000) {
+    entry.count = 0;
+    entry.ts = now;
+  }
+  entry.count++;
+  rate.set(ip, entry);
+  return entry.count <= 10; // 10 req/min por IP
+}
+
+async function parseImage(req) {
+  const contentType = req.headers['content-type'] || '';
+  const boundaryMatch = contentType.match(/boundary=([^;]+)/i);
+  if (!boundaryMatch) throw new Error('missing_boundary');
+  const boundary = Buffer.from('--' + boundaryMatch[1]);
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of req) {
+    total += chunk.length;
+    if (total > MAX_BYTES) throw new Error('file_too_large');
+    chunks.push(chunk);
+  }
+  const buffer = Buffer.concat(chunks);
+  const start = buffer.indexOf(boundary);
+  if (start < 0) throw new Error('invalid_form');
+  let s = start + boundary.length + 2; // skip CRLF
+  const next = buffer.indexOf(boundary, s);
+  if (next < 0) throw new Error('invalid_form');
+  const part = buffer.slice(s, next - 2); // trim CRLF
+  const headerEnd = part.indexOf('\r\n\r\n');
+  const header = part.slice(0, headerEnd).toString();
+  if (!/name="image"/.test(header)) throw new Error('missing_image');
+  return part.slice(headerEnd + 4);
+}
+
+async function moderateWithSightengine(buf) {
+  const user = process.env.SIGHTENGINE_USER;
+  const key = process.env.SIGHTENGINE_KEY;
+  if (!user || !key) throw new Error('missing_credentials');
+  const url = new URL('https://api.sightengine.com/1.0/check.json');
+  url.searchParams.set('models', 'nudity-2.0,offensive');
+  url.searchParams.set('api_user', user);
+  url.searchParams.set('api_secret', key);
+  const form = new FormData();
+  form.append('media', new File([buf], 'image.jpg'));
+  const resp = await fetch(url, { method: 'POST', body: form });
+  const data = await resp.json();
+  const nudity = data.nudity || {};
+  const offensive = data.offensive || {};
+  const scores = { nudity, offensive };
+  const reasons = [];
+  const nudityBlock = Number(process.env.MOD_NUDITY_BLOCK || '0.85');
+  const sexyBlock = Number(process.env.MOD_SEXY_BLOCK || '0.9');
+  const adultScore = nudity.sexual_activity || nudity.sexual_display || nudity.explicit || 0;
+  const sexyScore = nudity.suggestive || nudity.soft || 0;
+  if (adultScore >= nudityBlock || sexyScore >= sexyBlock) reasons.push('real_nudity');
+  const hate = (offensive.classes || []).some(c => ['swastika','nazi','kkk','ss'].includes(c.class) && c.prob > 0.5);
+  if (hate) reasons.push('hate_symbol');
+  return { allow: reasons.length === 0, reasons, scores, provider: 'sightengine' };
+}
+
+async function handler(req, res) {
+  const diagId = crypto.randomUUID();
+  res.setHeader('X-Diag-Id', diagId);
+  if (cors(req, res)) return;
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ ok: false, diag_id: diagId, message: 'method_not_allowed' });
+  }
+  const ip = (req.headers['x-forwarded-for'] || '').split(',')[0] || req.socket.remoteAddress || 'unknown';
+  if (!rateLimit(ip)) {
+    return res.status(429).json({ ok: false, diag_id: diagId, allow: false, message: 'rate_limited' });
+  }
+  let image;
+  try {
+    image = await parseImage(req);
+  } catch (e) {
+    const msg = e.message === 'file_too_large' ? 'file_too_large' : 'invalid_form';
+    return res.status(400).json({ ok: false, diag_id: diagId, allow: false, message: msg });
+  }
+  try {
+    const result = await moderateWithSightengine(image);
+    return res.status(200).json({ ok: true, diag_id: diagId, ...result });
+  } catch (e) {
+    console.error('moderation_error', e);
+    return res.status(500).json({ ok: false, diag_id: diagId, allow: false, message: 'provider_error' });
+  }
+}
+
+export default withObservability(handler);

--- a/mgm-front/README.md
+++ b/mgm-front/README.md
@@ -10,6 +10,9 @@ Antes de iniciar el entorno de desarrollo crea un archivo `.env` con:
 VITE_API_BASE=URL_de_tu_API
 VITE_SUPABASE_URL=URL_de_tu_proyecto_Supabase
 VITE_SUPABASE_ANON_KEY=clave_anon_de_Supabase
+VITE_ENABLE_MODERATION=true
+VITE_MODERATION_DRYRUN=false
+VITE_SHOW_MOD_SCORES=false
 ```
 
 Luego ejecuta `npm run dev` para iniciar el frontend.

--- a/mgm-front/src/components/LoadingOverlay.jsx
+++ b/mgm-front/src/components/LoadingOverlay.jsx
@@ -17,7 +17,9 @@ export default function LoadingOverlay({ show, messages = [] }) {
   return (
     <div className={styles.overlay}>
       <div className={`spinner ${styles.spinnerSpacing}`} />
-      <p className={styles.message}>{messages[index] || 'Cargando…'}</p>
+      <p className={styles.message} aria-live="polite">
+        {messages[index] || 'Cargando…'}
+      </p>
     </div>
   );
 }

--- a/mgm-front/src/components/UploadStep.jsx
+++ b/mgm-front/src/components/UploadStep.jsx
@@ -2,46 +2,79 @@
 import { useRef, useState, useEffect } from 'react';
 import styles from './UploadStep.module.css';
 import LoadingOverlay from './LoadingOverlay';
-import { dlog } from '../lib/debug';
+
+const ENABLE_MOD = (import.meta.env.VITE_ENABLE_MODERATION ?? 'true') !== 'false';
+const SHOW_SCORES = import.meta.env.VITE_SHOW_MOD_SCORES === 'true';
+const API_BASE = (import.meta.env.VITE_API_BASE || 'https://mgm-api.vercel.app').replace(/\/$/, '');
 
 export default function UploadStep({ onUploaded }) {
   const inputRef = useRef(null);
   const onUploadedRef = useRef(onUploaded);
   useEffect(() => { onUploadedRef.current = onUploaded; }, [onUploaded]);
+
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
-  const [file, setFile] = useState(null);
-  const phrases = ['Mejorando últimos ajustes', 'Cargando el último pixel'];
+  const [diag, setDiag] = useState('');
+  const [scores, setScores] = useState(null);
+  const [state, setState] = useState('idle'); // idle|local_ok|server_checking|blocked|allowed
 
   const openPicker = () => {
     setErr('');
+    setDiag('');
+    setScores(null);
     inputRef.current?.click();
   };
 
-  function handlePicked(e) {
+  async function handlePicked(e) {
     const picked = e.target.files?.[0];
     if (!picked) return;
-    setBusy(true);
-    setErr('');
-    setFile(picked);
     if (inputRef.current) inputRef.current.value = '';
-  }
+    setErr('');
+    setDiag('');
+    setScores(null);
 
-  useEffect(() => {
-    if (!file) return;
-    const localUrl = URL.createObjectURL(file);
-    const uploaded = { file, localUrl };
-    dlog('[UploadStep] local-only', uploaded);
+    if (!ENABLE_MOD) {
+      const localUrl = URL.createObjectURL(picked);
+      onUploadedRef.current?.({ file: picked, localUrl });
+      setState('allowed');
+      return;
+    }
+
+    setBusy(true);
     try {
-      onUploadedRef.current?.(uploaded);
+      const local = await runLocalModeration(picked);
+      setScores(local.scores);
+      if (local.state === 'blocked') {
+        setState('blocked');
+        setErr('Contenido bloqueado por desnudez real.');
+        return;
+      }
+      if (local.state === 'allowed') {
+        const localUrl = URL.createObjectURL(picked);
+        onUploadedRef.current?.({ file: picked, localUrl });
+        setState('allowed');
+        return;
+      }
+      setState('server_checking');
+      const server = await runServerModeration(picked);
+      setScores(server.scores);
+      setDiag(server.diag_id || '');
+      if (!server.allow) {
+        setState('blocked');
+        setErr('Bloqueada por política: ' + (server.reasons || []).join(', '));
+        return;
+      }
+      const localUrl = URL.createObjectURL(picked);
+      onUploadedRef.current?.({ file: picked, localUrl });
+      setState('allowed');
     } catch (e) {
       console.error(e);
       setErr(String(e?.message || e));
+      setState('blocked');
     } finally {
       setBusy(false);
     }
-    return () => URL.revokeObjectURL(localUrl);
-  }, [file]);
+  }
 
   return (
     <div className={styles.container}>
@@ -53,12 +86,100 @@ export default function UploadStep({ onUploaded }) {
         onChange={handlePicked}
       />
       <button onClick={openPicker} disabled={busy}>
-        {busy ? 'Subiendo…' : 'Subir imagen'}
+        {busy ? 'Procesando…' : 'Subir imagen'}
       </button>
 
-      <LoadingOverlay show={busy} messages={phrases} />
+      <LoadingOverlay show={busy} messages={[ 'Analizando imagen…' ]} />
 
-      {err && <p className={`errorText ${styles.error}`}>{err}</p>}
+      {err && (
+        <p className={`errorText ${styles.error}`}>
+          {err} {diag && <code>diag:{diag}</code>}
+        </p>
+      )}
+
+      {SHOW_SCORES && scores && (
+        <details>
+          <summary>Más detalles</summary>
+          <pre>{JSON.stringify(scores, null, 2)}</pre>
+        </details>
+      )}
     </div>
   );
+}
+
+async function runLocalModeration(file) {
+  const thresholds = {
+    porn: Number(import.meta.env.VITE_NUDITY_BLOCK || '0.85'),
+    sexy: Number(import.meta.env.VITE_SEXY_BLOCK || '0.9'),
+    anime: Number(import.meta.env.VITE_ANIME_ALLOW || '0.7'),
+    pornForAnime: Number(import.meta.env.VITE_ANIME_PORN_MAX || '0.6'),
+  };
+  const tf = await import(/* @vite-ignore */ 'https://esm.sh/@tensorflow/tfjs');
+  await tf.ready?.();
+  const nsfw = await import(/* @vite-ignore */ 'https://esm.sh/nsfwjs');
+  const model = await nsfw.load();
+  const img = document.createElement('img');
+  const url = URL.createObjectURL(file);
+  try {
+    await new Promise((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = reject;
+      img.src = url;
+    });
+    const max = Math.max(img.width, img.height);
+    const scale = Math.min(1, 224 / max);
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.round(img.width * scale);
+    canvas.height = Math.round(img.height * scale);
+    canvas.getContext('2d').drawImage(img, 0, 0, canvas.width, canvas.height);
+    const preds = await model.classify(canvas);
+    const get = cls => preds.find(p => p.className === cls)?.probability || 0;
+    const scores = {
+      Porn: get('Porn'),
+      Sexy: get('Sexy'),
+      Hentai: get('Hentai'),
+      Drawing: get('Drawing'),
+    };
+    if (scores.Porn >= thresholds.porn || (scores.Sexy >= thresholds.sexy && (scores.Drawing + scores.Hentai) < 0.4)) {
+      return { state: 'blocked', scores };
+    }
+    if ((scores.Hentai >= thresholds.anime || scores.Drawing >= thresholds.anime) && scores.Porn < thresholds.pornForAnime) {
+      return { state: 'allowed', scores };
+    }
+    return { state: 'local_ok', scores };
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+async function runServerModeration(file) {
+  const thumb = await createThumbnail(file);
+  const form = new FormData();
+  form.append('image', thumb, 'thumb.jpg');
+  const res = await fetch(`${API_BASE}/api/moderate-image`, {
+    method: 'POST',
+    body: form,
+  });
+  const json = await res.json();
+  if (!res.ok) throw new Error(json?.message || 'moderation_failed');
+  return json;
+}
+
+async function createThumbnail(file) {
+  const img = document.createElement('img');
+  const url = URL.createObjectURL(file);
+  await new Promise((resolve, reject) => {
+    img.onload = () => resolve();
+    img.onerror = reject;
+    img.src = url;
+  });
+  const maxSide = Math.max(img.width, img.height);
+  const scale = Math.min(1, 512 / maxSide);
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.round(img.width * scale);
+  canvas.height = Math.round(img.height * scale);
+  canvas.getContext('2d').drawImage(img, 0, 0, canvas.width, canvas.height);
+  return await new Promise((resolve) => {
+    canvas.toBlob(b => { URL.revokeObjectURL(url); resolve(b); }, 'image/jpeg', 0.8);
+  });
 }

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -144,6 +144,12 @@ export default function Home() {
       setErr('');
       setBusy(true);
 
+      if (import.meta.env.VITE_MODERATION_DRYRUN === 'true') {
+        alert('Modo prueba: no se sube a Supabase');
+        setBusy(false);
+        return;
+      }
+
       // 1) calcular hash local
       const file_hash = await sha256Hex(uploaded.file);
 


### PR DESCRIPTION
## Summary
- add NSFWJS screening and server moderation to upload step
- expose dry-run and moderation flags in frontend
- add /api/moderate-image endpoint using Sightengine

## Testing
- `npm --prefix mgm-front run lint` *(fails: Cannot find package '@eslint/js')*
- `node --check api/moderate-image.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3072aebb883279a2b5d10b63c431f