### PR TITLE
Fix initial centering and update mousepad safe margins

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -34,6 +34,10 @@ const IMG_ZOOM_MAX = 50; // límite cuando mantengo proporción
 const STAGE_BG = "#e5e7eb";
 const SNAP_LIVE_CM = 2.0;
 const RELEASE_CM = 3.0;
+const PRIMARY_SAFE_MARGIN_CM = 1.1;
+const SECONDARY_MARGIN_GAP_CM = 0.3;
+const SECONDARY_SAFE_MARGIN_CM =
+  PRIMARY_SAFE_MARGIN_CM + SECONDARY_MARGIN_GAP_CM;
 
 // ---------- Editor ----------
 const EditorCanvas = forwardRef(function EditorCanvas(
@@ -266,8 +270,18 @@ const EditorCanvas = forwardRef(function EditorCanvas(
   const [freeScale, setFreeScale] = useState(false); // ⟵ NUEVO: “Estirar sin límites”
   const keepRatio = !freeScale;
   const [mode, setMode] = useState("cover"); // 'cover' | 'contain' | 'stretch'
-  const stickyFitRef = useRef("cover");
+  const stickyFitRef = useRef(null);
   const [bgColor, setBgColor] = useState("#ffffff");
+  const isTransformingRef = useRef(false);
+
+  const moveBy = useCallback(
+    (dx, dy) => {
+      pushHistory(imgTx);
+      stickyFitRef.current = null;
+      setImgTx((tx) => ({ ...tx, x_cm: tx.x_cm + dx, y_cm: tx.y_cm + dy }));
+    },
+    [imgTx, pushHistory],
+  );
 
   useEffect(() => {
     const handler = (e) => {
@@ -275,20 +289,14 @@ const EditorCanvas = forwardRef(function EditorCanvas(
         return;
       e.preventDefault();
       const step = e.shiftKey ? 1 : 0.5;
-      let dx = 0;
-      let dy = 0;
-      if (e.key === "ArrowUp") dy = -step;
-      if (e.key === "ArrowDown") dy = step;
-      if (e.key === "ArrowLeft") dx = -step;
-      if (e.key === "ArrowRight") dx = step;
-      if (!dx && !dy) return;
-      pushHistory(imgTx);
-      stickyFitRef.current = null;
-      setImgTx((tx) => ({ ...tx, x_cm: tx.x_cm + dx, y_cm: tx.y_cm + dy }));
+      if (e.key === "ArrowUp") moveBy(0, -step);
+      if (e.key === "ArrowDown") moveBy(0, step);
+      if (e.key === "ArrowLeft") moveBy(-step, 0);
+      if (e.key === "ArrowRight") moveBy(step, 0);
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [imgTx, pushHistory]);
+  }, [moveBy]);
 
   // cover inicial 1 sola vez
   const didInitRef = useRef(false);
@@ -307,6 +315,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
     setImgTx(initial);
     pushHistory(initial);
     setMode("cover");
+    stickyFitRef.current = "cover";
     didInitRef.current = true;
   }, [imgBaseCm, workCm.w, workCm.h]);
 
@@ -329,7 +338,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
   };
   const dragBoundFunc = useCallback(
     (pos) => {
-      if (!imgBaseCm) return pos;
+      if (!imgBaseCm || isTransformingRef.current) return pos;
 
       let cx = pos.x;
       let cy = pos.y;
@@ -455,7 +464,14 @@ const EditorCanvas = forwardRef(function EditorCanvas(
   }, [imgEl, keepRatio, showTransformer]);
 
   // fin de resize por esquinas
+  const onTransformStart = useCallback(() => {
+    isTransformingRef.current = true;
+    stickRef.current = { x: null, y: null, activeX: false, activeY: false };
+  }, []);
+
   const onTransformEnd = () => {
+    isTransformingRef.current = false;
+    stickRef.current = { x: null, y: null, activeX: false, activeY: false };
     if (!imgRef.current || !imgBaseCm) return;
     pushHistory(imgTx);
     stickyFitRef.current = null;
@@ -1152,6 +1168,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
                       const h = Math.max(MIN_H, Math.min(newBox.height, MAX_H));
                       return { ...newBox, width: w, height: h };
                     }}
+                    onTransformStart={onTransformStart}
                     onTransformEnd={onTransformEnd}
                   />
                 </>
@@ -1264,24 +1281,30 @@ const EditorCanvas = forwardRef(function EditorCanvas(
               cornerRadius={cornerRadiusCm + bleedCm}
             />
             <Rect
-              x={bleedCm}
-              y={bleedCm}
-              width={wCm}
-              height={hCm}
+              x={bleedCm + PRIMARY_SAFE_MARGIN_CM}
+              y={bleedCm + PRIMARY_SAFE_MARGIN_CM}
+              width={Math.max(0, wCm - 2 * PRIMARY_SAFE_MARGIN_CM)}
+              height={Math.max(0, hCm - 2 * PRIMARY_SAFE_MARGIN_CM)}
               stroke="#111827"
               dash={[0.4, 0.4]}
               strokeWidth={0.04}
-              cornerRadius={cornerRadiusCm}
+              cornerRadius={Math.max(
+                0,
+                cornerRadiusCm - PRIMARY_SAFE_MARGIN_CM,
+              )}
             />
             <Rect
-              x={bleedCm + 1}
-              y={bleedCm + 1}
-              width={Math.max(0, wCm - 2)}
-              height={Math.max(0, hCm - 2)}
+              x={bleedCm + SECONDARY_SAFE_MARGIN_CM}
+              y={bleedCm + SECONDARY_SAFE_MARGIN_CM}
+              width={Math.max(0, wCm - 2 * SECONDARY_SAFE_MARGIN_CM)}
+              height={Math.max(0, hCm - 2 * SECONDARY_SAFE_MARGIN_CM)}
               stroke="#6b7280"
               dash={[0.3, 0.3]}
               strokeWidth={0.03}
-              cornerRadius={Math.max(0, cornerRadiusCm - 1)}
+              cornerRadius={Math.max(
+                0,
+                cornerRadiusCm - SECONDARY_SAFE_MARGIN_CM,
+              )}
             />
           </Layer>
         </Stage>


### PR DESCRIPTION
## Summary
- center the initial cover placement after the image loads by deferring sticky-fit tracking
- skip drag bounds while transforming so the artwork no longer jumps when resizing off the canvas
- update the mousepad safe-zone guides to 1.1 cm and 0.3 cm offsets using shared constants

## Testing
- npx eslint src/components/EditorCanvas.jsx

------
https://chatgpt.com/codex/tasks/task_e_68cdb45d94a08327b0510453d9d6c450