### PR TITLE
feat: default scale clamped by DPI

### DIFF
--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -145,6 +145,12 @@
   gap: 6px;
 }
 
+.notice {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #6b7280;
+}
+
 .qualityBadge {
   padding: 6px 10px;
   border-radius: 999px;


### PR DESCRIPTION
## Summary
- add optional "Escalar libre" toggle for manual scaling
- clamp image scaling based on DPI when free scaling is off
- surface inline notices when limits are applied

## Testing
- `npm test` (fails: Missing script: "test")
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@sentry%2freact)
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b3b859a1c48327aff409b6a54c1def