### PR TITLE
feat: dynamic clip and stable image transforms

### DIFF
--- a/mgm-front/src/components/Artboard.tsx
+++ b/mgm-front/src/components/Artboard.tsx
@@ -11,6 +11,9 @@ interface Props {
   onChangeImage: (s: ImageState) => void;
   fitMode: FitMode;
   fillColor: string;
+  isSelected: boolean;
+  onSelectImage: () => void;
+  onDeselect: () => void;
   innerRef?: any;
 }
 
@@ -22,12 +25,39 @@ export default function Artboard({
   onChangeImage,
   fitMode,
   fillColor,
+  isSelected,
+  onSelectImage,
+  onDeselect,
   innerRef,
 }: Props) {
   return (
-    <Group ref={innerRef} x={0} y={0} clip={{ x: 0, y: 0, width, height }}>
-      <Rect width={width} height={height} fill={fitMode === 'contain' ? fillColor : '#fff'} />
-      <ImageNode image={image} state={imageState} onChange={onChangeImage} />
+    <Group
+      ref={innerRef}
+      x={0}
+      y={0}
+      // Cuando la imagen no está seleccionada recortamos para ocultar desbordes
+      clip={isSelected ? undefined : { x: 0, y: 0, width, height }}
+    >
+      <Rect
+        width={width}
+        height={height}
+        fill={fitMode === 'contain' ? fillColor : '#fff'}
+        onMouseDown={(e) => {
+          onDeselect();
+          e.cancelBubble = true;
+        }}
+        onTap={(e) => {
+          onDeselect();
+          e.cancelBubble = true;
+        }}
+      />
+      <ImageNode
+        image={image}
+        state={imageState}
+        onChange={onChangeImage}
+        isSelected={isSelected}
+        onSelect={onSelectImage}
+      />
     </Group>
   );
 }

--- a/mgm-front/src/components/ImageNode.tsx
+++ b/mgm-front/src/components/ImageNode.tsx
@@ -7,18 +7,22 @@ interface Props {
   image: HTMLImageElement | null;
   state: ImageState;
   onChange: (s: ImageState) => void;
+  isSelected: boolean;
+  onSelect: () => void;
 }
 
-export default function ImageNode({ image, state, onChange }: Props) {
+export default function ImageNode({ image, state, onChange, isSelected, onSelect }: Props) {
   const imageRef = useRef<Konva.Image>(null);
   const trRef = useRef<Konva.Transformer>(null);
 
   useEffect(() => {
-    if (image && trRef.current && imageRef.current) {
+    if (image && trRef.current && imageRef.current && isSelected) {
       trRef.current.nodes([imageRef.current]);
       trRef.current.getLayer()?.batchDraw();
+    } else if (trRef.current) {
+      trRef.current.nodes([]);
     }
-  }, [image]);
+  }, [image, isSelected]);
 
   const handleDragEnd = (e: Konva.KonvaEventObject<DragEvent>) => {
     onChange({ ...state, x: e.target.x(), y: e.target.y() });
@@ -30,14 +34,19 @@ export default function ImageNode({ image, state, onChange }: Props) {
     const scaleX = node.scaleX();
     const scaleY = node.scaleY();
     const rotation = node.rotation();
+    // scale se aplica al width/height para evitar el "salto" visual al soltar
+    const width = Math.max(1, node.width() * scaleX);
+    const height = Math.max(1, node.height() * scaleY);
     node.scaleX(1);
     node.scaleY(1);
+    node.width(width);
+    node.height(height);
     onChange({
       ...state,
       x: node.x(),
       y: node.y(),
-      scaleX: state.scaleX * scaleX,
-      scaleY: state.scaleY * scaleY,
+      width,
+      height,
       rotation,
     });
   };
@@ -51,14 +60,17 @@ export default function ImageNode({ image, state, onChange }: Props) {
         image={image}
         x={state.x}
         y={state.y}
-        scaleX={state.scaleX}
-        scaleY={state.scaleY}
+        width={state.width || image.naturalWidth}
+        height={state.height || image.naturalHeight}
         rotation={state.rotation}
-        draggable
+        draggable={isSelected}
+        onClick={(e) => { onSelect(); e.cancelBubble = true; }}
+        onTap={(e) => { onSelect(); e.cancelBubble = true; }}
         onDragEnd={handleDragEnd}
         onTransformEnd={handleTransformEnd}
+        name="image-node"
       />
-      <Transformer ref={trRef} keepRatio rotateEnabled />
+      {isSelected && <Transformer ref={trRef} keepRatio rotateEnabled />}
     </>
   );
 }

--- a/mgm-front/src/hooks/useCanvasState.ts
+++ b/mgm-front/src/hooks/useCanvasState.ts
@@ -11,8 +11,8 @@ export interface StageState {
 export interface ImageState {
   x: number;
   y: number;
-  scaleX: number;
-  scaleY: number;
+  width: number;
+  height: number;
   rotation: number;
   src?: string;
 }
@@ -22,13 +22,15 @@ interface CanvasState {
   image: ImageState;
   fitMode: FitMode;
   fillColor: string;
+  selected: boolean;
 }
 
 const DEFAULT_STATE: CanvasState = {
   stage: { scale: 1, x: 0, y: 0 },
-  image: { x: 0, y: 0, scaleX: 1, scaleY: 1, rotation: 0, src: '' },
+  image: { x: 0, y: 0, width: 0, height: 0, rotation: 0, src: '' },
   fitMode: 'manual',
   fillColor: '#ffffff',
+  selected: false,
 };
 
 /**
@@ -39,6 +41,7 @@ export function useCanvasState(storageKey: string = STORAGE_KEY) {
   const [image, setImage] = useState<ImageState>(DEFAULT_STATE.image);
   const [fitMode, setFitMode] = useState<FitMode>(DEFAULT_STATE.fitMode);
   const [fillColor, setFillColor] = useState<string>(DEFAULT_STATE.fillColor);
+  const [selected, setSelected] = useState<boolean>(DEFAULT_STATE.selected);
   const [restored, setRestored] = useState(false);
   const stateRef = useRef<CanvasState>(DEFAULT_STATE);
   const saveTimer = useRef<NodeJS.Timeout | null>(null);
@@ -54,11 +57,13 @@ export function useCanvasState(storageKey: string = STORAGE_KEY) {
           setImage(parsed.image);
           setFitMode(parsed.fitMode || 'manual');
           setFillColor(parsed.fillColor || '#ffffff');
+          setSelected(parsed.selected || false);
           stateRef.current = {
             stage: parsed.stage,
             image: parsed.image,
             fitMode: parsed.fitMode || 'manual',
             fillColor: parsed.fillColor || '#ffffff',
+            selected: parsed.selected || false,
           };
         }
       }
@@ -103,6 +108,12 @@ export function useCanvasState(storageKey: string = STORAGE_KEY) {
     persist();
   };
 
+  const updateSelected = (s: boolean) => {
+    setSelected(s);
+    stateRef.current.selected = s;
+    persist();
+  };
+
   return {
     stage,
     image,
@@ -112,6 +123,8 @@ export function useCanvasState(storageKey: string = STORAGE_KEY) {
     updateImage,
     updateFitMode,
     updateFillColor,
+    selected,
+    updateSelected,
     restored,
   };
 }

--- a/mgm-front/src/lib/alignHelpers.ts
+++ b/mgm-front/src/lib/alignHelpers.ts
@@ -1,30 +1,24 @@
 export interface ImageDimensions {
-  imgW: number;
-  imgH: number;
-  scaleX: number;
-  scaleY: number;
+  width: number;
+  height: number;
 }
 
-export function alignCenter({ imgW, imgH, scaleX, scaleY }: ImageDimensions, boardW: number, boardH: number) {
-  const w = imgW * scaleX;
-  const h = imgH * scaleY;
-  return { x: (boardW - w) / 2, y: (boardH - h) / 2 };
+export function alignCenter({ width, height }: ImageDimensions, boardW: number, boardH: number) {
+  return { x: (boardW - width) / 2, y: (boardH - height) / 2 };
 }
 
-export function alignLeft({ imgW, scaleX }: ImageDimensions) {
+export function alignLeft() {
   return { x: 0 };
 }
 
-export function alignRight({ imgW, scaleX }: ImageDimensions, boardW: number) {
-  const w = imgW * scaleX;
-  return { x: boardW - w };
+export function alignRight({ width }: ImageDimensions, boardW: number) {
+  return { x: boardW - width };
 }
 
-export function alignTop({ imgH, scaleY }: ImageDimensions) {
+export function alignTop() {
   return { y: 0 };
 }
 
-export function alignBottom({ imgH, scaleY }: ImageDimensions, boardH: number) {
-  const h = imgH * scaleY;
-  return { y: boardH - h };
+export function alignBottom({ height }: ImageDimensions, boardH: number) {
+  return { y: boardH - height };
 }

--- a/mgm-front/src/lib/fitModes.ts
+++ b/mgm-front/src/lib/fitModes.ts
@@ -3,26 +3,28 @@ export type FitMode = 'contain' | 'cover' | 'stretch' | 'manual';
 export interface FitResult {
   x: number;
   y: number;
-  scaleX: number;
-  scaleY: number;
+  width: number;
+  height: number;
 }
 
 export function fitContain(imgW: number, imgH: number, boardW: number, boardH: number): FitResult {
   const scale = Math.min(boardW / imgW, boardH / imgH);
-  const x = (boardW - imgW * scale) / 2;
-  const y = (boardH - imgH * scale) / 2;
-  return { x, y, scaleX: scale, scaleY: scale };
+  const width = imgW * scale;
+  const height = imgH * scale;
+  const x = (boardW - width) / 2;
+  const y = (boardH - height) / 2;
+  return { x, y, width, height };
 }
 
 export function fitCover(imgW: number, imgH: number, boardW: number, boardH: number): FitResult {
   const scale = Math.max(boardW / imgW, boardH / imgH);
-  const x = (boardW - imgW * scale) / 2;
-  const y = (boardH - imgH * scale) / 2;
-  return { x, y, scaleX: scale, scaleY: scale };
+  const width = imgW * scale;
+  const height = imgH * scale;
+  const x = (boardW - width) / 2;
+  const y = (boardH - height) / 2;
+  return { x, y, width, height };
 }
 
 export function fitStretch(imgW: number, imgH: number, boardW: number, boardH: number): FitResult {
-  const scaleX = boardW / imgW;
-  const scaleY = boardH / imgH;
-  return { x: 0, y: 0, scaleX, scaleY };
+  return { x: 0, y: 0, width: boardW, height: boardH };
 }


### PR DESCRIPTION
## Summary
- add global selection state and toggle artboard clip to show/hide overflows
- fix resize jump by baking transform scale into width/height
- refactor fit and align helpers to use width/height

## Testing
- `npm test`
- `npm run lint` *(fails: Empty block statement / unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b73d24d9648327973a0cdf9f4664c0