### PR TITLE
Fix duplicate moveBy declaration in EditorCanvas

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -283,15 +283,6 @@ const EditorCanvas = forwardRef(function EditorCanvas(
     [imgTx, pushHistory],
   );
 
-  const moveBy = useCallback(
-    (dx, dy) => {
-      pushHistory(imgTx);
-      stickyFitRef.current = null;
-      setImgTx((tx) => ({ ...tx, x_cm: tx.x_cm + dx, y_cm: tx.y_cm + dy }));
-    },
-    [imgTx, pushHistory],
-  );
-
   useEffect(() => {
     const handler = (e) => {
       if (!["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key))


### PR DESCRIPTION
## Summary
- remove the duplicated `moveBy` hook in `EditorCanvas` so the component no longer redeclares the identifier during development builds

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc173f7a88327a70997711eb4acdf