### PR TITLE
fix(vercel): enforce v2 config and nodejs20.x runtime (remove legacy)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "packageManager": "npm@10",
   "scripts": {
     "build": "cd mgm-front && npm ci && npm run build",
-    "doctor:vercel": "node -e \"try{console.log(require('./vercel.json'))}catch(e){console.log('NO vercel.json en root')}\"",
-    "find:legacy": "git ls-files \"**/vercel.json\" | xargs -I{} bash -lc 'echo --- {}; grep -nE \"\\b(builds|routes)\\b\" {} || true'; test -f now.json && echo 'tiene now.json' && true || true",
-    "find:bad-runtime": "git grep -nE '\"runtime\"\\s*:\\s*\"nodejs(?!20\\.x)\"' -- **/vercel.json package.json || true",
+    "doctor:vercel": "node -e \"console.log(require('./vercel.json'))\"",
+    "find:legacy": "git grep -nE '\"version\"\\s*:\\s*1|\"(builds|routes)\"' -- **/vercel.json || true",
     "find:file-runtime": "git grep -nE 'export const config\\s*=\\s*\\{\\s*runtime' -- api || true",
+    "find:now": "git grep -n 'now-' -- . || true",
     "lint": "eslint .",
     "format": "prettier -w .",
     "doctor:env": "node -e \"console.log(process.version)\"",

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "framework": null,
   "functions": {
     "api/**/*.ts": { "runtime": "nodejs20.x", "memory": 512, "maxDuration": 15 },


### PR DESCRIPTION
## Summary
- force Vercel config v2 with Node.js 20 for all API functions
- add scripts to detect legacy or Now configs

## Testing
- `npm run doctor:vercel`
- `npm run find:legacy`
- `npm run find:file-runtime`
- `npm run find:now`


------
https://chatgpt.com/codex/tasks/task_e_68b9dbeeda348327aca2596c94a4aaf3