### PR TITLE
Restore arrow key move helper in EditorCanvas

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -269,26 +269,29 @@ const EditorCanvas = forwardRef(function EditorCanvas(
   const stickyFitRef = useRef("cover");
   const [bgColor, setBgColor] = useState("#ffffff");
 
+  const moveBy = useCallback(
+    (dx, dy) => {
+      pushHistory(imgTx);
+      stickyFitRef.current = null;
+      setImgTx((tx) => ({ ...tx, x_cm: tx.x_cm + dx, y_cm: tx.y_cm + dy }));
+    },
+    [imgTx, pushHistory],
+  );
+
   useEffect(() => {
     const handler = (e) => {
       if (!["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key))
         return;
       e.preventDefault();
       const step = e.shiftKey ? 1 : 0.5;
-      let dx = 0;
-      let dy = 0;
-      if (e.key === "ArrowUp") dy = -step;
-      if (e.key === "ArrowDown") dy = step;
-      if (e.key === "ArrowLeft") dx = -step;
-      if (e.key === "ArrowRight") dx = step;
-      if (!dx && !dy) return;
-      pushHistory(imgTx);
-      stickyFitRef.current = null;
-      setImgTx((tx) => ({ ...tx, x_cm: tx.x_cm + dx, y_cm: tx.y_cm + dy }));
+      if (e.key === "ArrowUp") moveBy(0, -step);
+      if (e.key === "ArrowDown") moveBy(0, step);
+      if (e.key === "ArrowLeft") moveBy(-step, 0);
+      if (e.key === "ArrowRight") moveBy(step, 0);
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [imgTx, pushHistory]);
+  }, [moveBy]);
 
   // cover inicial 1 sola vez
   const didInitRef = useRef(false);


### PR DESCRIPTION
## Summary
- reintroduce the shared moveBy helper around arrow key movement in EditorCanvas
- hook the keydown handler to the helper so history updates and sticky snapping reset stay centralized

## Testing
- npx eslint src/components/EditorCanvas.jsx

------
https://chatgpt.com/codex/tasks/task_e_68cdb45d94a08327b0510453d9d6c450