### PR TITLE
chore: use Node 20 runtime on Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "echo \"no build\"",
     "doctor:vercel": "node -e \"console.log(require('./vercel.json'))\"",
     "find:legacy": "grep -RniE '\\b(builds|routes)\\b' vercel.json now.json || true",
-    "find:bad-runtime": "grep -RniE '\"runtime\"\\s*:\\s*\"nodejs(?!18.x)\"' vercel.json package.json now.json || true",
+    "find:bad-runtime": "grep -RniP '\"runtime\"\\s*:\\s*\"nodejs(?!20.x)\"' vercel.json package.json now.json || true",
     "find:now-files": "ls -1 now.json project.json 2>/dev/null || true"
   },
   "dependencies": {

--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,10 @@
   "framework": null,
   "functions": {
     "api/**/*.ts": {
-      "runtime": "nodejs18.x"
+      "runtime": "nodejs20.x"
     },
     "api/**/*.js": {
-      "runtime": "nodejs18.x"
+      "runtime": "nodejs20.x"
     }
   }
 }


### PR DESCRIPTION
## Summary
- use Node 20 for all Vercel serverless functions
- adjust runtime check script for Node 20

## Testing
- `npm run doctor:vercel`
- `npm run find:bad-runtime`
- `npm run find:legacy`
- `npm run find:now-files`


------
https://chatgpt.com/codex/tasks/task_e_68b8e2e5533c8327a900bc7d2fc19e3d