### PR TITLE
feat(editor): add outer canvas and clipping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
## Summary
- extend editor canvas with extra margin for artboard-style workspace
- clip image content to work area so outside portions are hidden
- ignore root node_modules via new .gitignore

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@sentry%2freact)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fd0bb4b483278642be7f5dddcae5