### PR TITLE
feat: migrate to react-helmet-async

### DIFF
--- a/docs/seo.md
+++ b/docs/seo.md
@@ -1,6 +1,6 @@
 # SEO
 
-Las metas principales se definen en `mgm-front/index.html`. Para editar los metadatos por página utiliza [`react-helmet`](https://github.com/nfl/react-helmet) dentro de cada componente en `src/pages`. Allí puedes cambiar `<title>`, `description`, `canonical` y etiquetas Open Graph/Twitter.
+Las metas principales se definen en `mgm-front/index.html`. Para editar los metadatos por página utiliza [`react-helmet-async`](https://github.com/staylor/react-helmet-async) dentro de cada componente en `src/pages`. Allí puedes cambiar `<title>`, `description`, `canonical` y etiquetas Open Graph/Twitter.
 
 El sitemap y `robots.txt` se encuentran en `mgm-front/public/`. Si agregas nuevas rutas actualiza `sitemap.xml` manualmente y vuelve a desplegar.
 

--- a/mgm-front/package.json
+++ b/mgm-front/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^19.1.1",
     "react-konva": "^19.0.7",
     "react-router-dom": "^7.8.0",
-    "react-helmet": "^6.1.0",
+    "react-helmet-async": "^1.3.0",
     "use-image": "^1.1.4",
     "zod": "^4.0.17",
     "nsfwjs": "2.4.2",

--- a/mgm-front/src/components/SeoJsonLd.jsx
+++ b/mgm-front/src/components/SeoJsonLd.jsx
@@ -1,47 +1,60 @@
-import { Helmet } from 'react-helmet';
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
 
-const BASE_DATA = [
-  {
-    "@context": "https://schema.org",
-    "@type": "Organization",
-    "name": "MGMGAMERS",
-    "url": "https://www.mgmgamers.store",
-    "logo": "/icons/icon-512.png",
-    "sameAs": ["https://www.instagram.com/mgmgamers.store"]
-  },
-  {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    "url": "https://www.mgmgamers.store",
-    "name": "MGMGAMERS"
-  }
-];
+const BASE = {
+  siteName: 'MGMGAMERS',
+  canonical: 'https://www.mgmgamers.store',
+  title: 'Tu Mousepad Personalizado — MGMGAMERS',
+  description:
+    'Mousepad Profesionales Personalizados, Gamers, diseño y medida que quieras. Perfectos para gaming control y speed.',
+  ogImage: '/og/og-default.png',
+  locale: 'es_AR'
+};
 
-export default function SeoJsonLd({ product, includeBase = true }) {
-  const data = [];
-  if (includeBase) data.push(...BASE_DATA);
-  if (product) {
-    data.push({
-      "@context": "https://schema.org",
-      "@type": "Product",
-      "name": "Mousepad Personalizado",
-      "brand": "MGMGAMERS",
-      "description": "Mousepad Profesionales Personalizados, Gamers, diseño y medida que quieras. Perfectos para gaming control y speed.",
-      "image": product.image,
-      "offers": {
-        "@type": "Offer",
-        "priceCurrency": "ARS",
-        "price": String(product.price ?? 0),
-        "availability": "https://schema.org/InStock"
-      }
-    });
-  }
-  if (!data.length) return null;
+export default function SeoJsonLd({
+  title = BASE.title,
+  description = BASE.description,
+  canonical = BASE.canonical,
+  ogImage = BASE.ogImage,
+  noIndex = false,
+  jsonLd = null
+}) {
+  const ld = jsonLd ? JSON.stringify(jsonLd) : null;
+
   return (
-    <Helmet>
-      <script type="application/ld+json">
-        {JSON.stringify(data.length === 1 ? data[0] : data)}
-      </script>
-    </Helmet>
+    <>
+      <Helmet prioritizeSeoTags>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <link rel="canonical" href={canonical} />
+        {noIndex && <meta name="robots" content="noindex,nofollow" />}
+
+        {/* Open Graph */}
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content={BASE.siteName} />
+        <meta property="og:locale" content={BASE.locale} />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:url" content={canonical} />
+        <meta property="og:image" content={ogImage} />
+
+        {/* Twitter */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={ogImage} />
+
+        {/* Idioma */}
+        <html lang="es-AR" />
+      </Helmet>
+
+      {ld && (
+        <script
+          type="application/ld+json"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: ld }}
+        />
+      )}
+    </>
   );
 }

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -15,6 +15,7 @@ import PreguntasFrecuentes from './pages/PreguntasFrecuentes.jsx';
 import Contacto from './pages/Contacto.jsx';
 import { OrderFlowProvider } from './store/orderFlow';
 import './globals.css';
+import { HelmetProvider } from 'react-helmet-async';
 
 const routes = [
   {
@@ -42,8 +43,10 @@ const router = createBrowserRouter(routes);
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <OrderFlowProvider>
-      <RouterProvider router={router} />
-    </OrderFlowProvider>
+    <HelmetProvider>
+      <OrderFlowProvider>
+        <RouterProvider router={router} />
+      </OrderFlowProvider>
+    </HelmetProvider>
   </React.StrictMode>
 );

--- a/mgm-front/src/pages/ComoFunciona.jsx
+++ b/mgm-front/src/pages/ComoFunciona.jsx
@@ -1,4 +1,4 @@
-import { Helmet } from 'react-helmet';
+import SeoJsonLd from '../components/SeoJsonLd';
 
 export default function ComoFunciona() {
   const title = 'Cómo funciona — MGMGAMERS';
@@ -6,11 +6,18 @@ export default function ComoFunciona() {
   const url = 'https://www.mgmgamers.store/como-funciona';
   return (
     <>
-      <Helmet>
-        <title>{title}</title>
-        <meta name="description" content={description} />
-        <link rel="canonical" href={url} />
-      </Helmet>
+      <SeoJsonLd
+        title={title}
+        description={description}
+        canonical={url}
+        jsonLd={{
+          '@context': 'https://schema.org',
+          '@type': 'Organization',
+          name: 'MGMGAMERS',
+          url: 'https://www.mgmgamers.store',
+          sameAs: ['https://www.instagram.com/mgmgamers.store']
+        }}
+      />
       <h1>Cómo funciona</h1>
       <p>Próximamente la explicación del proceso.</p>
     </>

--- a/mgm-front/src/pages/Contacto.jsx
+++ b/mgm-front/src/pages/Contacto.jsx
@@ -1,4 +1,4 @@
-import { Helmet } from 'react-helmet';
+import SeoJsonLd from '../components/SeoJsonLd';
 
 export default function Contacto() {
   const title = 'Contacto — MGMGAMERS';
@@ -6,11 +6,18 @@ export default function Contacto() {
   const url = 'https://www.mgmgamers.store/contacto';
   return (
     <>
-      <Helmet>
-        <title>{title}</title>
-        <meta name="description" content={description} />
-        <link rel="canonical" href={url} />
-      </Helmet>
+      <SeoJsonLd
+        title={title}
+        description={description}
+        canonical={url}
+        jsonLd={{
+          '@context': 'https://schema.org',
+          '@type': 'Organization',
+          name: 'MGMGAMERS',
+          url: 'https://www.mgmgamers.store',
+          sameAs: ['https://www.instagram.com/mgmgamers.store']
+        }}
+      />
       <h1>Contacto</h1>
       <p>Próximamente información de contacto.</p>
     </>

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -1,7 +1,7 @@
 // src/pages/Home.jsx
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Helmet } from 'react-helmet';
+import SeoJsonLd from '../components/SeoJsonLd';
 
 import UploadStep from '../components/UploadStep';
 import EditorCanvas from '../components/EditorCanvas';
@@ -186,11 +186,18 @@ export default function Home() {
   const url = 'https://www.mgmgamers.store/';
   return (
     <div className={styles.container}>
-      <Helmet>
-        <title>{title}</title>
-        <meta name="description" content={description} />
-        <link rel="canonical" href={url} />
-      </Helmet>
+      <SeoJsonLd
+        title={title}
+        description={description}
+        canonical={url}
+        jsonLd={{
+          '@context': 'https://schema.org',
+          '@type': 'Organization',
+          name: 'MGMGAMERS',
+          url: 'https://www.mgmgamers.store',
+          sameAs: ['https://www.instagram.com/mgmgamers.store']
+        }}
+      />
       <div className={styles.sidebar}>
         {uploaded && (
           <>

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Helmet } from 'react-helmet';
 import { useOrderFlow } from '../store/orderFlow';
 import SeoJsonLd from '../components/SeoJsonLd';
 
@@ -89,11 +88,25 @@ export default function Mockup() {
       className="mockup-wrap"
       style={{ display: 'grid', placeItems: 'center', padding: '24px' }}
     >
-      <Helmet>
-        <title>Vista previa del producto — MGMGAMERS</title>
-        <link rel="canonical" href="https://www.mgmgamers.store/mockup" />
-      </Helmet>
-      <SeoJsonLd product={{ image: preview, price: 0 }} includeBase={false} />
+      <SeoJsonLd
+        title="Vista previa del producto — MGMGAMERS"
+        canonical="https://www.mgmgamers.store/mockup"
+        jsonLd={{
+          '@context': 'https://schema.org',
+          '@type': 'Product',
+          name: 'Mousepad Personalizado',
+          brand: 'MGMGAMERS',
+          description:
+            'Mousepad Profesionales Personalizados, Gamers, diseño y medida que quieras. Perfectos para gaming control y speed.',
+          image: preview,
+          offers: {
+            '@type': 'Offer',
+            priceCurrency: 'ARS',
+            price: '0',
+            availability: 'https://schema.org/InStock'
+          }
+        }}
+      />
       <div
         className="mockup-frame"
         style={{

--- a/mgm-front/src/pages/MousepadsPersonalizados.jsx
+++ b/mgm-front/src/pages/MousepadsPersonalizados.jsx
@@ -1,4 +1,4 @@
-import { Helmet } from 'react-helmet';
+import SeoJsonLd from '../components/SeoJsonLd';
 
 export default function MousepadsPersonalizados() {
   const title = 'Mousepads Profesionales Personalizados — MGMGAMERS';
@@ -6,21 +6,18 @@ export default function MousepadsPersonalizados() {
   const url = 'https://www.mgmgamers.store/mousepads-personalizados';
   return (
     <>
-      <Helmet>
-        <title>{title}</title>
-        <meta name="description" content={description} />
-        <link rel="canonical" href={url} />
-        <meta property="og:title" content={title} />
-        <meta property="og:description" content={description} />
-        <meta property="og:type" content="website" />
-        <meta property="og:site_name" content="MGMGAMERS" />
-        <meta property="og:url" content={url} />
-        <meta property="og:image" content="/og/og-default.png" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={title} />
-        <meta name="twitter:description" content={description} />
-        <meta name="twitter:image" content="/og/og-default.png" />
-      </Helmet>
+      <SeoJsonLd
+        title={title}
+        description={description}
+        canonical={url}
+        jsonLd={{
+          '@context': 'https://schema.org',
+          '@type': 'Organization',
+          name: 'MGMGAMERS',
+          url: 'https://www.mgmgamers.store',
+          sameAs: ['https://www.instagram.com/mgmgamers.store']
+        }}
+      />
       <h1>Mousepads Profesionales Personalizados</h1>
       <p>Próximamente contenido del catálogo.</p>
     </>

--- a/mgm-front/src/pages/PreguntasFrecuentes.jsx
+++ b/mgm-front/src/pages/PreguntasFrecuentes.jsx
@@ -1,4 +1,4 @@
-import { Helmet } from 'react-helmet';
+import SeoJsonLd from '../components/SeoJsonLd';
 
 export default function PreguntasFrecuentes() {
   const title = 'Preguntas frecuentes — MGMGAMERS';
@@ -6,11 +6,18 @@ export default function PreguntasFrecuentes() {
   const url = 'https://www.mgmgamers.store/preguntas-frecuentes';
   return (
     <>
-      <Helmet>
-        <title>{title}</title>
-        <meta name="description" content={description} />
-        <link rel="canonical" href={url} />
-      </Helmet>
+      <SeoJsonLd
+        title={title}
+        description={description}
+        canonical={url}
+        jsonLd={{
+          '@context': 'https://schema.org',
+          '@type': 'Organization',
+          name: 'MGMGAMERS',
+          url: 'https://www.mgmgamers.store',
+          sameAs: ['https://www.instagram.com/mgmgamers.store']
+        }}
+      />
       <h1>Preguntas frecuentes</h1>
       <p>Próximamente preguntas y respuestas.</p>
     </>


### PR DESCRIPTION
## Summary
- replace react-helmet with react-helmet-async
- wrap app in HelmetProvider and centralize SEO tags
- document use of react-helmet-async

## Testing
- `npm i` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-helmet-async)*
- `npm run dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b900a7a6ac83279dee5c41394ce65d