### PR TITLE
Adjust mockup scaling and export format

### DIFF
--- a/mgm-front/src/lib/mockup.js
+++ b/mgm-front/src/lib/mockup.js
@@ -36,9 +36,16 @@ export async function renderMockup1080(opts) {
   }
 
   const longestCm = Math.max(widthCm, heightCm);
-  let targetLongestPx = Math.round((longestCm / 90) * maxContent);
+  const safeLongestCm = Number.isFinite(longestCm) ? Math.max(0, longestCm) : 0;
+  const norm = safeLongestCm / 140;
+  let ratio = Number.isFinite(norm) ? Math.pow(Math.max(norm, 0), 0.6) : 0;
+  if (!Number.isFinite(ratio)) {
+    ratio = 0;
+  }
+  ratio = Math.min(1, Math.max(0.26, ratio));
+  let targetLongestPx = Math.round(maxContent * ratio);
   if (!Number.isFinite(targetLongestPx) || targetLongestPx <= 0) {
-    targetLongestPx = maxContent;
+    targetLongestPx = Math.round(maxContent * 0.26);
   }
   targetLongestPx = Math.min(maxContent, Math.max(1, targetLongestPx));
 
@@ -72,14 +79,35 @@ export async function renderMockup1080(opts) {
   const dx = Math.round((size - drawW) / 2);
   const dy = Math.round((size - drawH) / 2);
 
+  const clipRoundedRect = (context, x, y, width, height, radius) => {
+    const r = Math.max(0, Math.min(radius, Math.min(width, height) / 2));
+    context.beginPath();
+    if (typeof context.roundRect === 'function') {
+      context.roundRect(x, y, width, height, r);
+    } else {
+      context.moveTo(x + r, y);
+      context.lineTo(x + width - r, y);
+      context.arcTo(x + width, y, x + width, y + r, r);
+      context.lineTo(x + width, y + height - r);
+      context.arcTo(x + width, y + height, x + width - r, y + height, r);
+      context.lineTo(x + r, y + height);
+      context.arcTo(x, y + height, x, y + height - r, r);
+      context.lineTo(x, y + r);
+      context.arcTo(x, y, x + r, y, r);
+      context.closePath();
+    }
+    context.clip();
+  };
+
+  ctx.save();
+  clipRoundedRect(ctx, dx, dy, drawW, drawH, 12);
   ctx.drawImage(image, dx, dy, drawW, drawH);
 
   if (opts.productType === 'glasspad') {
-    ctx.save();
     ctx.fillStyle = 'rgba(255,255,255,0.18)';
     ctx.fillRect(dx, dy, drawW, drawH);
-    ctx.restore();
   }
+  ctx.restore();
 
   const blob = await new Promise((res) => canvas.toBlob(res, 'image/png', 1));
   return blob;

--- a/mgm-front/src/pages/DevCanvasPreview.jsx
+++ b/mgm-front/src/pages/DevCanvasPreview.jsx
@@ -81,7 +81,6 @@ export default function DevCanvasPreview() {
   async function downloadMockup() {
     if (!padBlob || !render_v2) return;
     const { w_cm, h_cm, material } = render_v2;
-    const baseName = buildExportBaseName(designName, w_cm, h_cm);
     const bitmap = await createImageBitmap(padBlob);
     const blob = await renderMockup1080({
       productType: material === 'Glasspad' ? 'glasspad' : 'mousepad',
@@ -89,7 +88,11 @@ export default function DevCanvasPreview() {
       width_cm: w_cm,
       height_cm: h_cm,
     });
-    downloadBlob(blob, `${baseName}.png`);
+    const widthLabel = Number(w_cm);
+    const heightLabel = Number(h_cm);
+    const safeWidth = Number.isFinite(widthLabel) ? widthLabel : 0;
+    const safeHeight = Number.isFinite(heightLabel) ? heightLabel : 0;
+    downloadBlob(blob, `mockup_1080_${safeWidth}x${safeHeight}.png`);
   }
 
   async function previewGlasspadPNG() {


### PR DESCRIPTION
## Summary
- update the 1080px mockup renderer to scale mousepads with the new curved ratio and margin rules
- clip rendered mousepads to 12px rounded corners so transparent backgrounds respect the shape
- export downloaded mockups with the required mockup_1080_{width}x{height}.png naming pattern

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cdcbb3d5ac8327ade96e49fdd77dc8