### PR TITLE
Respect mockup image aspect ratio

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -62,6 +62,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
   const wrapRef = useRef(null);
   const stageRef = useRef(null);
   const exportStageRef = useRef(null);
+  const padGroupRef = useRef(null);
   const [wrapSize, setWrapSize] = useState({ w: 960, h: 540 });
   useEffect(() => {
     const ro = new ResizeObserver(() => {
@@ -773,6 +774,16 @@ const EditorCanvas = forwardRef(function EditorCanvas(
   };
 
   const exportPreviewDataURL = () => {
+    if (padGroupRef.current) {
+      try {
+        return padGroupRef.current.toDataURL({
+          pixelRatio: 0.5,
+          mimeType: 'image/png',
+        });
+      } catch (e) {
+        /* ignore */
+      }
+    }
     if (!exportStageRef.current) return null;
     try {
       return exportStageRef.current.toDataURL({ pixelRatio: 0.5 });
@@ -782,9 +793,22 @@ const EditorCanvas = forwardRef(function EditorCanvas(
   };
 
   const exportPadDataURL = (pixelRatio = 1) => {
+    if (padGroupRef.current) {
+      try {
+        return padGroupRef.current.toDataURL({
+          pixelRatio,
+          mimeType: 'image/png',
+        });
+      } catch (e) {
+        /* ignore */
+      }
+    }
     if (!exportStageRef.current) return null;
     try {
-      return exportStageRef.current.toDataURL({ pixelRatio, mimeType: 'image/png' });
+      return exportStageRef.current.toDataURL({
+        pixelRatio,
+        mimeType: 'image/png',
+      });
     } catch (e) {
       return null;
     }
@@ -1272,29 +1296,31 @@ const EditorCanvas = forwardRef(function EditorCanvas(
           style={{ display: "none" }}
         >
           <Layer>
-            {mode === "contain" && (
-              <Rect
-                x={0}
-                y={0}
-                width={padRectPx.w}
-                height={padRectPx.h}
-                fill={bgColor}
-                listening={false}
-              />
-            )}
-            {imgEl && imgBaseCm && (
-              <KonvaImage
-                image={imgEl}
-                x={(imgTx.x_cm - bleedCm + dispW / 2) * exportScale}
-                y={(imgTx.y_cm - bleedCm + dispH / 2) * exportScale}
-                width={dispW * exportScale}
-                height={dispH * exportScale}
-                offsetX={(dispW * exportScale) / 2}
-                offsetY={(dispH * exportScale) / 2}
-                rotation={imgTx.rotation_deg}
-                listening={false}
-              />
-            )}
+            <Group ref={padGroupRef}>
+              {mode === "contain" && (
+                <Rect
+                  x={0}
+                  y={0}
+                  width={padRectPx.w}
+                  height={padRectPx.h}
+                  fill={bgColor}
+                  listening={false}
+                />
+              )}
+              {imgEl && imgBaseCm && (
+                <KonvaImage
+                  image={imgEl}
+                  x={(imgTx.x_cm - bleedCm + dispW / 2) * exportScale}
+                  y={(imgTx.y_cm - bleedCm + dispH / 2) * exportScale}
+                  width={dispW * exportScale}
+                  height={dispH * exportScale}
+                  offsetX={(dispW * exportScale) / 2}
+                  offsetY={(dispH * exportScale) / 2}
+                  rotation={imgTx.rotation_deg}
+                  listening={false}
+                />
+              )}
+            </Group>
           </Layer>
         </Stage>
         {imageUrl && imgStatus !== "loaded" && (

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -1,13 +1,25 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useOrderFlow } from '../store/orderFlow';
 
+const MAX_W = 720;
+const MAX_H = 520;
+
 export default function Mockup() {
   const navigate = useNavigate();
-  const { preview_png_dataurl, master_png_dataurl, mode, width_cm, height_cm, bleed_mm, rotate_deg } = useOrderFlow();
+  const {
+    preview_png_dataurl,
+    master_png_dataurl,
+    mode,
+    width_cm,
+    height_cm,
+    bleed_mm,
+    rotate_deg,
+  } = useOrderFlow();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [links, setLinks] = useState(null);
+  const [dim, setDim] = useState(null);
 
   if (!preview_png_dataurl) {
     return (
@@ -18,15 +30,30 @@ export default function Mockup() {
     );
   }
 
+  const handleImgLoad = (e) => {
+    const el = e.currentTarget;
+    const iw = el.naturalWidth || 1;
+    const ih = el.naturalHeight || 1;
+    const scale = Math.min(MAX_W / iw, MAX_H / ih, 1);
+    const next = { w: Math.round(iw * scale), h: Math.round(ih * scale) };
+    setDim(next);
+    console.log('[mockup natural size]', iw, ih, '→', next);
+  };
+
   async function handleCreateShopifyProduct() {
-    setLoading(true); setError(null);
+    setLoading(true);
+    setError(null);
     try {
       const mod = await fetch('/api/moderate-image', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ image_dataurl: master_png_dataurl })
-      }).then(r => r.json());
-      if (!mod.allow) { setError('La imagen contiene contenido no permitido.'); setLoading(false); return; }
+        body: JSON.stringify({ image_dataurl: master_png_dataurl }),
+      }).then((r) => r.json());
+      if (!mod.allow) {
+        setError('La imagen contiene contenido no permitido.');
+        setLoading(false);
+        return;
+      }
 
       const payload = {
         mode,
@@ -34,15 +61,16 @@ export default function Mockup() {
         height_cm: Number(height_cm),
         bleed_mm: Number(bleed_mm),
         rotate_deg: Number(rotate_deg),
-        image_dataurl: master_png_dataurl
+        image_dataurl: master_png_dataurl,
       };
       const res = await fetch('/api/shopify/create-product', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
+        body: JSON.stringify(payload),
       });
       const data = await res.json();
-      if (!res.ok || !data?.ok) throw new Error(data?.message || 'Error al crear el producto');
+      if (!res.ok || !data?.ok)
+        throw new Error(data?.message || 'Error al crear el producto');
       setLinks({ product: data.productUrl, checkout: data.checkoutUrl });
     } catch (e) {
       setError(e?.message || 'Error inesperado');
@@ -51,26 +79,94 @@ export default function Mockup() {
     }
   }
 
+  const preview = preview_png_dataurl;
+  const isGlasspad = mode === 'Glasspad';
+
   return (
-    <div style={{ padding: 24 }}>
-      <div className="mockup-frame" style={{position:'relative', width: 680, aspectRatio:'49 / 42', background:'#eee', overflow:'hidden', borderRadius:16}}>
-        <img src="/mockups/mousepad_base.png" alt="" style={{position:'absolute', inset:0, width:'100%', height:'100%', objectFit:'cover'}}/>
-        <img src={preview_png_dataurl} alt="" style={{position:'absolute', inset:'var(--padInset, 24px)', width:'calc(100% - 48px)', height:'calc(100% - 48px)', objectFit:'cover', borderRadius:12}}/>
-        {mode === 'Glasspad' && (
-          <div style={{position:'absolute', inset:'var(--padInset, 24px)', borderRadius:12, pointerEvents:'none', zIndex:5, background:'rgba(255,255,255,.28)', backdropFilter:'blur(2px) saturate(1.03)', WebkitBackdropFilter:'blur(2px) saturate(1.03)'}}/>
+    <div
+      className="mockup-wrap"
+      style={{ display: 'grid', placeItems: 'center', padding: '24px' }}
+    >
+      <div
+        className="mockup-frame"
+        style={{
+          position: 'relative',
+          width: dim?.w ?? Math.min(MAX_W, 360),
+          height: dim?.h ?? 'auto',
+          background: '#f1f1f1',
+          borderRadius: 16,
+          padding: 12,
+          boxShadow: '0 0 0 2px rgba(255,255,255,0.25) inset',
+        }}
+      >
+        <img
+          src="/mockups/mousepad_base.png"
+          alt=""
+          style={{
+            position: 'absolute',
+            inset: 12,
+            width: 'calc(100% - 24px)',
+            height: 'calc(100% - 24px)',
+            objectFit: 'contain',
+            borderRadius: 12,
+          }}
+        />
+
+        <img
+          src={preview}
+          alt="Vista previa"
+          onLoad={handleImgLoad}
+          style={{
+            display: 'block',
+            width: '100%',
+            height: 'auto',
+            objectFit: 'contain',
+            borderRadius: 12,
+            imageRendering: 'auto',
+          }}
+        />
+
+        {isGlasspad && (
+          <div
+            aria-hidden
+            style={{
+              position: 'absolute',
+              inset: 12,
+              borderRadius: 12,
+              pointerEvents: 'none',
+              background: 'rgba(255,255,255,.28)',
+              backdropFilter: 'blur(2px) saturate(1.03)',
+              WebkitBackdropFilter: 'blur(2px) saturate(1.03)',
+            }}
+          />
         )}
       </div>
-      <div style={{marginTop:16, display:'flex', gap:8}}>
+
+      <div style={{ marginTop: 16, display: 'flex', gap: 24 }}>
         {!links && (
           <>
             <button onClick={() => navigate('/')}>Atrás</button>
-            <button onClick={handleCreateShopifyProduct} disabled={loading}>{loading ? 'Creando...' : 'Avanzar y comprar'}</button>
+            <button onClick={handleCreateShopifyProduct} disabled={loading}>
+              {loading ? 'Creando...' : 'Avanzar y comprar'}
+            </button>
           </>
         )}
         {links && (
           <>
-            <a href={links.product} target="_blank" rel="noopener noreferrer">Ver producto</a>
-            <a href={links.checkout} target="_blank" rel="noopener noreferrer">Ir a checkout</a>
+            <a
+              href={links.product}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Ver producto
+            </a>
+            <a
+              href={links.checkout}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Ir a checkout
+            </a>
           </>
         )}
       </div>
@@ -78,3 +174,4 @@ export default function Mockup() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- scale mockup container based on natural image dimensions
- export only pad group from Konva to preserve preview aspect ratio

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd mgm-front && npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b8f4f922ec832795b544d40fbb8e64