### PR TITLE
fix(vercel): desactivar build del front en proyecto de APIs

### DIFF
--- a/docs/vercel.md
+++ b/docs/vercel.md
@@ -1,5 +1,9 @@
-Este proyecto (APIs) se despliega desde la RAÍZ.
+Este proyecto (APIs) se despliega desde la **raíz**.
 
-En Vercel → Framework: "Other", Build Command: vacío o `echo no-build`, Output Directory: `.`, Node.js: 20.x.
+En Vercel configura:
+- Framework: "Other"
+- Build Command: vacío o `npm run vercel-build`
+- Output Directory: `.`
+- Node.js: 20.x
 
-Recomendación: separar Front (proyecto aparte con Root = mgm-front) para evitar conflictos.
+El front (`mgm-front`) se despliega en otro proyecto con Root Directory=`mgm-front`.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "packageManager": "npm@10",
   "scripts": {
-    "build": "cd mgm-front && npm ci && npm run build",
+    "vercel-build": "echo no-build",
+    "build": "echo no-build",
     "doctor:vercel": "node -e \"console.log(require('./vercel.json'))\"",
     "find:legacy": "git grep -nE '\"version\"\\s*:\\s*1|\"(builds|routes)\"|now-' -- **/vercel.json || true",
     "find:file-runtime": "git grep -nE 'export const config\\s*=\\s*\\{\\s*runtime' -- api || true",


### PR DESCRIPTION
## Summary
- replace root build script with no-op and add `vercel-build`
- document Vercel setup for API-only deploys

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8')); console.log('vercel.json OK')"`
- `cat package.json` (scripts + engines)
- `cat .vercelignore`
- `grep -Rni "export const config = { runtime" api || true`


------
https://chatgpt.com/codex/tasks/task_e_68ba03a3d1e88327bd329424c5bf48e3