### PR TITLE
Map Glasspad material to PRO for upload-url API

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -148,6 +148,8 @@ export default function Home() {
       const ext = (uploaded.file.name.split('.').pop() || 'png').toLowerCase();
       const mime = uploaded.file.type || 'image/png';
       const size_bytes = uploaded.file.size;
+      // API /api/upload-url solo acepta Classic o PRO; mapear Glasspad -> PRO
+      const materialApi = material === 'Glasspad' ? 'PRO' : material;
       const uploadUrlRes = await fetch(`${API_BASE}/api/upload-url`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -156,7 +158,7 @@ export default function Home() {
           ext,
           mime,
           size_bytes,
-          material,
+          material: materialApi,
           w_cm: sizeCm.w,
           h_cm: sizeCm.h,
           sha256: file_hash,


### PR DESCRIPTION
## Summary
- Map unsupported `Glasspad` material to `PRO` when requesting an upload URL to satisfy API validation

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b74d0781f8832781936e34b51b678c