### PR TITLE
Ensure mousepad exports fill uncovered background

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -1394,16 +1394,14 @@ const EditorCanvas = forwardRef(function EditorCanvas(
         >
           <Layer>
             <Group ref={padGroupRef}>
-              {mode === "contain" && (
-                <Rect
-                  x={0}
-                  y={0}
-                  width={padRectPx.w}
-                  height={padRectPx.h}
-                  fill={bgColor}
-                  listening={false}
-                />
-              )}
+              <Rect
+                x={0}
+                y={0}
+                width={padRectPx.w}
+                height={padRectPx.h}
+                fill={mode === "contain" ? bgColor : "#ffffff"}
+                listening={false}
+              />
               {imgEl && imgBaseCm && (
                 <KonvaImage
                   image={imgEl}


### PR DESCRIPTION
## Summary
- always render a solid rectangle behind the exported pad artwork so uncovered areas turn white instead of staying transparent
- keep the contain mode behavior by using the selected background color when present and defaulting to white otherwise

## Testing
- `npm run lint` *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cde1a6cb408327838f67a2dab9d432