### PR TITLE
fix(vercel): destrabar build agregando public mínima; recomendado Output "." en dashboard

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -4,3 +4,4 @@
 !lib/**
 !package.json
 !package-lock.json
+!public/**

--- a/docs/vercel.md
+++ b/docs/vercel.md
@@ -2,8 +2,9 @@ Este proyecto (APIs) se despliega desde la **raíz**.
 
 En Vercel configura:
 - Framework: "Other"
-- Build Command: (vacío)
-- Output Directory: `.`
+- Build Command: (vacío) o `npm run vercel-build`
+- Output Directory recomendado: `.`
 - Node.js: 20.x
+- Mientras el Output Directory en el Dashboard siga en `public`, la carpeta mínima `public/` evita el error.
 
 El front (`mgm-front`) se despliega en otro proyecto con Root Directory=`mgm-front`.

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="es">
+  <head><meta charset="utf-8"><title>MGM API</title></head>
+  <body>OK</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,1 @@
-{
-  "version": 2
-}
+{ "version": 2 }


### PR DESCRIPTION
## Summary
- permite carpeta `public/` y añade `index.html` mínimo para evitar error de Vercel
- documenta configuración recomendada del proyecto API en Vercel (Output `.`)

## Testing
- `npm test` *(missing script: "test")*
- `npm run lint` *(ESLint couldn't find a configuration file)*

Tras merge: hacer **Redeploy → Clear build cache**.
(Opcional) Ajustar **Output Directory** a `.` en Project Settings para eliminar la necesidad de `/public`. 

------
https://chatgpt.com/codex/tasks/task_e_68ba0a43fbcc83278775511064ac6232