### PR TITLE
Fix Glasspad mode dimensions and preview overlay

### DIFF
--- a/mgm-front/src/components/SizeControls.jsx
+++ b/mgm-front/src/components/SizeControls.jsx
@@ -1,7 +1,7 @@
 // src/components/SizeControls.jsx
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styles from './SizeControls.module.css';
-import { LIMITS, STANDARD } from '../lib/material.js';
+import { LIMITS, STANDARD, GLASSPAD_SIZE_CM } from '../lib/material.js';
 
 /**
  * Props:
@@ -12,6 +12,7 @@ import { LIMITS, STANDARD } from '../lib/material.js';
 export default function SizeControls({ material, size, onChange, locked = false }) {
   const limits = LIMITS[material] || { maxW: size.w, maxH: size.h };
   const presets = STANDARD[material] || [];
+  const isGlasspad = material === 'Glasspad';
 
   const [wText, setWText] = useState(String(size.w || ''));
   const [hText, setHText] = useState(String(size.h || ''));
@@ -19,12 +20,17 @@ export default function SizeControls({ material, size, onChange, locked = false 
   useEffect(() => { setWText(String(size.w ?? '')); }, [size.w]);
   useEffect(() => { setHText(String(size.h ?? '')); }, [size.h]);
 
+  const glasspadInitRef = useRef(false);
   useEffect(() => {
-    if (material === 'Glasspad') {
-      setWText('50');
-      setHText('40');
-      onChange({ w: 50, h: 40 });
+    if (material !== 'Glasspad') {
+      glasspadInitRef.current = false;
+      return;
     }
+    if (glasspadInitRef.current) return;
+    setWText(String(GLASSPAD_SIZE_CM.w));
+    setHText(String(GLASSPAD_SIZE_CM.h));
+    onChange?.({ w: GLASSPAD_SIZE_CM.w, h: GLASSPAD_SIZE_CM.h });
+    glasspadInitRef.current = true;
   }, [material, onChange]);
 
   const numPattern = /^[0-9]{0,3}(\.[0-9]{0,2})?$/;
@@ -70,23 +76,23 @@ export default function SizeControls({ material, size, onChange, locked = false 
 
       <label>Ancho (cm)
         <input
-          value={wText}
-          onChange={handleWChange}
-          onBlur={handleWBlur}
+          value={isGlasspad ? GLASSPAD_SIZE_CM.w : wText}
+          onChange={!isGlasspad ? handleWChange : undefined}
+          onBlur={!isGlasspad ? handleWBlur : undefined}
           inputMode="decimal"
           pattern="[0-9]*"
-          disabled={locked || material === 'Glasspad'}
+          disabled={locked || isGlasspad}
         />
       </label>
 
       <label>Alto (cm)
         <input
-          value={hText}
-          onChange={handleHChange}
-          onBlur={handleHBlur}
+          value={isGlasspad ? GLASSPAD_SIZE_CM.h : hText}
+          onChange={!isGlasspad ? handleHChange : undefined}
+          onBlur={!isGlasspad ? handleHBlur : undefined}
           inputMode="decimal"
           pattern="[0-9]*"
-          disabled={locked || material === 'Glasspad'}
+          disabled={locked || isGlasspad}
         />
       </label>
 
@@ -98,14 +104,14 @@ export default function SizeControls({ material, size, onChange, locked = false 
         ))}
       </div>
 
-      {!locked && material !== 'Glasspad' && (
+      {!locked && !isGlasspad && (
         <small className={styles.helper}>
           Máximo {limits.maxW}×{limits.maxH} cm para {material}
         </small>
       )}
 
       {locked && (
-        <small className={styles.helper}>Medida fija 50×40 cm</small>
+        <small className={styles.helper}>Medida fija {GLASSPAD_SIZE_CM.w}×{GLASSPAD_SIZE_CM.h} cm</small>
       )}
     </div>
   );

--- a/mgm-front/src/lib/material.js
+++ b/mgm-front/src/lib/material.js
@@ -1,7 +1,9 @@
+export const GLASSPAD_SIZE_CM = { w: 49, h: 42 };
+
 export const LIMITS = {
   Classic: { maxW: 140, maxH: 100 },
   PRO: { maxW: 120, maxH: 60 },
-  Glasspad: { maxW: 50, maxH: 40 },
+  Glasspad: { maxW: GLASSPAD_SIZE_CM.w, maxH: GLASSPAD_SIZE_CM.h },
 };
 
 export const STANDARD = {
@@ -18,7 +20,5 @@ export const STANDARD = {
     { w: 90, h: 40 },
     { w: 120, h: 60 },
   ],
-  Glasspad: [
-    { w: 50, h: 40 },
-  ],
+  Glasspad: [GLASSPAD_SIZE_CM],
 };


### PR DESCRIPTION
## Summary
- add `GLASSPAD_SIZE_CM` constant and use it to lock Glasspad to 49×42 cm
- disable size inputs and guard state updates when Glasspad is selected
- add frosted overlay and one-time centering logic to Glasspad previews

## Testing
- `npm test`
- `npm test` (mgm-front) *(fails: Missing script "test")*
- `npx eslint src/lib/material.js src/components/SizeControls.jsx src/pages/Home.jsx src/pages/DevCanvasPreview.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68b79aa5a9a483278783109fe1695a3e