### PR TITLE
feat: base SEO setup with Spanish routes

### DIFF
--- a/docs/seo.md
+++ b/docs/seo.md
@@ -1,0 +1,13 @@
+# SEO
+
+Las metas principales se definen en `mgm-front/index.html`. Para editar los metadatos por página utiliza [`react-helmet`](https://github.com/nfl/react-helmet) dentro de cada componente en `src/pages`. Allí puedes cambiar `<title>`, `description`, `canonical` y etiquetas Open Graph/Twitter.
+
+El sitemap y `robots.txt` se encuentran en `mgm-front/public/`. Si agregas nuevas rutas actualiza `sitemap.xml` manualmente y vuelve a desplegar.
+
+Para regenerar o validar SEO ejecuta en el frontend:
+
+```bash
+npm run build
+```
+
+Esto generará los archivos estáticos listos para Vercel.

--- a/mgm-front/index.html
+++ b/mgm-front/index.html
@@ -1,11 +1,44 @@
 <!doctype html>
-<html lang="en">
+<html lang="es-AR">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/icons/icon-192.png" />
+    <link rel="manifest" href="/site.webmanifest" />
     <link rel="stylesheet" href="/src/index.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Tu Mousepad Personalizado — MGMGAMERS</title>
+    <meta
+      name="description"
+      content="Mousepad Profesionales Personalizados, Gamers, diseño y medida que quieras. Perfectos para gaming control y speed."
+    />
+    <link rel="canonical" href="https://www.mgmgamers.store" />
+    <meta property="og:title" content="Tu Mousepad Personalizado — MGMGAMERS" />
+    <meta
+      property="og:description"
+      content="Mousepad Profesionales Personalizados, Gamers, diseño y medida que quieras. Perfectos para gaming control y speed."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="MGMGAMERS" />
+    <meta property="og:url" content="https://www.mgmgamers.store" />
+    <meta property="og:image" content="/og/og-default.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Tu Mousepad Personalizado — MGMGAMERS" />
+    <meta
+      name="twitter:description"
+      content="Mousepad Profesionales Personalizados, Gamers, diseño y medida que quieras. Perfectos para gaming control y speed."
+    />
+    <meta name="twitter:image" content="/og/og-default.png" />
+    <!-- Google Analytics / GTM placeholder -->
+    <!--
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-XXXX');
+    </script>
+    -->
     <style>
       #initial-spinner {
         position: fixed;

--- a/mgm-front/package.json
+++ b/mgm-front/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^19.1.1",
     "react-konva": "^19.0.7",
     "react-router-dom": "^7.8.0",
+    "react-helmet": "^6.1.0",
     "use-image": "^1.1.4",
     "zod": "^4.0.17",
     "nsfwjs": "2.4.2",

--- a/mgm-front/public/icons/.gitkeep
+++ b/mgm-front/public/icons/.gitkeep
@@ -1,0 +1,1 @@
+# icons go here

--- a/mgm-front/public/og/.gitkeep
+++ b/mgm-front/public/og/.gitkeep
@@ -1,0 +1,1 @@
+# og images go here

--- a/mgm-front/public/robots.txt
+++ b/mgm-front/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Disallow: /api/
+Disallow: /admin/
+Disallow: /preview/
+Allow: /
+Sitemap: https://www.mgmgamers.store/sitemap.xml

--- a/mgm-front/public/site.webmanifest
+++ b/mgm-front/public/site.webmanifest
@@ -1,0 +1,12 @@
+{
+  "name": "MGMGAMERS",
+  "short_name": "MGMGAMERS",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/mgm-front/public/sitemap.xml
+++ b/mgm-front/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://www.mgmgamers.store/</loc></url>
+  <url><loc>https://www.mgmgamers.store/mousepads-personalizados</loc></url>
+  <url><loc>https://www.mgmgamers.store/como-funciona</loc></url>
+  <url><loc>https://www.mgmgamers.store/preguntas-frecuentes</loc></url>
+  <url><loc>https://www.mgmgamers.store/contacto</loc></url>
+</urlset>

--- a/mgm-front/src/App.jsx
+++ b/mgm-front/src/App.jsx
@@ -1,9 +1,11 @@
 import { Outlet } from 'react-router-dom';
 import styles from './App.module.css';
+import SeoJsonLd from './components/SeoJsonLd';
 
 export default function App() {
   return (
     <div className={styles.container}>
+      <SeoJsonLd />
       <header className={styles.header}>
         <strong>MGM GAMERS®</strong>
         <span>EDITOR</span>

--- a/mgm-front/src/components/SeoJsonLd.jsx
+++ b/mgm-front/src/components/SeoJsonLd.jsx
@@ -1,0 +1,47 @@
+import { Helmet } from 'react-helmet';
+
+const BASE_DATA = [
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "MGMGAMERS",
+    "url": "https://www.mgmgamers.store",
+    "logo": "/icons/icon-512.png",
+    "sameAs": ["https://www.instagram.com/mgmgamers.store"]
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "url": "https://www.mgmgamers.store",
+    "name": "MGMGAMERS"
+  }
+];
+
+export default function SeoJsonLd({ product, includeBase = true }) {
+  const data = [];
+  if (includeBase) data.push(...BASE_DATA);
+  if (product) {
+    data.push({
+      "@context": "https://schema.org",
+      "@type": "Product",
+      "name": "Mousepad Personalizado",
+      "brand": "MGMGAMERS",
+      "description": "Mousepad Profesionales Personalizados, Gamers, diseño y medida que quieras. Perfectos para gaming control y speed.",
+      "image": product.image,
+      "offers": {
+        "@type": "Offer",
+        "priceCurrency": "ARS",
+        "price": String(product.price ?? 0),
+        "availability": "https://schema.org/InStock"
+      }
+    });
+  }
+  if (!data.length) return null;
+  return (
+    <Helmet>
+      <script type="application/ld+json">
+        {JSON.stringify(data.length === 1 ? data[0] : data)}
+      </script>
+    </Helmet>
+  );
+}

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -9,6 +9,10 @@ import Result from './pages/Result.jsx';
 import DevRenderPreview from './pages/DevRenderPreview.jsx';
 import DevCanvasPreview from './pages/DevCanvasPreview.jsx';
 import Mockup from './pages/Mockup.jsx';
+import MousepadsPersonalizados from './pages/MousepadsPersonalizados.jsx';
+import ComoFunciona from './pages/ComoFunciona.jsx';
+import PreguntasFrecuentes from './pages/PreguntasFrecuentes.jsx';
+import Contacto from './pages/Contacto.jsx';
 import { OrderFlowProvider } from './store/orderFlow';
 import './globals.css';
 
@@ -17,6 +21,10 @@ const routes = [
     element: <App />,
     children: [
       { path: '/', element: <Home /> },
+      { path: '/mousepads-personalizados', element: <MousepadsPersonalizados /> },
+      { path: '/como-funciona', element: <ComoFunciona /> },
+      { path: '/preguntas-frecuentes', element: <PreguntasFrecuentes /> },
+      { path: '/contacto', element: <Contacto /> },
       { path: '/confirm', element: <Confirm /> },
       { path: '/mockup', element: <Mockup /> },
       { path: '/creating/:jobId', element: <Creating /> },

--- a/mgm-front/src/pages/ComoFunciona.jsx
+++ b/mgm-front/src/pages/ComoFunciona.jsx
@@ -1,0 +1,18 @@
+import { Helmet } from 'react-helmet';
+
+export default function ComoFunciona() {
+  const title = 'Cómo funciona — MGMGAMERS';
+  const description = 'Explicación del proceso para crear tu mousepad personalizado.';
+  const url = 'https://www.mgmgamers.store/como-funciona';
+  return (
+    <>
+      <Helmet>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <link rel="canonical" href={url} />
+      </Helmet>
+      <h1>Cómo funciona</h1>
+      <p>Próximamente la explicación del proceso.</p>
+    </>
+  );
+}

--- a/mgm-front/src/pages/Contacto.jsx
+++ b/mgm-front/src/pages/Contacto.jsx
@@ -1,0 +1,18 @@
+import { Helmet } from 'react-helmet';
+
+export default function Contacto() {
+  const title = 'Contacto — MGMGAMERS';
+  const description = 'Ponte en contacto con MGMGAMERS para tus mousepads personalizados.';
+  const url = 'https://www.mgmgamers.store/contacto';
+  return (
+    <>
+      <Helmet>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <link rel="canonical" href={url} />
+      </Helmet>
+      <h1>Contacto</h1>
+      <p>Próximamente información de contacto.</p>
+    </>
+  );
+}

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -1,6 +1,7 @@
 // src/pages/Home.jsx
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
 
 import UploadStep from '../components/UploadStep';
 import EditorCanvas from '../components/EditorCanvas';
@@ -180,8 +181,16 @@ export default function Home() {
   }
 
 
+  const title = 'Tu Mousepad Personalizado — MGMGAMERS';
+  const description = 'Mousepad Profesionales Personalizados, Gamers, diseño y medida que quieras. Perfectos para gaming control y speed.';
+  const url = 'https://www.mgmgamers.store/';
   return (
     <div className={styles.container}>
+      <Helmet>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <link rel="canonical" href={url} />
+      </Helmet>
       <div className={styles.sidebar}>
         {uploaded && (
           <>

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
 import { useOrderFlow } from '../store/orderFlow';
+import SeoJsonLd from '../components/SeoJsonLd';
 
 const MAX_W = 720;
 const MAX_H = 520;
@@ -87,6 +89,11 @@ export default function Mockup() {
       className="mockup-wrap"
       style={{ display: 'grid', placeItems: 'center', padding: '24px' }}
     >
+      <Helmet>
+        <title>Vista previa del producto — MGMGAMERS</title>
+        <link rel="canonical" href="https://www.mgmgamers.store/mockup" />
+      </Helmet>
+      <SeoJsonLd product={{ image: preview, price: 0 }} includeBase={false} />
       <div
         className="mockup-frame"
         style={{
@@ -101,7 +108,7 @@ export default function Mockup() {
       >
         <img
           src="/mockups/mousepad_base.png"
-          alt=""
+          alt="Base de mousepad para vista previa"
           style={{
             position: 'absolute',
             inset: 12,

--- a/mgm-front/src/pages/MousepadsPersonalizados.jsx
+++ b/mgm-front/src/pages/MousepadsPersonalizados.jsx
@@ -1,0 +1,28 @@
+import { Helmet } from 'react-helmet';
+
+export default function MousepadsPersonalizados() {
+  const title = 'Mousepads Profesionales Personalizados — MGMGAMERS';
+  const description = 'Mousepad Profesionales Personalizados, Gamers, diseño y medida que quieras. Perfectos para gaming control y speed.';
+  const url = 'https://www.mgmgamers.store/mousepads-personalizados';
+  return (
+    <>
+      <Helmet>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <link rel="canonical" href={url} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="MGMGAMERS" />
+        <meta property="og:url" content={url} />
+        <meta property="og:image" content="/og/og-default.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content="/og/og-default.png" />
+      </Helmet>
+      <h1>Mousepads Profesionales Personalizados</h1>
+      <p>Próximamente contenido del catálogo.</p>
+    </>
+  );
+}

--- a/mgm-front/src/pages/PreguntasFrecuentes.jsx
+++ b/mgm-front/src/pages/PreguntasFrecuentes.jsx
@@ -1,0 +1,18 @@
+import { Helmet } from 'react-helmet';
+
+export default function PreguntasFrecuentes() {
+  const title = 'Preguntas frecuentes — MGMGAMERS';
+  const description = 'Respuestas a dudas comunes sobre nuestros mousepads personalizados.';
+  const url = 'https://www.mgmgamers.store/preguntas-frecuentes';
+  return (
+    <>
+      <Helmet>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <link rel="canonical" href={url} />
+      </Helmet>
+      <h1>Preguntas frecuentes</h1>
+      <p>Próximamente preguntas y respuestas.</p>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- configure index.html with canonical, OG/Twitter metadata and GA placeholder
- add SEO helpers, JSON-LD, sitemap/robots and Spanish info pages
- inject product structured data and alt text for mockup preview

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f692ef3c832789920e77f31e23d3