### PR TITLE
fix(vercel): destrabar build creando public/index.html; recomendado Output "." en dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "packageManager": "npm@10",
   "scripts": {
-    "vercel-build": "echo no-build",
-    "build": "echo no-build",
+    "vercel-build": "mkdir -p public && echo OK > public/index.html && echo no-build",
+    "build": "mkdir -p public && echo OK > public/index.html && echo no-build",
     "doctor:vercel": "node -e \"console.log(require('./vercel.json'))\"",
     "find:legacy": "git grep -nE '\"version\"\\s*:\\s*1|\"(builds|routes)\"|now-' -- **/vercel.json || true",
     "find:file-runtime": "git grep -nE 'export const config\\s*=\\s*\\{\\s*runtime' -- api || true",


### PR DESCRIPTION
## Summary
- crea script de build no-op que genera placeholder en public/index.html

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

Tras merge, en Vercel hacer **Redeploy → Clear build cache**.

------
https://chatgpt.com/codex/tasks/task_e_68ba0cd656cc8327b92fd608b415c7a6