### PR TITLE
fix(vercel): salir de legacy (v2) y forzar nodejs20.x en funciones

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   "scripts": {
     "build": "cd mgm-front && npm ci && npm run build",
     "doctor:vercel": "node -e \"console.log(require('./vercel.json'))\"",
-    "find:legacy": "git grep -nE '\"version\"\\s*:\\s*1|\"(builds|routes)\"' -- **/vercel.json || true",
+    "find:legacy": "git grep -nE '\"version\"\\s*:\\s*1|\"(builds|routes)\"|\"use\"\\s*:\\s*\".*now-' -- **/vercel.json || true",
     "find:file-runtime": "git grep -nE 'export const config\\s*=\\s*\\{\\s*runtime' -- api || true",
-    "find:now": "git grep -n 'now-' -- . || true",
+    "find:now-key": "git grep -nE '\"now\"\\s*:' -- **/package.json || true",
+    "find:php": "git ls-files | grep -iE '\\.php$' || true",
     "lint": "eslint .",
     "format": "prettier -w .",
     "doctor:env": "node -e \"console.log(process.version)\"",


### PR DESCRIPTION
## Summary
- ensure only modern `vercel.json` (v2) with nodejs20.x runtimes
- add scripts to detect legacy Now/V1 configs and file runtimes

## Testing
- `npm run doctor:vercel`
- `npm run find:legacy`
- `npm run find:file-runtime`
- `npm run find:now-key`
- `npm run find:php`
- `vercel link --confirm` *(login required, failed)*
- `vercel build --prod --debug` *(canceled: missing project settings)*

## Audit
```bash
$ git ls-files "**/vercel.json"
# (no output)

$ git grep -nE '"version"\s*:\s*1' -- **/vercel.json || true
# (no output)

$ git grep -nE '"(builds|routes)"' -- **/vercel.json || true
# (no output)

$ git grep -nE '"use"\s*:\s*".*now-' -- **/vercel.json || true
# (no output)

$ git grep -n "now-" -- . || true
# (no output)

$ git grep -nE '"now"\s*:' -- **/package.json || true
# (no output)

$ git ls-files | grep -iE '\.php$' || true
# (no output)

$ git grep -nE 'export const config\s*=\s*\{\s*runtime' -- api || true
# (no output)
```

## Scripts
```bash
$ npm run doctor:vercel
{ version: 2, framework: null, functions: { 'api/**/*.ts': { runtime: 'nodejs20.x', memory: 512, maxDuration: 15 }, 'api/**/*.js': { runtime: 'nodejs20.x', memory: 512, maxDuration: 15 } } }

$ npm run find:legacy
# (no output)

$ npm run find:file-runtime
# (no output)

$ npm run find:now-key
# (no output)

$ npm run find:php
# (no output)
```

## Vercel CLI
```bash
$ vercel link --confirm
> No existing credentials found. Please log in (interactive prompt).

$ vercel build --prod --debug
> No Project Settings found locally. Run `vercel pull` for retrieving them?
```


------
https://chatgpt.com/codex/tasks/task_e_68b9e116a6e48327b55c0b09b0cf6359