### PR TITLE
feat: add two-phase image moderation

### DIFF
--- a/api/moderate.js
+++ b/api/moderate.js
@@ -1,0 +1,89 @@
+// /api/moderate.js
+// Quick moderation endpoint with timeout and no manual review
+import crypto from 'node:crypto';
+import { cors } from './_lib/cors.js';
+import { withObservability } from './_lib/observability.js';
+import { scanImage } from './_lib/moderation/adapter.ts';
+
+const MAX_BYTES = 2 * 1024 * 1024;
+const MAX_MS = Number(process.env.MOD_MAX_MS || '1000');
+const BLOCK_REAL_NUDITY = Number(process.env.MOD_BLOCK_REAL_NUDITY || '0.8');
+const BLOCK_HATE_SYMBOL = Number(process.env.MOD_BLOCK_HATE_SYMBOL || '0.7');
+
+async function parseImage(req) {
+  const contentType = req.headers['content-type'] || '';
+  const boundaryMatch = contentType.match(/boundary=([^;]+)/i);
+  if (!boundaryMatch) throw new Error('missing_boundary');
+  const boundary = Buffer.from('--' + boundaryMatch[1]);
+  const chunks = [];
+  let total = 0;
+  for await (const chunk of req) {
+    total += chunk.length;
+    if (total > MAX_BYTES) throw new Error('file_too_large');
+    chunks.push(chunk);
+  }
+  const buffer = Buffer.concat(chunks);
+  const start = buffer.indexOf(boundary);
+  if (start < 0) throw new Error('invalid_form');
+  let s = start + boundary.length + 2; // skip CRLF
+  const next = buffer.indexOf(boundary, s);
+  if (next < 0) throw new Error('invalid_form');
+  const part = buffer.slice(s, next - 2); // trim CRLF
+  const headerEnd = part.indexOf('\r\n\r\n');
+  const header = part.slice(0, headerEnd).toString();
+  if (!/name="image"/.test(header)) throw new Error('missing_image');
+  return part.slice(headerEnd + 4);
+}
+
+async function handler(req, res) {
+  const diagId = crypto.randomUUID();
+  res.setHeader('X-Diag-Id', diagId);
+  if (cors(req, res)) return;
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ allow: false, reason: 'method_not_allowed', diag_id: diagId });
+  }
+  let image;
+  try {
+    image = await parseImage(req);
+  } catch (e) {
+    const msg = e.message === 'file_too_large' ? 'file_too_large' : 'invalid_form';
+    return res.status(400).json({ allow: false, reason: msg, diag_id: diagId });
+  }
+
+  let scan;
+  try {
+    scan = await Promise.race([
+      scanImage(image),
+      new Promise((resolve) => setTimeout(() => resolve({ timeout: true }), MAX_MS)),
+    ]);
+  } catch {
+    scan = { error: true };
+  }
+
+  if (scan?.timeout || scan?.error || scan?.labels?.includes('provider_error')) {
+    return res.status(200).json({ allow: true, reason: 'indeterminate', diag_id: diagId });
+  }
+
+  const scores = scan.scores || {};
+  const labels = scan.labels || [];
+  const isHentai = labels.includes('hentai') || labels.includes('drawing');
+
+  if (isHentai) {
+    return res.status(200).json({ allow: true, scores, diag_id: diagId });
+  }
+
+  const nudity = Math.max(scores.nudity_adult || 0, scores.sexual_explicit || 0);
+  if (nudity >= BLOCK_REAL_NUDITY) {
+    return res.status(200).json({ allow: false, reason: 'real_person_nudity', scores, diag_id: diagId });
+  }
+
+  const hate = Math.max(scores.hate_symbol || 0, scores.extremist_content || 0);
+  if (hate >= BLOCK_HATE_SYMBOL) {
+    return res.status(200).json({ allow: false, reason: 'hate_symbol', scores, diag_id: diagId });
+  }
+
+  return res.status(200).json({ allow: true, scores, diag_id: diagId });
+}
+
+export default withObservability(handler);

--- a/mgm-front/src/components/UploadStep.jsx
+++ b/mgm-front/src/components/UploadStep.jsx
@@ -2,10 +2,7 @@
 import { useRef, useState, useEffect } from 'react';
 import styles from './UploadStep.module.css';
 import LoadingOverlay from './LoadingOverlay';
-
-const ENABLE_MOD = (import.meta.env.VITE_ENABLE_MODERATION ?? 'true') !== 'false';
-const SHOW_SCORES = import.meta.env.VITE_SHOW_MOD_SCORES === 'true';
-const API_BASE = (import.meta.env.VITE_API_BASE || 'https://mgm-api.vercel.app').replace(/\/$/, '');
+import { quickPass, deepPass, MODERATION } from '../lib/moderation';
 
 export default function UploadStep({ onUploaded }) {
   const inputRef = useRef(null);
@@ -14,57 +11,49 @@ export default function UploadStep({ onUploaded }) {
 
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
-  const [diag, setDiag] = useState('');
-  const [scores, setScores] = useState(null);
-  const [state, setState] = useState('idle'); // idle|server_checking|blocked|allowed|warn
+  const [moderationState, setModerationState] = useState(null); // null|quick|deep
 
   const openPicker = () => {
     setErr('');
-    setDiag('');
-    setScores(null);
     inputRef.current?.click();
   };
 
   async function handlePicked(e) {
-    const picked = e.target.files?.[0];
-    if (!picked) return;
+    const file = e.target.files?.[0];
+    if (!file) return;
     if (inputRef.current) inputRef.current.value = '';
     setErr('');
-    setDiag('');
-    setScores(null);
-
-    if (!ENABLE_MOD) {
-      const localUrl = URL.createObjectURL(picked);
-      onUploadedRef.current?.({ file: picked, localUrl });
-      setState('allowed');
-      return;
-    }
-
     setBusy(true);
+    let allow = false;
     try {
-      const local = await runLocalModeration(picked);
-      setScores(local.scores);
-      setState('server_checking');
-      const server = await runServerModeration(picked);
-      setScores(server.scores);
-      setDiag(server.diag_id || '');
-      if (server.action === 'block' || !server.allow) {
-        setState('blocked');
-        setErr('Bloqueada por política: ' + server.reason);
-        return;
+      setModerationState('quick');
+      const q = await quickPass(file, { filename: file.name });
+      if (!q.escalate) {
+        allow = true;
+      } else {
+        setModerationState('deep');
+        const ac = new AbortController();
+        const t = setTimeout(() => ac.abort('timeout'), MODERATION.deep.maxMs);
+        try {
+          const r = await deepPass(file, ac.signal);
+          allow = !!r.allow;
+          if (!r.allow) setErr('Bloqueada por política: ' + (r.reason || 'Contenido no permitido'));
+        } catch {
+          allow = true; // prefer allow on failure
+        } finally {
+          clearTimeout(t);
+        }
       }
-      if (server.reason === 'provider_error') {
-        alert('No se pudo verificar, continuamos y revisamos manualmente');
-      }
-      const localUrl = URL.createObjectURL(picked);
-      onUploadedRef.current?.({ file: picked, localUrl });
-      setState(server.action === 'warn' || local.state === 'warn' ? 'warn' : 'allowed');
     } catch (e) {
       console.error(e);
       setErr(String(e?.message || e));
-      setState('blocked');
     } finally {
       setBusy(false);
+      setModerationState(null);
+    }
+    if (allow) {
+      const localUrl = URL.createObjectURL(file);
+      onUploadedRef.current?.({ file, localUrl });
     }
   }
 
@@ -73,7 +62,7 @@ export default function UploadStep({ onUploaded }) {
       <input
         ref={inputRef}
         type="file"
-        accept="image/png, image/jpeg"
+        accept="image/png, image/jpeg, image/webp"
         className={styles.hiddenInput}
         onChange={handlePicked}
       />
@@ -81,98 +70,13 @@ export default function UploadStep({ onUploaded }) {
         {busy ? 'Procesando…' : 'Subir imagen'}
       </button>
 
-      <LoadingOverlay show={busy} messages={[ 'Analizando imagen…' ]} />
+      <LoadingOverlay show={moderationState === 'deep'} messages={[ 'Chequeo adicional…' ]} />
 
       {err && (
         <p className={`errorText ${styles.error}`}>
-          {err} {diag && <code>diag:{diag}</code>}
+          {err}
         </p>
-      )}
-
-      {state === 'warn' && !err && (
-        <p className={styles.warn}>Revisión manual</p>
-      )}
-
-      {SHOW_SCORES && scores && (
-        <details>
-          <summary>Más detalles</summary>
-          <pre>{JSON.stringify(scores, null, 2)}</pre>
-        </details>
       )}
     </div>
   );
-}
-
-async function runLocalModeration(file) {
-  if (!window.__nsfwModel) {
-    const tf = await import(/* @vite-ignore */ 'https://esm.sh/@tensorflow/tfjs');
-    await tf.ready?.();
-    const nsfw = await import(/* @vite-ignore */ 'https://esm.sh/nsfwjs');
-    window.__nsfwModel = await nsfw.load();
-  }
-  const model = window.__nsfwModel;
-  const img = document.createElement('img');
-  const url = URL.createObjectURL(file);
-  try {
-    await new Promise((resolve, reject) => {
-      img.onload = () => resolve();
-      img.onerror = reject;
-      img.src = url;
-    });
-    const max = Math.max(img.width, img.height);
-    const scale = Math.min(1, 224 / max);
-    const canvas = document.createElement('canvas');
-    canvas.width = Math.round(img.width * scale);
-    canvas.height = Math.round(img.height * scale);
-    canvas.getContext('2d').drawImage(img, 0, 0, canvas.width, canvas.height);
-    const preds = await model.classify(canvas);
-    const get = cls => preds.find(p => p.className === cls)?.probability || 0;
-    const scores = {
-      Porn: get('Porn'),
-      Sexy: get('Sexy'),
-      Hentai: get('Hentai'),
-      Drawing: get('Drawing'),
-    };
-    if (scores.Porn >= 0.5) return { state: 'warn', scores };
-    return { state: 'allow', scores };
-  } finally {
-    URL.revokeObjectURL(url);
-  }
-}
-
-async function runServerModeration(file) {
-  try {
-    const thumb = await createThumbnail(file);
-    const form = new FormData();
-    form.append('image', thumb, 'thumb.jpg');
-    const res = await fetch(`${API_BASE}/api/moderate-image`, {
-      method: 'POST',
-      body: form,
-    });
-    const json = await res.json().catch(() => ({}));
-    if (!res.ok) throw new Error(json?.message || 'moderation_failed');
-    return json;
-  } catch (e) {
-    console.error('runServerModeration', e);
-    return { allow: true, action: 'warn', reason: 'provider_error', scores: {}, diag_id: '' };
-  }
-}
-
-async function createThumbnail(file) {
-  const img = document.createElement('img');
-  const url = URL.createObjectURL(file);
-  await new Promise((resolve, reject) => {
-    img.onload = () => resolve();
-    img.onerror = reject;
-    img.src = url;
-  });
-  const maxSide = Math.max(img.width, img.height);
-  const scale = Math.min(1, 512 / maxSide);
-  const canvas = document.createElement('canvas');
-  canvas.width = Math.round(img.width * scale);
-  canvas.height = Math.round(img.height * scale);
-  canvas.getContext('2d').drawImage(img, 0, 0, canvas.width, canvas.height);
-  return await new Promise((resolve) => {
-    canvas.toBlob(b => { URL.revokeObjectURL(url); resolve(b); }, 'image/jpeg', 0.8);
-  });
 }

--- a/mgm-front/src/lib/moderation/config.ts
+++ b/mgm-front/src/lib/moderation/config.ts
@@ -1,0 +1,21 @@
+export const MODERATION = {
+  quick: {
+    enable: true,
+    maxMs: 120,
+    minSizePx: 128,
+    allowFranchises: [/roblox/i, /mario/i, /pokemon/i, /marvel/i, /dc/i],
+  },
+  deep: {
+    enable: true,
+    maxMs: 1500,
+    escalateIfRisk: 0.35,
+    blockIfRealNudity: 0.8,
+    blockIfHateSymbol: 0.7,
+  },
+  policy: {
+    allowAnimeNudity: true,
+    blockRealPersonNudity: true,
+    blockHateSymbols: true,
+  },
+  debug: false,
+};

--- a/mgm-front/src/lib/moderation/index.ts
+++ b/mgm-front/src/lib/moderation/index.ts
@@ -1,0 +1,93 @@
+import { MODERATION } from './config';
+
+const API_BASE = (import.meta.env.VITE_API_BASE || '').replace(/\/$/, '');
+
+export async function quickPass(file: File, meta: { filename?: string } = {}): Promise<{ escalate: boolean; reason?: string; signals?: any }> {
+  const { quick, deep, debug } = MODERATION;
+  if (!quick.enable) return { escalate: false };
+  const start = performance.now();
+  let url = '';
+  try {
+    if (!['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
+      return { escalate: true, reason: 'unsupported_type' };
+    }
+    url = URL.createObjectURL(file);
+    const img = document.createElement('img');
+    await new Promise((resolve, reject) => {
+      img.onload = () => resolve(null);
+      img.onerror = reject;
+      img.src = url;
+    });
+    const maxSide = Math.max(img.width, img.height);
+    if (maxSide < quick.minSizePx) return { escalate: false, signals: { risk: 0 } };
+    const name = meta.filename || '';
+    for (const re of quick.allowFranchises) {
+      if (re.test(name)) return { escalate: false, signals: { risk: 0 } };
+    }
+    let risk = 0;
+    if (/nude|sex|xxx|porn|swastika|nazi|hitler/i.test(name)) risk = 0.9;
+    const canvas = document.createElement('canvas');
+    canvas.width = 32;
+    canvas.height = 32;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(img, 0, 0, 32, 32);
+    const { data } = ctx.getImageData(0, 0, 32, 32);
+    const colors = new Set<number>();
+    for (let i = 0; i < data.length; i += 4) {
+      colors.add((data[i] << 16) | (data[i + 1] << 8) | data[i + 2]);
+    }
+    const isDrawing = colors.size < 1000;
+    if (!isDrawing) risk = Math.max(risk, 0.5);
+    const escalate = risk >= deep.escalateIfRisk;
+    if (debug) console.log('[quickPass]', { risk, escalate, isDrawing, name, elapsed: performance.now() - start });
+    return { escalate, signals: { risk, isDrawing } };
+  } catch (e) {
+    if (debug) console.log('[quickPass] error', e);
+    return { escalate: true, reason: 'quick_error' };
+  } finally {
+    if (url) URL.revokeObjectURL(url);
+  }
+}
+
+export async function deepPass(file: File, signal: AbortSignal): Promise<{ allow: boolean; reason?: string; scores?: any }> {
+  const { deep, debug } = MODERATION;
+  if (!deep.enable) return { allow: true };
+  try {
+    const thumb = await createThumbnail(file);
+    const form = new FormData();
+    form.append('image', thumb, 'thumb.jpg');
+    const res = await fetch(`${API_BASE}/api/moderate`, { method: 'POST', body: form, signal });
+    const json = await res.json().catch(() => ({}));
+    if (debug) console.log('[deepPass]', json);
+    if (!res.ok) return { allow: true, reason: 'provider_error' };
+    if (typeof json.allow === 'boolean') return json;
+    return { allow: true, reason: 'indeterminate' };
+  } catch (e) {
+    if (debug) console.log('[deepPass] error', e);
+    return { allow: true, reason: 'error' };
+  }
+}
+
+async function createThumbnail(file: File): Promise<Blob> {
+  const img = document.createElement('img');
+  const url = URL.createObjectURL(file);
+  await new Promise((resolve, reject) => {
+    img.onload = () => resolve(null);
+    img.onerror = reject;
+    img.src = url;
+  });
+  const maxSide = Math.max(img.width, img.height);
+  const scale = Math.min(1, 512 / maxSide);
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.round(img.width * scale);
+  canvas.height = Math.round(img.height * scale);
+  canvas.getContext('2d').drawImage(img, 0, 0, canvas.width, canvas.height);
+  return await new Promise((resolve) => {
+    canvas.toBlob((b) => {
+      URL.revokeObjectURL(url);
+      resolve(b as Blob);
+    }, 'image/jpeg', 0.8);
+  });
+}
+
+export { MODERATION };


### PR DESCRIPTION
## Summary
- add central moderation config
- implement quick and deep moderation passes
- refactor upload flow and add API endpoint for policy-based blocking

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b332057a5483279d1aa207affcf88b