### PR TITLE
feat: add upload-url endpoint with improved CORS and fallback

### DIFF
--- a/api/_lib/cors.js
+++ b/api/_lib/cors.js
@@ -15,14 +15,18 @@ export function cors(req, res) {
   res.setHeader('X-Frame-Options', 'DENY');
   res.setHeader('X-Content-Type-Options', 'nosniff');
 
-  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
   res.setHeader(
     'Access-Control-Allow-Headers',
-    'Content-Type, Idempotency-Key, Authorization'
+    'Content-Type, Idempotency-Key, Authorization, apikey, x-client-info'
   );
   res.setHeader('Access-Control-Expose-Headers', 'X-Diag-Id');
 
-  if (origin && allowed.includes(origin)) {
+  if (allowed.length === 0) {
+    if (process.env.NODE_ENV !== 'production') {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+    }
+  } else if (origin && allowed.includes(origin)) {
     res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader('Vary', 'Origin');
   }

--- a/api/upload-url.js
+++ b/api/upload-url.js
@@ -1,0 +1,63 @@
+import { randomUUID } from 'node:crypto';
+import { cors } from './_lib/cors.js';
+import getSupabaseAdmin from './_lib/supabaseAdmin.js';
+
+export default async function handler(req, res) {
+  const diagId = randomUUID();
+  res.setHeader('X-Diag-Id', diagId);
+
+  if (cors(req, res)) return;
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST, OPTIONS');
+    return res
+      .status(405)
+      .json({ ok: false, diag_id: diagId, error: 'method_not_allowed' });
+  }
+
+  let body = req.body;
+  if (!body || typeof body !== 'object') {
+    try {
+      body = JSON.parse(body || '{}');
+    } catch {
+      body = {};
+    }
+  }
+
+  const objectKey = body.object_key;
+  const contentType = body.contentType;
+
+  if (!objectKey || !contentType) {
+    return res
+      .status(400)
+      .json({ ok: false, diag_id: diagId, error: 'invalid_body' });
+  }
+
+  try {
+    const supabase = getSupabaseAdmin();
+    const { data, error } = await supabase
+      .storage
+      .from('uploads')
+      .createSignedUploadUrl(objectKey, 60);
+
+    if (error) {
+      console.error('upload-url sign', { diagId, error: error.message });
+      return res
+        .status(500)
+        .json({ ok: false, diag_id: diagId, error: 'sign_upload_failed' });
+    }
+
+    return res.status(200).json({
+      ok: true,
+      signed_url: data.signedUrl,
+      token: data.token,
+      expires_in: 60,
+      object_key: objectKey,
+    });
+  } catch (e) {
+    console.error('upload-url unknown', { diagId, error: e?.message || e });
+    return res
+      .status(500)
+      .json({ ok: false, diag_id: diagId, error: 'internal_error' });
+  }
+}


### PR DESCRIPTION
## Summary
- add `POST /api/upload-url` serverless function with Supabase signing
- expand CORS helper to reflect origins and handle OPTIONS preflight
- fallback on the front-end when upload-url fails and adapt to new API shape

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd mgm-front && npm test` *(fails: Missing script: "test")*
- `cd mgm-front && npm run lint` *(fails: Cannot find package '@eslint/js')*
- `curl -i -X OPTIONS 'https://mgm-api.vercel.app/api/upload-url' -H 'Origin: http://localhost:5173' -H 'Access-Control-Request-Method: POST' -H 'Access-Control-Request-Headers: content-type,idempotency-key'` *(fails: CONNECT tunnel failed, response 403)*
- `curl -i -X POST 'https://mgm-api.vercel.app/api/upload-url' -H 'Origin: http://localhost:5173' -H 'Content-Type: application/json' -d '{"object_key":"original/2025/08/job_20250824_demo/abc123.png","contentType":"image/png"}'` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b3153db6608327aa878ce4cc126b80