### PR TITLE
feat: use local next build

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,15 @@
+# Build
+
+This project installs dependencies using the local npm registry.
+
+- **Install Command:** `npm ci`
+- **Build Command:** `npm run build`
+
+The build uses the local `next` binary from `node_modules/.bin/next` and must not rely on `npx`.
+
+If your network requires a proxy, configure the following environment variables:
+
+- `HTTP_PROXY`
+- `HTTPS_PROXY`
+- `NPM_CONFIG_REGISTRY`
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.54.0",
         "nanoid": "^5.1.5",
+        "next": "latest",
         "pdf-lib": "^1.17.1",
         "sharp": "^0.34.3",
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -3,19 +3,24 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "npm@10",
   "scripts": {
     "start": "node api/upload-url.js",
+    "build": "next build",
     "test": "node --test",
     "api:smoke": "node scripts/api-smoke.js",
     "check:runtimes": "grep -Rni \"runtime.*nodejs20\" . || true && grep -Rni \"nodejs20\\.x\" . || true && grep -Rni \"export const runtime\" . || true && grep -Rni \\\"functions\\\" vercel.json || true",
     "cors:smoke": "node scripts/cors-smoke.mjs",
     "syntax:check": "node ./scripts/syntax-check.mjs",
     "syntax:check:build": "node --check .next/server/**/*.js || true",
-    "find:bad-imports": "grep -RniE \"from '(/|.*\\.ts')\" --include=*.{ts,tsx,js,jsx} . || true"
+    "find:bad-imports": "grep -RniE \"from '(/|.*\\.ts')\" --include=*.{ts,tsx,js,jsx} . || true",
+    "doctor:registry": "npm config get registry && npm ping",
+    "doctor:which-next": "node -e \"console.log(require.resolve('next/package.json'))\""
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.54.0",
     "nanoid": "^5.1.5",
+    "next": "latest",
     "pdf-lib": "^1.17.1",
     "sharp": "^0.34.3",
     "zod": "^3.23.8"


### PR DESCRIPTION
## Summary
- add Next.js dependency and build script
- configure npm registry and package manager
- document build commands for Vercel

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*
- `npm run doctor:registry` *(fails: 403 Forbidden - GET https://registry.npmjs.org/-/ping)*
- `npm run doctor:which-next` *(fails: Cannot find module 'next/package.json')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7983e8a988327abf1f181b2cd0812