### PR TITLE
Add physical-size scaling for mockup renders

### DIFF
--- a/mgm-front/src/lib/mockup.ts
+++ b/mgm-front/src/lib/mockup.ts
@@ -1,60 +1,108 @@
-export type MockupOptions = {
+type ImageSource = HTMLImageElement | HTMLCanvasElement | ImageBitmap;
+
+type SizeOptions = {
+  widthCm?: number;
+  heightCm?: number;
+  width_cm?: number;
+  height_cm?: number;
+};
+
+export type MockupOptions = SizeOptions & {
   productType: 'mousepad' | 'glasspad';
-  composition: {
-    image: HTMLImageElement | HTMLCanvasElement | ImageBitmap;
-    offsetX?: number;
-    offsetY?: number;
-    scaleX?: number;
-    scaleY?: number;
-    rotation?: number; // degrees
-    printableRect?: { x: number; y: number; w: number; h: number };
-  };
-  background?: string;
+  image?: ImageSource;
+  composition?: { image: ImageSource } & SizeOptions;
 };
 
 export async function renderMockup1080(opts: MockupOptions): Promise<Blob> {
   const size = 1080;
+  const margin = 40;
+  const maxContent = size - margin * 2;
   const canvas = document.createElement('canvas');
   canvas.width = size;
   canvas.height = size;
-  const ctx = canvas.getContext('2d')!;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('2d context unavailable');
 
-  // background
-  ctx.fillStyle = opts.background || '#f5f5f5';
-  ctx.fillRect(0, 0, size, size);
+  ctx.clearRect(0, 0, size, size);
 
-  // draw base art
-  ctx.save();
-  const cx = size / 2;
-  const cy = size / 2;
-  const comp = opts.composition;
-  ctx.translate(cx + (comp.offsetX || 0), cy + (comp.offsetY || 0));
-  ctx.rotate(((comp.rotation || 0) * Math.PI) / 180);
-  ctx.scale(comp.scaleX || 1, comp.scaleY || 1);
-  const img = comp.image as HTMLImageElement | HTMLCanvasElement;
-  const iw =
-    'width' in img && img.width
-      ? img.width
-      : (img as any).naturalWidth || 0;
-  const ih =
-    'height' in img && img.height
-      ? img.height
-      : (img as any).naturalHeight || 0;
-  ctx.drawImage(img, -iw / 2, -ih / 2, iw, ih);
-  ctx.restore();
+  const toBlob = () =>
+    new Promise<Blob>((resolve) =>
+      canvas.toBlob((b) => resolve(b!), 'image/png', 1)
+    );
 
-  // glasspad overlay
+  const image = opts.image ?? opts.composition?.image;
+  if (!image) {
+    return toBlob();
+  }
+
+  const widthCm = Number(
+    opts.widthCm ??
+      opts.width_cm ??
+      opts.composition?.widthCm ??
+      opts.composition?.width_cm ??
+      0
+  );
+  const heightCm = Number(
+    opts.heightCm ??
+      opts.height_cm ??
+      opts.composition?.heightCm ??
+      opts.composition?.height_cm ??
+      0
+  );
+
+  const anyImg = image as any;
+  const iw = Number(anyImg.width ?? anyImg.naturalWidth ?? anyImg.videoWidth ?? 0);
+  const ih = Number(anyImg.height ?? anyImg.naturalHeight ?? anyImg.videoHeight ?? 0);
+  if (!iw || !ih) {
+    return toBlob();
+  }
+
+  const longestCm = Math.max(widthCm, heightCm);
+  let targetLongestPx = Math.round((longestCm / 90) * maxContent);
+  if (!Number.isFinite(targetLongestPx) || targetLongestPx <= 0) {
+    targetLongestPx = maxContent;
+  }
+  targetLongestPx = Math.min(maxContent, Math.max(1, targetLongestPx));
+
+  let drawW: number;
+  let drawH: number;
+  if (iw >= ih) {
+    drawW = targetLongestPx;
+    drawH = Math.round((ih / Math.max(1e-6, iw)) * drawW);
+  } else {
+    drawH = targetLongestPx;
+    drawW = Math.round((iw / Math.max(1e-6, ih)) * drawH);
+  }
+
+  if (drawW > maxContent) {
+    const ratio = drawH / Math.max(1e-6, drawW);
+    drawW = maxContent;
+    drawH = Math.round(drawW * ratio);
+  }
+  if (drawH > maxContent) {
+    const ratio = drawW / Math.max(1e-6, drawH);
+    drawH = maxContent;
+    drawW = Math.round(drawH * ratio);
+  }
+
+  drawW = Math.max(1, Math.round(drawW));
+  drawH = Math.max(1, Math.round(drawH));
+
+  const dx = Math.round((size - drawW) / 2);
+  const dy = Math.round((size - drawH) / 2);
+
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = 'high';
+  ctx.drawImage(image, dx, dy, drawW, drawH);
+
   if (opts.productType === 'glasspad') {
     ctx.save();
     ctx.fillStyle = 'rgba(255,255,255,0.18)';
-    ctx.fillRect(0, 0, size, size);
+    ctx.fillRect(dx, dy, drawW, drawH);
     ctx.restore();
   }
 
-  const blob: Blob = await new Promise((resolve) =>
-    canvas.toBlob((b) => resolve(b!), 'image/png', 1)
-  );
-  return blob;
+  return toBlob();
 }
 
 export function downloadBlob(blob: Blob, name: string) {

--- a/mgm-front/src/pages/DevCanvasPreview.jsx
+++ b/mgm-front/src/pages/DevCanvasPreview.jsx
@@ -85,8 +85,9 @@ export default function DevCanvasPreview() {
     const bitmap = await createImageBitmap(padBlob);
     const blob = await renderMockup1080({
       productType: material === 'Glasspad' ? 'glasspad' : 'mousepad',
-      composition: { image: bitmap },
-      background: '#f5f5f5',
+      image: bitmap,
+      width_cm: w_cm,
+      height_cm: h_cm,
     });
     downloadBlob(blob, `${baseName}.png`);
   }

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -190,8 +190,9 @@ export default function Home() {
       await img.decode();
       const blob = await renderMockup1080({
         productType: material === 'Glasspad' ? 'glasspad' : 'mousepad',
-        composition: { image: img },
-        background: '#f5f5f5',
+        image: img,
+        width_cm: activeWcm,
+        height_cm: activeHcm,
       });
       const mockupUrl = URL.createObjectURL(blob);
 


### PR DESCRIPTION
## Summary
- scale mousepad mockups relative to a 90×40 cm reference with a fixed 40 px margin and transparent background
- expose the new sizing options in the mockup renderer typings
- pass the selected physical dimensions when generating mockups from the home flow and dev preview

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cdc7cf14748327b377eb334ea9dfea