### PR TITLE
refactor: consolidate API into single serverless entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # MGM API
 
+## Arquitectura de API unificada
+
+Todas las rutas bajo `/api` se resuelven por una única Serverless Function definida en `api/index.js`. Un mini-router interno despacha según `req.method` y `pathname` hacia los handlers en `api/_routes`.
+
+Para agregar una nueva ruta:
+1. Crear el handler en `api/_routes` (puede usar subcarpetas como `admin` o `user`).
+2. Exportar una función `default` con la lógica de la ruta.
+3. Registrar la ruta en `api/index.js` dentro del objeto `routes` usando `import()` dinámico.
+
+No crear archivos sueltos dentro de `api/` fuera de `_routes` o `_lib`, ya que cada archivo generaría una función adicional en Vercel.
+
+
 ## Configuración de CORS
 
 Establece la variable de entorno `ALLOWED_ORIGINS` como una lista separada por comas de orígenes sin barra final.

--- a/api/_routes/admin/search-jobs.js
+++ b/api/_routes/admin/search-jobs.js
@@ -1,13 +1,11 @@
 import crypto from 'node:crypto';
-import { supa } from '../../lib/supa.js';
-import { cors } from '../_lib/cors.js';
-import { parseSupabasePath } from '../../lib/storage.js';
+import { supa } from '../../../lib/supa.js';
+import { parseSupabasePath } from '../../../lib/storage.js';
 
 export default async function handler(req, res) {
   const diagId = crypto.randomUUID?.() ?? require('node:crypto').randomUUID();
   res.setHeader('X-Diag-Id', String(diagId));
 
-  if (cors(req, res)) return;
 
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');

--- a/api/_routes/cors-diagnose.js
+++ b/api/_routes/cors-diagnose.js
@@ -1,4 +1,4 @@
-import { cors } from './_lib/cors.js';
+import { cors } from '../_lib/cors.js';
 
 export default function handler(req, res) {
   const ended = cors(req, res);

--- a/api/_routes/create-cart-link.js
+++ b/api/_routes/create-cart-link.js
@@ -1,10 +1,9 @@
 // /api/create-cart-link.js
 // Endpoint idempotente para crear/reutilizar producto y variante en Shopify.
 import crypto from 'node:crypto';
-import { supa } from '../lib/supa.js';
-import { shopifyAdmin, shopifyAdminGraphQL } from '../lib/shopify.js';
-import { cors } from './_lib/cors.js';
-import { withObservability } from './_lib/observability.js';
+import { supa } from '../../lib/supa.js';
+import { shopifyAdmin, shopifyAdminGraphQL } from '../../lib/shopify.js';
+import { withObservability } from '../_lib/observability.js';
 
 function slugify(s){ return String(s).toLowerCase().trim()
   .replace(/\s+/g,'-').replace(/[^a-z0-9-]/g,'').replace(/-+/g,'-').replace(/^-|-$/g,''); }
@@ -21,7 +20,6 @@ async function handler(req, res) {
   const diagId = crypto.randomUUID?.() ?? require('node:crypto').randomUUID();
   res.setHeader('X-Diag-Id', String(diagId));
 
-  if (cors(req, res)) return;
 
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');

--- a/api/_routes/create-checkout.js
+++ b/api/_routes/create-checkout.js
@@ -1,8 +1,7 @@
 // /api/create-checkout.js
 import crypto from 'node:crypto';
-import { supa } from '../lib/supa.js';
-import { shopifyAdmin } from '../lib/shopify.js';
-import { cors } from './_lib/cors.js';
+import { supa } from '../../lib/supa.js';
+import { shopifyAdmin } from '../../lib/shopify.js';
 
 async function getInvoiceUrl(draftId) {
   // lee el draft y devuelve invoice_url si existe
@@ -14,7 +13,6 @@ export default async function handler(req, res) {
   const diagId = crypto.randomUUID?.() ?? require('node:crypto').randomUUID();
   res.setHeader('X-Diag-Id', String(diagId));
 
-  if (cors(req, res)) return;
 
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');

--- a/api/_routes/env-check.js
+++ b/api/_routes/env-check.js
@@ -1,12 +1,10 @@
 import crypto from 'node:crypto';
-import { getEnv, mask } from './_lib/env.js';
-import { cors } from './_lib/cors.js';
+import { getEnv, mask } from '../_lib/env.js';
 
 export default async function handler(req, res) {
   const diagId = crypto.randomUUID?.() ?? require('node:crypto').randomUUID();
   res.setHeader('X-Diag-Id', String(diagId));
 
-  if (cors(req, res)) return;
 
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');

--- a/api/_routes/finalize-assets.js
+++ b/api/_routes/finalize-assets.js
@@ -1,9 +1,8 @@
 // api/finalize-assets.js
-import { cors } from './_lib/cors.js';
-import getSupabaseAdmin from './_lib/supabaseAdmin.js';
+import getSupabaseAdmin from '../_lib/supabaseAdmin.js';
 import sharp from 'sharp';
 import { PDFDocument } from 'pdf-lib';
-import composeImage from './_lib/composeImage.ts';
+import composeImage from '../_lib/composeImage.ts';
 import crypto from 'node:crypto';
 
 function parseUploadsObjectKey(url = '') {
@@ -37,7 +36,6 @@ function isPosFinite(n) {
 }
 
 export default async function handler(req, res) {
-  if (cors(req, res)) return;
   const diagId = crypto.randomUUID?.() ?? crypto.randomUUID();
   res.setHeader('X-Diag-Id', String(diagId));
   if (req.method !== 'POST') {
@@ -51,6 +49,8 @@ export default async function handler(req, res) {
 
   let stage = 'validate';
   let debug = {};
+
+  try {
 
   let body;
   try {

--- a/api/_routes/job-status.js
+++ b/api/_routes/job-status.js
@@ -1,9 +1,7 @@
 // api/job-status.js
-import { cors } from './_lib/cors.js';
-import getSupabaseAdmin from './_lib/supabaseAdmin.js';
+import getSupabaseAdmin from '../_lib/supabaseAdmin.js';
 
 export default async function handler(req, res) {
-  if (cors(req, res)) return;
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');
     return res.status(405).json({ ok:false, error: 'method_not_allowed' });

--- a/api/_routes/job-summary.js
+++ b/api/_routes/job-summary.js
@@ -1,12 +1,10 @@
 import crypto from 'node:crypto';
-import { supa } from '../lib/supa.js';
-import { cors } from './_lib/cors.js';
+import { supa } from '../../lib/supa.js';
 
 export default async function handler(req, res) {
   const diagId = crypto.randomUUID?.() ?? require('node:crypto').randomUUID();
   res.setHeader('X-Diag-Id', String(diagId));
 
-  if (cors(req, res)) return;
 
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');

--- a/api/_routes/publish-product.js
+++ b/api/_routes/publish-product.js
@@ -1,13 +1,11 @@
 import crypto from 'node:crypto';
-import { supa } from '../lib/supa.js';
-import { shopifyAdmin } from '../lib/shopify.js';
-import { cors } from './_lib/cors.js';
+import { supa } from '../../lib/supa.js';
+import { shopifyAdmin } from '../../lib/shopify.js';
 
 export default async function handler(req, res) {
   const diagId = crypto.randomUUID?.() ?? require('node:crypto').randomUUID();
   res.setHeader('X-Diag-Id', String(diagId));
 
-  if (cors(req, res)) return;
 
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');

--- a/api/_routes/render-dryrun.js
+++ b/api/_routes/render-dryrun.js
@@ -1,7 +1,6 @@
 import crypto from 'node:crypto';
-import { cors } from './_lib/cors.js';
-import getSupabaseAdmin from './_lib/supabaseAdmin.js';
-import composeImage from './_lib/composeImage.ts';
+import getSupabaseAdmin from '../_lib/supabaseAdmin.js';
+import composeImage from '../_lib/composeImage.ts';
 
 function err(res, status, { diag_id, stage, message, debug = {} }) {
   return res.status(status).json({ ok: false, diag_id, stage, message, debug });
@@ -15,7 +14,6 @@ function parseUploadsObjectKey(url = '') {
 export default async function handler(req, res) {
   const diagId = crypto.randomUUID?.() ?? crypto.randomUUID();
   res.setHeader('X-Diag-Id', String(diagId));
-  if (cors(req, res)) return;
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
     return err(res, 405, { diag_id: diagId, stage: 'method', message: 'method_not_allowed' });

--- a/api/_routes/search-assets.js
+++ b/api/_routes/search-assets.js
@@ -1,12 +1,10 @@
 import crypto from 'node:crypto';
-import { supa } from '../lib/supa.js';
-import { cors } from './_lib/cors.js';
+import { supa } from '../../lib/supa.js';
 
 export default async function handler(req, res) {
   const diagId = crypto.randomUUID?.() ?? require('node:crypto').randomUUID();
   res.setHeader('X-Diag-Id', String(diagId));
 
-  if (cors(req, res)) return;
 
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');

--- a/api/_routes/submit-job.js
+++ b/api/_routes/submit-job.js
@@ -1,16 +1,14 @@
 // api/submit-job.js
 import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
-import { cors } from './_lib/cors.js';
-import getSupabaseAdmin from './_lib/supabaseAdmin.js';
-import { getEnv } from './_lib/env.js';
-import { withObservability } from './_lib/observability.js';
+import getSupabaseAdmin from '../_lib/supabaseAdmin.js';
+import { getEnv } from '../_lib/env.js';
+import { withObservability } from '../_lib/observability.js';
 
 async function handler(req, res) {
   const diagId = randomUUID();
   res.setHeader('X-Diag-Id', diagId);
 
-  if (cors(req, res)) return;
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
     return res

--- a/api/_routes/upload-url.js
+++ b/api/_routes/upload-url.js
@@ -2,10 +2,9 @@
 // Requiere: "type": "module" en package.json
 import crypto from 'node:crypto';
 import { z } from 'zod';
-import { supa } from '../lib/supa.js';
-import { cors } from './_lib/cors.js';
-import { buildObjectKey } from './_lib/slug.js';
-import { withObservability } from './_lib/observability.js';
+import { supa } from '../../lib/supa.js';
+import { buildObjectKey } from '../_lib/slug.js';
+import { withObservability } from '../_lib/observability.js';
 
 const BodySchema = z.object({
   design_name: z.string().min(1),
@@ -26,7 +25,6 @@ async function handler(req, res) {
   res.setHeader('X-Diag-Id', String(diagId));
 
   // CORS + preflight
-  if (cors(req, res)) return;
 
   // Solo POST
   if (req.method !== 'POST') {

--- a/api/_routes/user/jobs.js
+++ b/api/_routes/user/jobs.js
@@ -1,13 +1,11 @@
 import { randomUUID } from 'node:crypto';
-import { cors } from '../_lib/cors.js';
-import { withObservability } from '../_lib/observability.js';
-import getSupabaseAdmin from '../_lib/supabaseAdmin.js';
-import { verifyUserToken } from '../_lib/userToken.js';
+import { withObservability } from '../../_lib/observability.js';
+import getSupabaseAdmin from '../../_lib/supabaseAdmin.js';
+import { verifyUserToken } from '../../_lib/userToken.js';
 
 async function handler(req, res) {
   const diagId = randomUUID();
   res.setHeader('X-Diag-Id', diagId);
-  if (cors(req, res)) return;
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');
     return res.status(405).json({ ok: false, diag_id: diagId, message: 'method_not_allowed' });

--- a/api/_routes/user/login-link.js
+++ b/api/_routes/user/login-link.js
@@ -1,12 +1,10 @@
 import { randomUUID } from 'node:crypto';
-import { cors } from '../_lib/cors.js';
-import { withObservability } from '../_lib/observability.js';
-import { createUserToken } from '../_lib/userToken.js';
+import { withObservability } from '../../_lib/observability.js';
+import { createUserToken } from '../../_lib/userToken.js';
 
 async function handler(req, res) {
   const diagId = randomUUID();
   res.setHeader('X-Diag-Id', diagId);
-  if (cors(req, res)) return;
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
     return res.status(405).json({ ok: false, diag_id: diagId, message: 'method_not_allowed' });

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,39 @@
+import { randomUUID } from "node:crypto";
+import { cors } from './_lib/cors.js';
+import { withObservability } from './_lib/observability.js';
+
+const routes = {
+  'post /api/upload-url': () => import('./_routes/upload-url.js'),
+  'post /api/submit-job': () => import('./_routes/submit-job.js'),
+  'post /api/finalize-assets': () => import('./_routes/finalize-assets.js'),
+  'post /api/create-cart-link': () => import('./_routes/create-cart-link.js'),
+  'post /api/create-checkout': () => import('./_routes/create-checkout.js'),
+  'post /api/publish-product': () => import('./_routes/publish-product.js'),
+  'post /api/render-dryrun': () => import('./_routes/render-dryrun.js'),
+  'get /api/job-status': () => import('./_routes/job-status.js'),
+  'get /api/job-summary': () => import('./_routes/job-summary.js'),
+  'get /api/search-assets': () => import('./_routes/search-assets.js'),
+  'get /api/env-check': () => import('./_routes/env-check.js'),
+  'get /api/cors-diagnose': () => import('./_routes/cors-diagnose.js'),
+  'get /api/admin/search-jobs': () => import('./_routes/admin/search-jobs.js'),
+  'get /api/user/jobs': () => import('./_routes/user/jobs.js'),
+  'post /api/user/login-link': () => import('./_routes/user/login-link.js'),
+};
+
+export default withObservability(async function handler(req, res) {
+  const diagId = randomUUID();
+  res.setHeader("X-Diag-Id", diagId);
+  if (cors(req, res)) return;
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  let pathname = url.pathname.replace(/\/$/, '');
+  const method = (req.method || 'GET').toLowerCase();
+  const key = `${method} ${pathname.toLowerCase()}`;
+
+  const loader = routes[key];
+  if (loader) {
+    const mod = await loader();
+    return mod.default(req, res);
+  }
+  res.status(404).json({ ok: false, message: 'not_found' });
+});


### PR DESCRIPTION
## Summary
- refactor multiple API routes into single catch-all `api/index.js`
- move existing route handlers to `api/_routes` and dispatch via internal mini-router
- document unified API architecture in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b30b237e88832795e18a7b38d8585a