### PR TITLE
Add Vercel version to configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,12 @@
 {
+  "version": 2,
   "framework": null,
   "functions": {
-    "api/**/*.ts": { "runtime": "nodejs20.x" },
-    "api/**/*.js": { "runtime": "nodejs20.x" }
+    "api/**/*.ts": {
+      "runtime": "nodejs20.x"
+    },
+    "api/**/*.js": {
+      "runtime": "nodejs20.x"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- specify version in `vercel.json` to use modern runtime configuration

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`
- `npm run doctor:vercel`


------
https://chatgpt.com/codex/tasks/task_e_68b85cc8312c832789b82c8b14ad144f