### PR TITLE
fix(front): quitar sintaxis TS de Home.jsx (FileReader, Promise) y asegurar JS puro

### DIFF
--- a/mgm-front/src/lib/blob.ts
+++ b/mgm-front/src/lib/blob.ts
@@ -1,0 +1,8 @@
+export function blobToDataURL(blob) {
+  return new Promise((resolve, reject) => {
+    const r = new FileReader();
+    r.onloadend = () => resolve(typeof r.result === 'string' ? r.result : '');
+    r.onerror = reject;
+    r.readAsDataURL(blob);
+  });
+}

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -16,6 +16,7 @@ import { dpiLevel } from '../lib/dpi';
 import styles from './Home.module.css';
 import { useOrderFlow } from '../store/orderFlow';
 import { renderMockup1080 } from '../lib/mockup';
+import { blobToDataURL } from '@/lib/blob';
 
 export default function Home() {
 
@@ -169,11 +170,7 @@ export default function Home() {
         composition: { image: img },
         background: '#f5f5f5',
       });
-      const mockupDataUrl: string = await new Promise((resolve) => {
-        const r = new FileReader();
-        r.onloadend = () => resolve(r.result as string);
-        r.readAsDataURL(blob);
-      });
+      const mockupDataUrl = await blobToDataURL(blob);
 
       const rotationDeg = Number(layout?.transform?.rotation_deg || 0);
       const bleed = 3;


### PR DESCRIPTION
## Summary
- remove TypeScript annotations from Home.jsx and use blobToDataURL helper
- add blobToDataURL utility for blob -> data URL conversion

## Testing
- `npm run lint` *(fails: react/no-danger, no-unused-vars, no-undef)*
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68ba5ba74b948327847faa1ae9f1b230