### PR TITLE
fix: use supported node runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "echo \"no build\"",
     "doctor:vercel": "node -e \"console.log(require('./vercel.json'))\"",
     "find:legacy": "grep -RniE '\\b(builds|routes)\\b' vercel.json now.json || true",
-    "find:bad-runtime": "grep -RniE '\"runtime\"\\s*:\\s*\"nodejs(?!20\\.x)\"' vercel.json package.json now.json || true",
+    "find:bad-runtime": "grep -RniE '\"runtime\"\\s*:\\s*\"nodejs(?!18.x)\"' vercel.json package.json now.json || true",
     "find:now-files": "ls -1 now.json project.json 2>/dev/null || true"
   },
   "dependencies": {
@@ -19,6 +19,6 @@
     "zod": "^3.23.8"
   },
   "engines": {
-    "node": "20.x"
+    "node": "18.x"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,10 @@
   "framework": null,
   "functions": {
     "api/**/*.ts": {
-      "runtime": "nodejs20.x"
+      "runtime": "nodejs18.x"
     },
     "api/**/*.js": {
-      "runtime": "nodejs20.x"
+      "runtime": "nodejs18.x"
     }
   }
 }


### PR DESCRIPTION
## Summary
- use Node.js 18 runtime for Vercel functions
- align package engine and diagnostics script with Node 18

## Testing
- `npm run doctor:vercel`
- `npm run find:legacy`
- `npm run find:bad-runtime` *(fails: grep: warning: ? at start of expression)*
- `npm run find:now-files`
- `npx vercel@latest build` *(fails: npm error 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b8680dfeb483279ff5b619021b195e