### PR TITLE
refactor: normalize cors imports

### DIFF
--- a/api/finalize-assets.js
+++ b/api/finalize-assets.js
@@ -1,9 +1,9 @@
 // api/finalize-assets.js
-import { buildCorsHeaders } from "../lib/cors.ts";
+import { buildCorsHeaders } from "../lib/cors";
 import getSupabaseAdmin from "./_lib/supabaseAdmin.js";
 import sharp from "sharp";
 import { PDFDocument } from "pdf-lib";
-import composeImage from "./_lib/composeImage.ts";
+import composeImage from "./_lib/composeImage";
 import crypto from "node:crypto";
 
 export const config = {

--- a/api/render-dryrun.js
+++ b/api/render-dryrun.js
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import { cors } from "./_lib/cors.js";
 import getSupabaseAdmin from "./_lib/supabaseAdmin.js";
-import composeImage from "./_lib/composeImage.ts";
+import composeImage from "./_lib/composeImage";
 
 function err(res, status, { diag_id, stage, message, debug = {} }) {
   return res.status(status).json({ ok: false, diag_id, stage, message, debug });

--- a/docs/cors.md
+++ b/docs/cors.md
@@ -9,7 +9,7 @@ Edit `ALLOWED_ORIGINS` inside `lib/cors.ts` to modify permitted origins.
 For Pages API style handlers (`api/*.js`), compute CORS headers per request:
 
 ```js
-import { buildCorsHeaders } from '../lib/cors.ts';
+import { buildCorsHeaders } from '../lib/cors';
 
 export default async function handler(req, res) {
   const origin = req.headers.origin || null;
@@ -28,7 +28,7 @@ export default async function handler(req, res) {
 For App Router routes (`app/api/**`), use:
 
 ```ts
-import { buildCorsHeaders, preflight, withCorsJson } from '@/lib/cors';
+import { buildCorsHeaders, preflight, applyCorsToResponse } from '@/lib/cors';
 
 export async function OPTIONS(req: Request) {
   return preflight(req.headers.get('origin'));
@@ -47,8 +47,7 @@ export async function POST(req: Request) {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   });
-  Object.entries(cors).forEach(([k, v]) => res.headers.set(k, String(v)));
-  return res;
+  return applyCorsToResponse(res, origin);
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "check:runtimes": "grep -Rni \"runtime.*nodejs20\" . || true && grep -Rni \"nodejs20\\.x\" . || true && grep -Rni \"export const runtime\" . || true && grep -Rni \\\"functions\\\" vercel.json || true",
     "cors:smoke": "node scripts/cors-smoke.mjs",
     "syntax:check": "node ./scripts/syntax-check.mjs",
-    "syntax:check:build": "node --check .next/server/**/*.js || true"
+    "syntax:check:build": "node --check .next/server/**/*.js || true",
+    "find:bad-imports": "grep -RniE \"from '(/|.*\\.ts')\" --include=*.{ts,tsx,js,jsx} . || true"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.54.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,9 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "NodeNext",
-    "skipLibCheck": true
-  }
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": { "@/*": ["*"] }
+  },
+  "include": ["lib/**/*", "api/**/*", "scripts/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
## Summary
- export comprehensive CORS helpers
- fix serverless API imports to avoid `.ts` extensions
- tighten TS config and add bad-import finder

## Testing
- `npm run find:bad-imports`
- `npx next build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*

------
https://chatgpt.com/codex/tasks/task_e_68b7837c030c8327a6a391ec0f347f17