### PR TITLE
chore: specify vercel node runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,9 @@
       },
       "engines": {
         "node": "20.x"
+      },
+      "devDependencies": {
+        "@vercel/node": "^3.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   },
   "engines": {
     "node": "20.x"
+  },
+  "devDependencies": {
+    "@vercel/node": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `@vercel/node` dev dependency so Vercel has an explicit runtime version

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install --package-lock-only` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b1463670832781f349243c7bd813