### PR TITLE
Remove unused @vercel/node dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,6 @@
       },
       "engines": {
         "node": "20.x"
-      },
-      "devDependencies": {
-        "@vercel/node": "^3.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,5 @@
   },
   "engines": {
     "node": "20.x"
-  },
-  "devDependencies": {
-    "@vercel/node": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove dangling `@vercel/node` devDependency
- regenerate lockfile so only runtime node 20 remains

## Testing
- `npm test` (fails: Missing script)
- `npm run doctor:vercel`
- `npm run find:legacy`
- `npm run find:bad-runtime`
- `npm run find:now-files`


------
https://chatgpt.com/codex/tasks/task_e_68b85fa6897083278e0a60008b546d2c