### PR TITLE
fix(vercel): API-only build (output '.', no-build) + Node 20

### DIFF
--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,0 +1,7 @@
+{
+  "settings": {
+    "framework": null,
+    "buildCommand": "",
+    "outputDirectory": "."
+  }
+}

--- a/docs/vercel.md
+++ b/docs/vercel.md
@@ -2,7 +2,7 @@ Este proyecto (APIs) se despliega desde la **raíz**.
 
 En Vercel configura:
 - Framework: "Other"
-- Build Command: vacío o `npm run vercel-build`
+- Build Command: (vacío)
 - Output Directory: `.`
 - Node.js: 20.x
 


### PR DESCRIPTION
## Summary
- add `.vercel/project.json` to force API-only build with output `.` and no build step
- document Vercel settings noting separate `mgm-front` deployment

## Validation
- `cat vercel.json`
```json
{
  "version": 2
}
```
- `jq '{scripts, engines}' package.json`
```json
{
  "scripts": {
    "vercel-build": "echo no-build",
    "build": "echo no-build",
    "doctor:vercel": "node -e \"console.log(require('./vercel.json'))\"",
    "find:legacy": "git grep -nE '\"version\"\\s*:\\s*1|\"(builds|routes)\"|now-' -- **/vercel.json || true",
    "find:file-runtime": "git grep -nE 'export const config\\s*=\\s*\\{\\s*runtime' -- api || true",
    "find:now": "git grep -n 'now-' -- . || true",
    "lint": "eslint .",
    "format": "prettier -w .",
    "doctor:env": "node -e \"console.log(process.version)\"",
    "doctor:imports": "grep -RniE \"from '(/|.*\\\\.ts')\" --include=*.{ts,tsx,js,jsx} . || true",
    "doctor:big": "git diff --name-only main...HEAD | xargs -I{} bash -lc 'test -f {} && wc -c <{} || true' | awk '{sum+=$1} END {printf \"Total bytes: %d\\n\", sum}'",
    "doctor:ignored": "git check-ignore -v dist build .next .cache coverage || true"
  },
  "engines": {
    "node": "20.x"
  }
}
```
- `cat .vercelignore`
```
*
!vercel.json
!api/**
!lib/**
!package.json
!package-lock.json
```
- `rg "config\.runtime" -n api` → no results
- `npm test` → missing script: "test"

> After merging, redeploy in Vercel with **Clear build cache**.


------
https://chatgpt.com/codex/tasks/task_e_68ba0678dec883279a02b178887abd66