### PR TITLE
Pad moderation input with white background

### DIFF
--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -202,6 +202,81 @@ async function detectNazi(buffer) {
   return { nazi: false, reason: 'none', score: minDist };
 }
 
+// Ensure the moderation heuristics evaluate at least a medium sized canvas.
+const MIN_PADDED_DIMENSION = 512;
+
+async function prepareModerationImage(buffer) {
+  try {
+    const originalMeta = await sharp(buffer).metadata();
+    let pipeline = sharp(buffer);
+    let changed = false;
+    let removedAlpha = false;
+    let padding = null;
+
+    if (originalMeta?.hasAlpha || (originalMeta?.channels || 0) >= 4) {
+      pipeline = pipeline.flatten({ background: { r: 255, g: 255, b: 255 } });
+      removedAlpha = true;
+      changed = true;
+    }
+
+    const width = originalMeta?.width || 0;
+    const height = originalMeta?.height || 0;
+    if (width && height) {
+      const targetWidth = Math.max(width, MIN_PADDED_DIMENSION);
+      const targetHeight = Math.max(height, MIN_PADDED_DIMENSION);
+      const extraW = targetWidth - width;
+      const extraH = targetHeight - height;
+      if (extraW > 0 || extraH > 0) {
+        const pad = {
+          left: Math.floor(extraW / 2),
+          right: extraW - Math.floor(extraW / 2),
+          top: Math.floor(extraH / 2),
+          bottom: extraH - Math.floor(extraH / 2),
+        };
+        padding = pad;
+        pipeline = pipeline.extend({
+          ...pad,
+          background: { r: 255, g: 255, b: 255, alpha: 1 },
+        });
+        changed = true;
+      }
+    }
+
+    if (!changed) {
+      return {
+        buffer,
+        meta: originalMeta,
+        originalMeta,
+        removedAlpha,
+        padding,
+      };
+    }
+
+    const finalBuffer = await pipeline.toBuffer();
+    const normalizedMeta = await sharp(finalBuffer).metadata();
+
+    return {
+      buffer: finalBuffer,
+      meta: normalizedMeta,
+      originalMeta,
+      removedAlpha,
+      padding,
+    };
+  } catch (err) {
+    try {
+      console.warn('[moderation] prepareModerationImage failed', err?.message || err);
+    } catch {}
+    return {
+      buffer,
+      meta: null,
+      originalMeta: null,
+      removedAlpha: false,
+      padding: null,
+      error: err?.message || String(err),
+    };
+  }
+}
+
 function computeNudityConfidence({ skinPercent = 0, largestBlob = 0 }) {
   const skinScore = clamp((skinPercent - 0.35) / 0.45);
   const blobScore = clamp((largestBlob - 0.1) / 0.4);
@@ -236,9 +311,18 @@ export async function evaluateImage(buffer, filename, designName = '') {
     }
   };
 
-  // Preload metadata for downstream heuristics
+  // Preload metadata for downstream heuristics and normalize buffer
+  let workingBuffer = buffer;
   try {
-    debug.metadata = await sharp(buffer).metadata();
+    const prepared = await prepareModerationImage(buffer);
+    workingBuffer = prepared.buffer;
+    debug.metadata = {
+      original: prepared.originalMeta,
+      normalized: prepared.meta,
+      removedAlpha: prepared.removedAlpha,
+      padding: prepared.padding,
+      error: prepared.error,
+    };
   } catch (err) {
     debug.metadata = { error: err?.message };
   }
@@ -250,7 +334,7 @@ export async function evaluateImage(buffer, filename, designName = '') {
   }
 
   // A) skin-based real nudity heuristic
-  const skin = await detectSkin(buffer);
+  const skin = await detectSkin(workingBuffer);
   debug.skin = skin;
   const nudityConfidence = computeNudityConfidence(skin);
   debug.scores.realNudity = nudityConfidence;
@@ -264,7 +348,7 @@ export async function evaluateImage(buffer, filename, designName = '') {
   }
 
   // B) nazi detection via pHash + color heuristic
-  const nazi = await detectNazi(buffer);
+  const nazi = await detectNazi(workingBuffer);
   debug.nazi = nazi;
   let naziConfidence = 0;
   if (nazi.nazi) {
@@ -280,7 +364,7 @@ export async function evaluateImage(buffer, filename, designName = '') {
 
   // C) OCR-based hate speech detection (only if not already blocked for text)
   if (SEVERITY_RANK[label] < SEVERITY_RANK.BLOCK) {
-    const textHints = await extractTextHints(buffer);
+    const textHints = await extractTextHints(workingBuffer);
     debug.textHints = textHints.length;
     if (textHints) {
       const textGate = hateTextCheck({ filename, designName, textHints });
@@ -291,7 +375,7 @@ export async function evaluateImage(buffer, filename, designName = '') {
   }
 
   // D) illustration vs real estimation
-  const illustration = await detectIllustration(buffer);
+  const illustration = await detectIllustration(workingBuffer);
   debug.illustration = illustration;
   debug.scores.illustration = illustration.cartoonConfidence;
   if (SEVERITY_RANK[label] < SEVERITY_RANK.BLOCK) {
@@ -303,7 +387,7 @@ export async function evaluateImage(buffer, filename, designName = '') {
   }
 
   // E) quality heuristics for review
-  const meta = debug.metadata || {};
+  const meta = (debug.metadata && (debug.metadata.normalized || debug.metadata.original)) || debug.metadata || {};
   if (SEVERITY_RANK[label] < SEVERITY_RANK.BLOCK) {
     if ((meta.width && meta.width < 256) || (meta.height && meta.height < 256)) {
       applyOutcome('REVIEW', ['low_resolution_uncertain'], 0.45);


### PR DESCRIPTION
## Summary
- normalize images before moderation by flattening transparency to white and padding to a minimum canvas size
- reuse the normalized buffer for all image heuristics while tracking both original and normalized metadata

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cec330a5888327a15d424b012ce51e