### PR TITLE
feat: add mockup flow with Shopify product creation

### DIFF
--- a/api/shopify/create-product.ts
+++ b/api/shopify/create-product.ts
@@ -1,0 +1,55 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { buildCorsHeaders } from '../../lib/cors';
+import { shopifyAdmin } from '../../lib/shopify.js';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const origin = (req.headers.origin as string) || null;
+  const cors = buildCorsHeaders(origin);
+  if (req.method === 'OPTIONS') {
+    if (!cors) return res.status(403).json({ message: 'origin_not_allowed' });
+    Object.entries(cors).forEach(([k, v]) => res.setHeader(k, v as string));
+    return res.status(204).end();
+  }
+  if (req.method !== 'POST') {
+    return res.status(405).json({ ok: false, message: 'method_not_allowed' });
+  }
+  if (!cors) return res.status(403).json({ ok: false, message: 'origin_not_allowed' });
+  Object.entries(cors).forEach(([k, v]) => res.setHeader(k, v as string));
+
+  try {
+    const { mode, width_cm, height_cm, bleed_mm, rotate_deg, image_dataurl } = req.body || {};
+    const modeOk = ['Classic', 'Pro', 'Glasspad'].includes(mode);
+    const width = Number(width_cm);
+    const height = Number(height_cm);
+    const bleed = Number(bleed_mm);
+    const rotate = Number(rotate_deg);
+    if (!modeOk || Number.isNaN(width) || Number.isNaN(height) || Number.isNaN(bleed) || Number.isNaN(rotate)) {
+      return res.status(400).json({ ok: false, message: 'invalid_fields' });
+    }
+    if (typeof image_dataurl !== 'string' || !image_dataurl.startsWith('data:image/')) {
+      return res.status(400).json({ ok: false, message: 'invalid_image' });
+    }
+    const base64 = image_dataurl.split(',')[1];
+    const payload = {
+      product: {
+        title: `Mousepad Personalizado - ${mode}`,
+        body_html: `<p>Personalizado ${width}x${height} cm</p>`,
+        images: [{ attachment: base64 }],
+        variants: [{ price: '0.00' }],
+        status: 'draft'
+      }
+    };
+    const { product } = await shopifyAdmin('/products.json', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+    const pubBase = process.env.SHOPIFY_PUBLIC_BASE || `https://${process.env.SHOPIFY_STORE_DOMAIN}`;
+    const productUrl = `${pubBase}/products/${product.handle}`;
+    const variantId = String(product?.variants?.[0]?.id || '');
+    const checkoutUrl = `${pubBase}/cart/${variantId}:1`;
+    return res.status(200).json({ ok: true, productUrl, checkoutUrl });
+  } catch (e: any) {
+    const status = Number(e?.status) || 500;
+    return res.status(status).json({ ok: false, message: e?.message || 'shopify_error' });
+  }
+}

--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -781,6 +781,15 @@ const EditorCanvas = forwardRef(function EditorCanvas(
     }
   };
 
+  const exportPadDataURL = (pixelRatio = 1) => {
+    if (!exportStageRef.current) return null;
+    try {
+      return exportStageRef.current.toDataURL({ pixelRatio, mimeType: 'image/png' });
+    } catch (e) {
+      return null;
+    }
+  };
+
   useImperativeHandle(ref, () => ({
     getRenderDescriptor: () => {
       if (!imgEl || !imgBaseCm) return null;
@@ -839,6 +848,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
     getPadRectPx,
     exportPadAsBlob,
     exportPreviewDataURL,
+    exportPadDataURL,
     startPickColor,
   }));
 

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -8,6 +8,8 @@ import Creating from './pages/Creating.jsx';
 import Result from './pages/Result.jsx';
 import DevRenderPreview from './pages/DevRenderPreview.jsx';
 import DevCanvasPreview from './pages/DevCanvasPreview.jsx';
+import Mockup from './pages/Mockup.jsx';
+import { OrderFlowProvider } from './store/orderFlow';
 import './globals.css';
 
 const routes = [
@@ -16,6 +18,7 @@ const routes = [
     children: [
       { path: '/', element: <Home /> },
       { path: '/confirm', element: <Confirm /> },
+      { path: '/mockup', element: <Mockup /> },
       { path: '/creating/:jobId', element: <Creating /> },
       { path: '/result/:jobId', element: <Result /> }
     ]
@@ -31,6 +34,8 @@ const router = createBrowserRouter(routes);
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <OrderFlowProvider>
+      <RouterProvider router={router} />
+    </OrderFlowProvider>
   </React.StrictMode>
 );

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useOrderFlow } from '../store/orderFlow';
+
+export default function Mockup() {
+  const navigate = useNavigate();
+  const { preview_png_dataurl, master_png_dataurl, mode, width_cm, height_cm, bleed_mm, rotate_deg } = useOrderFlow();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [links, setLinks] = useState(null);
+
+  if (!preview_png_dataurl) {
+    return (
+      <div style={{ padding: 32 }}>
+        <p>No hay imagen para mostrar.</p>
+        <button onClick={() => navigate('/')}>Volver</button>
+      </div>
+    );
+  }
+
+  async function handleCreateShopifyProduct() {
+    setLoading(true); setError(null);
+    try {
+      const mod = await fetch('/api/moderate-image', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ image_dataurl: master_png_dataurl })
+      }).then(r => r.json());
+      if (!mod.allow) { setError('La imagen contiene contenido no permitido.'); setLoading(false); return; }
+
+      const payload = {
+        mode,
+        width_cm: Number(width_cm),
+        height_cm: Number(height_cm),
+        bleed_mm: Number(bleed_mm),
+        rotate_deg: Number(rotate_deg),
+        image_dataurl: master_png_dataurl
+      };
+      const res = await fetch('/api/shopify/create-product', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      const data = await res.json();
+      if (!res.ok || !data?.ok) throw new Error(data?.message || 'Error al crear el producto');
+      setLinks({ product: data.productUrl, checkout: data.checkoutUrl });
+    } catch (e) {
+      setError(e?.message || 'Error inesperado');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div style={{ padding: 24 }}>
+      <div className="mockup-frame" style={{position:'relative', width: 680, aspectRatio:'49 / 42', background:'#eee', overflow:'hidden', borderRadius:16}}>
+        <img src="/mockups/mousepad_base.png" alt="" style={{position:'absolute', inset:0, width:'100%', height:'100%', objectFit:'cover'}}/>
+        <img src={preview_png_dataurl} alt="" style={{position:'absolute', inset:'var(--padInset, 24px)', width:'calc(100% - 48px)', height:'calc(100% - 48px)', objectFit:'cover', borderRadius:12}}/>
+        {mode === 'Glasspad' && (
+          <div style={{position:'absolute', inset:'var(--padInset, 24px)', borderRadius:12, pointerEvents:'none', zIndex:5, background:'rgba(255,255,255,.28)', backdropFilter:'blur(2px) saturate(1.03)', WebkitBackdropFilter:'blur(2px) saturate(1.03)'}}/>
+        )}
+      </div>
+      <div style={{marginTop:16, display:'flex', gap:8}}>
+        {!links && (
+          <>
+            <button onClick={() => navigate('/')}>Atrás</button>
+            <button onClick={handleCreateShopifyProduct} disabled={loading}>{loading ? 'Creando...' : 'Avanzar y comprar'}</button>
+          </>
+        )}
+        {links && (
+          <>
+            <a href={links.product} target="_blank" rel="noopener noreferrer">Ver producto</a>
+            <a href={links.checkout} target="_blank" rel="noopener noreferrer">Ir a checkout</a>
+          </>
+        )}
+      </div>
+      {error && <p className="errorText">{error}</p>}
+    </div>
+  );
+}

--- a/mgm-front/src/store/orderFlow.ts
+++ b/mgm-front/src/store/orderFlow.ts
@@ -1,0 +1,43 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+export type FlowState = {
+  mode: 'Classic' | 'Pro' | 'Glasspad';
+  width_cm: number;
+  height_cm: number;
+  bleed_mm: number;
+  rotate_deg: number;
+  preview_png_dataurl: string | null;
+  master_png_dataurl: string | null;
+  set: (p: Partial<FlowState>) => void;
+  reset: () => void;
+};
+
+const defaultState: Omit<FlowState, 'set' | 'reset'> = {
+  mode: 'Classic',
+  width_cm: 0,
+  height_cm: 0,
+  bleed_mm: 0,
+  rotate_deg: 0,
+  preview_png_dataurl: null,
+  master_png_dataurl: null,
+};
+
+const OrderFlowContext = createContext<FlowState>({
+  ...defaultState,
+  set: () => {},
+  reset: () => {},
+});
+
+export function OrderFlowProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState(defaultState);
+  const value: FlowState = {
+    ...state,
+    set: (p) => setState((s) => ({ ...s, ...p })),
+    reset: () => setState(defaultState),
+  };
+  return <OrderFlowContext.Provider value={value}>{children}</OrderFlowContext.Provider>;
+}
+
+export function useOrderFlow() {
+  return useContext(OrderFlowContext);
+}


### PR DESCRIPTION
## Summary
- add simple order flow store with set/reset and provider
- capture canvas previews and navigate to new mockup page
- Shopify create-product API with basic validation and CORS

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd mgm-front && npm test` *(fails: Missing script: "test")*
- `cd mgm-front && npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b8dc67495083278e4dcc65367b6117