### PR TITLE
Configure Vercel function resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "packageManager": "npm@10",
   "scripts": {
     "build": "echo \"no build\"",
-    "start": "echo \"vercel runs functions\""
+    "start": "echo \"vercel runs functions\"",
+    "doctor:vercel": "node -e \"console.log(require('./vercel.json'))\"",
+    "find:file-runtime": "grep -RniE \"export const config\\s*=\\s*\\{\\s*runtime\" api || true"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.54.0",

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,8 @@
 {
   "framework": null,
   "functions": {
-    "api/**/*.ts": { "runtime": "nodejs20.x" },
-    "api/**/*.js": { "runtime": "nodejs20.x" }
+    "api/**/*.ts": { "runtime": "nodejs20.x", "memory": 512, "maxDuration": 15 },
+    "api/**/*.js": { "runtime": "nodejs20.x", "memory": 512, "maxDuration": 15 },
+    "api/worker-process.js": { "runtime": "nodejs20.x", "memory": 1536, "maxDuration": 60 }
   }
 }


### PR DESCRIPTION
## Summary
- configure function runtimes in `vercel.json` with memory and duration limits
- add helper scripts and clean up `package.json`

## Testing
- `npm run doctor:vercel`
- `npm run find:file-runtime`


------
https://chatgpt.com/codex/tasks/task_e_68b7a8ddfa748327a573b112ad623126