### PR TITLE
fix(vercel): config moderna v2 + Node 20 (ignorar front en build de API)

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,6 @@
+*
+!vercel.json
+!api/**
+!lib/**
+!package.json
+!package-lock.json

--- a/api/healthcheck.js
+++ b/api/healthcheck.js
@@ -1,12 +1,3 @@
-﻿export default async function handler(req, res) {
-  try {
-    return res.status(200).json({
-      ok: true,
-      runtime: "nodejs20.x",
-      node: process.version,
-      ts: Date.now()
-    });
-  } catch (e) {
-    return res.status(500).json({ ok: false, error: e?.message || "unknown" });
-  }
-}
+module.exports = (req, res) => {
+  res.status(200).json({ ok: true, note: "serverless up", ts: Date.now() });
+};

--- a/docs/vercel.md
+++ b/docs/vercel.md
@@ -1,10 +1,5 @@
-# Vercel deployment
+Este proyecto (APIs) se despliega desde la RAÍZ.
 
-Este proyecto utiliza **Node.js 20** para las funciones en `/api/**` y un frontend Vite en `mgm-front`.
+En Vercel → Framework: "Other", Build Command: vacío o `echo no-build`, Output Directory: `.`, Node.js: 20.x.
 
-- **Root Directory:** raíz del repo (`.`)
-- **Install Command:** `npm install`
-- **Build Command:** `npm run build`
-- **Output Directory:** `mgm-front/dist`
-
-El archivo `vercel.json` en la raíz define `nodejs20.x` como runtime para todas las funciones.
+Recomendación: separar Front (proyecto aparte con Root = mgm-front) para evitar conflictos.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "cd mgm-front && npm ci && npm run build",
     "doctor:vercel": "node -e \"console.log(require('./vercel.json'))\"",
-    "find:legacy": "git grep -nE '\"version\"\\s*:\\s*1|\"(builds|routes)\"' -- **/vercel.json || true",
+    "find:legacy": "git grep -nE '\"version\"\\s*:\\s*1|\"(builds|routes)\"|now-' -- **/vercel.json || true",
     "find:file-runtime": "git grep -nE 'export const config\\s*=\\s*\\{\\s*runtime' -- api || true",
     "find:now": "git grep -n 'now-' -- . || true",
     "lint": "eslint .",

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,3 @@
 {
-  "version": 2,
-  "framework": null,
-  "functions": {
-    "api/**/*.ts": { "runtime": "nodejs20.x", "memory": 512, "maxDuration": 15 },
-    "api/**/*.js": { "runtime": "nodejs20.x", "memory": 512, "maxDuration": 15 }
-  }
+  "version": 2
 }


### PR DESCRIPTION
## Summary
- simplify root `vercel.json` to version 2 only and ensure Node 20 engine
- restrict Vercel packaging via `.vercelignore`
- add `/api/healthcheck` endpoint and document deployment setup

## Testing
- `npm run doctor:vercel`
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> mgm-api@0.1.0 doctor:vercel
> node -e "console.log(require('./vercel.json'))"

{ version: 2 }
```
- `npm run find:legacy`
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> mgm-api@0.1.0 find:legacy
> git grep -nE '"version"\s*:\s*1|"(builds|routes)"|now-' -- **/vercel.json || true
```
- `npm run find:file-runtime`
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> mgm-api@0.1.0 find:file-runtime
> git grep -nE 'export const config\s*=\s*\{\s*runtime' -- api || true
```


------
https://chatgpt.com/codex/tasks/task_e_68b9feffa3508327afd832dd8ef47384