### PR TITLE
fix: avoid canvas overlay intercepting clicks

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -1355,10 +1355,10 @@ async function onConfirmSubmit() {
                     ctx.arcTo(0, 0, rr, 0, rr);
                     ctx.closePath();
                   }}
-                ><Rect x={0} y={0} width={workCm.w} height={workCm.h} fill="transparent" />
+                ><Rect x={0} y={0} width={workCm.w} height={workCm.h} fill="transparent" listening={false} />
   {/* si estás en 'contain', pintar el color debajo del arte */}
   {mode === 'contain' && (
-    <Rect x={0} y={0} width={workCm.w} height={workCm.h} fill={bgColor} />
+    <Rect x={0} y={0} width={workCm.w} height={workCm.h} fill={bgColor} listening={false} />
   )}
                   <KonvaImage
                     ref={imgRef}


### PR DESCRIPTION
## Summary
- ensure non-interactive rects in EditorCanvas don't block pointer events

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b5197dcce0832781c53299f4db8c10