### PR TITLE
feat(moderation): nazi symbol detection via OCR + in-memory SVG dHash (no binaries)

### DIFF
--- a/api/moderate-image.js
+++ b/api/moderate-image.js
@@ -1,7 +1,10 @@
 
 import { withCors } from '../lib/cors.js';
 import { checkNSFW } from '../lib/moderation/nsfw.js';
-import { checkHate } from '../lib/moderation/hate.js';
+import { checkHate, initHateTemplates } from '../lib/moderation/hate.js';
+
+// precalentar plantillas de odio, pero no abortar si falla
+initHateTemplates().catch(() => {});
 
 function toBufferFromDataUrl(dataUrl) {
   const m = /^data:(.+?);base64,(.+)$/.exec(dataUrl || '');

--- a/lib/moderation/hate.js
+++ b/lib/moderation/hate.js
@@ -1,43 +1,74 @@
 import sharp from 'sharp';
 import { createWorker } from 'tesseract.js';
 
-// Palabras clave de odio/racismo (minúsculas)
-const HATE_WORDS = [
-  'nazi',
-  'swastika',
-  'esvastica',
-  'hitler',
-  'kkk',
-  'heil',
-  'ss-totenkopf',
-  'white power',
-  'wpww',
-  '1488',
-  '14/88',
-  'sieg heil'
+// --- Normalización texto ---
+const LEET = new Map(Object.entries({ '0':'o','1':'i','3':'e','4':'a','5':'s','7':'t','8':'b' }));
+export function normalizeText(s = '') {
+  s = s.normalize('NFKD').toLowerCase();
+  s = s.replace(/[\u0300-\u036f]/g, ''); // quitar diacríticos
+  s = s.replace(/[^a-z0-9]+/g, ''); // quitar espacios/puntuación
+  s = s.replace(/[0134578]/g, (c) => LEET.get(c) || c); // leet básico
+  s = s.replace(/(.)\1+/g, '$1'); // colapsar repeticiones
+  return s;
+}
+
+export const HATE_WORDS = [
+  'nazi','swastika','esvastica','siegheil','heilhitler','hitler','kkk',
+  'whitepower','wpww','1488','14','88','schutzstaffel','ss'
 ];
 
-async function dHash(buffer) {
-  const { data } = await sharp(buffer)
+// --- OCR (worker cacheado) ---
+let _worker;
+async function getWorker() {
+  if (_worker) return _worker;
+  _worker = await createWorker('eng+deu+spa', 1, { gzip: false });
+  return _worker;
+}
+export async function ocrHasHate(buffer, timeout = 5000) {
+  try {
+    const worker = await getWorker();
+    const p = worker.recognize(buffer, { preserve_interword_spaces: 1 });
+    const res = await Promise.race([
+      p,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), timeout))
+    ]);
+    const { data: { text = '' } = {} } = res || {};
+    const t = normalizeText(text);
+    return HATE_WORDS.some((w) => t.includes(w));
+  } catch {
+    return false;
+  }
+}
+
+// --- dHash util ---
+async function toGray(buffer, size = 128) {
+  return await sharp(buffer)
+    .resize(size, size, { fit: 'fill' })
     .grayscale()
-    .resize(9, 8, { fit: 'fill' })
+    .threshold(128, { grayscale: true })
     .raw()
     .toBuffer({ resolveWithObject: true });
+}
+function dHashFromRaw({ data, info }) {
+  const w = info.width, h = info.height;
+  const rx = 9, ry = 8;
+  const sx = (w - 1) / (rx - 1), sy = h / ry;
   let bits = '';
-  for (let y = 0; y < 8; y++) {
-    for (let x = 0; x < 8; x++) {
-      const idxL = y * 9 + x;
-      const idxR = y * 9 + x + 1;
-      bits += data[idxL] < data[idxR] ? '1' : '0';
+  for (let y = 0; y < ry; y++) {
+    const yy = Math.min(h - 1, Math.round(y * sy));
+    for (let x = 0; x < rx - 1; x++) {
+      const xl = Math.min(w - 1, Math.round(x * sx));
+      const xr = Math.min(w - 1, Math.round((x + 1) * sx));
+      const L = data[yy * w + xl];
+      const R = data[yy * w + xr];
+      bits += L < R ? '1' : '0';
     }
   }
   return BigInt('0b' + bits).toString(16).padStart(16, '0');
 }
-
-function hamming(a, b) {
+export function hamming(a, b) {
   const x = BigInt('0x' + a) ^ BigInt('0x' + b);
-  let n = 0n,
-    y = x;
+  let n = 0n, y = x;
   while (y) {
     n += y & 1n;
     y >>= 1n;
@@ -45,53 +76,67 @@ function hamming(a, b) {
   return Number(n);
 }
 
-// Plantillas dHash calculadas desde assets/mod-templates/swastika/*.png
-const SWASTIKA_HASHES = [
-  '26cecdcfcccc4c48', // base
-  '4d96330f8e178e4d', // rot45
-  '808c4c0ccccccd2d', // rot90
-  '49b2334d4d33b249', // rot135
-  '2dcdcccc0c4c8c80', // rot180
-  '4d8e178e0f33964d', // rot225
-  '484ccccccfcdce26' // rot270
-];
+// --- Plantillas en memoria (SVG -> raster -> dHash) ---
+let TEMPLATE_HASHES = null;
 
-async function looksLikeSwastika(buffer) {
-  const hash = await dHash(buffer);
-  return SWASTIKA_HASHES.some((h) => hamming(hash, h) <= 10);
+function swastikaSVG({ size = 128, stroke = 18, invert = false, rotate = 0 }) {
+  const s = size, m = s / 2;
+  const c = invert ? '#fff' : '#000';
+  const bg = invert ? '#000' : '#fff';
+  return `\n<svg xmlns="http://www.w3.org/2000/svg" width="${s}" height="${s}" viewBox="0 0 ${s} ${s}">\n  <rect width="100%" height="100%" fill="${bg}"/>\n  <g transform="rotate(${rotate}, ${m}, ${m})" fill="${c}">\n    <rect x="${m - stroke/2}" y="${m - s*0.35}" width="${stroke}" height="${s*0.7}"/>\n    <rect x="${m - s*0.35}" y="${m - stroke/2}" width="${s*0.7}" height="${stroke}"/>\n    <!-- codos -->\n    <rect x="${m + stroke*0.5}" y="${m - s*0.35}" width="${s*0.2}" height="${stroke}"/>\n    <rect x="${m - stroke/2}" y="${m + stroke*0.5}" width="${stroke}" height="${s*0.2}"/>\n    <rect x="${m - s*0.35}" y="${m - stroke*0.5 - s*0.2}" width="${s*0.2}" height="${stroke}"/>\n    <rect x="${m - stroke*0.5 - s*0.2}" y="${m - stroke/2}" width="${stroke}" height="${s*0.2}"/>\n  </g>\n</svg>`;
 }
 
-async function ocrHate(buffer) {
-  const worker = await createWorker('eng', 1, { gzip: false });
-  try {
-    const {
-      data: { text }
-    } = await worker.recognize(buffer);
-    const t = (text || '').toLowerCase();
-    return HATE_WORDS.some((w) => t.includes(w));
-  } finally {
-    await worker.terminate();
+async function svgToHash(svg) {
+  const buf = Buffer.from(svg);
+  const png = await sharp(buf).toBuffer();
+  const raw = await toGray(png, 128);
+  return dHashFromRaw(raw);
+}
+
+export async function initHateTemplates() {
+  if (TEMPLATE_HASHES) return TEMPLATE_HASHES;
+  const rotations = [0, 45, 90, 135];
+  const strokes = [10, 16, 22, 28];
+  const inverses = [false, true];
+  const tasks = [];
+  for (const r of rotations) {
+    for (const st of strokes) {
+      for (const inv of inverses) {
+        tasks.push(svgToHash(swastikaSVG({ rotate: r, stroke: st, invert: inv })));
+      }
+    }
   }
+  const hashes = await Promise.all(tasks);
+  TEMPLATE_HASHES = Array.from(new Set(hashes));
+  return TEMPLATE_HASHES;
+}
+
+export async function looksLikeSwastika(buffer, threshold = 18) {
+  const raw = await toGray(buffer, 128);
+  const hash = dHashFromRaw(raw);
+  const templates = await initHateTemplates();
+  return templates.some((h) => hamming(hash, h) <= threshold);
 }
 
 export async function checkHate(buffer, filename = '') {
-  const name = (filename || '').toLowerCase();
-  if (HATE_WORDS.some((w) => name.includes(w))) return { block: true, reason: 'filename' };
+  const nameN = normalizeText(filename);
+  if (HATE_WORDS.some((w) => nameN.includes(w))) {
+    return { block: true, reason: 'filename' };
+  }
 
   let hasText = false;
   try {
-    hasText = await ocrHate(buffer);
-  } catch (_) {
-    /* ignore OCR failure */
-  }
+    hasText = await ocrHasHate(buffer);
+  } catch {}
   if (hasText) return { block: true, reason: 'ocr' };
 
   let looks = false;
   try {
-    looks = await looksLikeSwastika(buffer);
-  } catch (_) {
-    /* ignore */
-  }
-  return { block: looks, reason: looks ? 'template' : null };
+    looks = await looksLikeSwastika(buffer, 18);
+  } catch {}
+  if (looks) return { block: true, reason: 'template' };
+
+  return { block: false, reason: null };
 }
 
+export default { checkHate, initHateTemplates };


### PR DESCRIPTION
## Summary
- normalize text with leet mapping and collapse repeats for hate OCR
- cache single tesseract.js worker (eng+deu+spa) and block on detected keywords
- generate swastika templates in-memory via SVG->sharp->dHash (no png assets) and compare with threshold
- preload templates in `moderate-image` endpoint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `node -e "(init templates & check hamming)"` *(templates 26, hamming swastika 0, hamming plus 4)*
- `git ls-files | rg '\.png$'`

------
https://chatgpt.com/codex/tasks/task_e_68ba4c633cec8327b9cea985a9163ec9