### PR TITLE
Relax moderation for stylized images

### DIFF
--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -333,18 +333,39 @@ export async function evaluateImage(buffer, filename, designName = '') {
     applyOutcome('BLOCK', ['extremism_nazi_text'], 0.85);
   }
 
-  // A) skin-based real nudity heuristic
+  // Pre-compute illustration confidence before applying nudity heuristics so we can relax
+  // false positives on stylized or padded images (e.g. Valorant renders or solid color fills).
+  const illustration = await detectIllustration(workingBuffer);
+  debug.illustration = illustration;
+  const cartoonConfidence = illustration?.cartoonConfidence || 0;
+  debug.scores.illustration = cartoonConfidence;
+
+  // A) skin-based real nudity heuristic with illustration-based relaxations
   const skin = await detectSkin(workingBuffer);
   debug.skin = skin;
   const nudityConfidence = computeNudityConfidence(skin);
   debug.scores.realNudity = nudityConfidence;
+
+  const CARTOON_STRONG_THRESHOLD = 0.7;
+  const CARTOON_RELAX_THRESHOLD = 0.5;
+
   if (nudityConfidence >= 0.6) {
-    const nudityReasons = ['real_nudity'];
-    if (skin.largestBlob >= 0.4) nudityReasons.push('genitals_visible');
-    if (skin.skinPercent >= 0.75) nudityReasons.push('sex_act');
-    applyOutcome('BLOCK', nudityReasons, nudityConfidence);
+    if (cartoonConfidence >= CARTOON_RELAX_THRESHOLD) {
+      const allowConfidence = clamp(0.65 + (cartoonConfidence - CARTOON_RELAX_THRESHOLD) * 0.3);
+      applyOutcome('ALLOW', ['animated_explicit_allowed'], allowConfidence);
+    } else {
+      const nudityReasons = ['real_nudity'];
+      if (skin.largestBlob >= 0.4) nudityReasons.push('genitals_visible');
+      if (skin.skinPercent >= 0.75) nudityReasons.push('sex_act');
+      applyOutcome('BLOCK', nudityReasons, nudityConfidence);
+    }
   } else if (nudityConfidence >= 0.4) {
-    applyOutcome('REVIEW', ['real_nudity_suspected'], nudityConfidence);
+    if (cartoonConfidence >= CARTOON_RELAX_THRESHOLD) {
+      const allowConfidence = clamp(0.6 + (cartoonConfidence - CARTOON_RELAX_THRESHOLD) * 0.25);
+      applyOutcome('ALLOW', ['animated_skin_visible'], allowConfidence);
+    } else {
+      applyOutcome('REVIEW', ['real_nudity_suspected'], nudityConfidence);
+    }
   }
 
   // B) nazi detection via pHash + color heuristic
@@ -374,15 +395,12 @@ export async function evaluateImage(buffer, filename, designName = '') {
     }
   }
 
-  // D) illustration vs real estimation
-  const illustration = await detectIllustration(workingBuffer);
-  debug.illustration = illustration;
-  debug.scores.illustration = illustration.cartoonConfidence;
+  // D) illustration vs real estimation based on skin detection context
   if (SEVERITY_RANK[label] < SEVERITY_RANK.BLOCK) {
-    if (illustration.cartoonConfidence >= 0.7) {
-      applyOutcome('ALLOW', ['animated_explicit_allowed'], illustration.cartoonConfidence);
-    } else if (illustration.cartoonConfidence >= 0.4) {
-      applyOutcome('REVIEW', ['animated_uncertain_age'], illustration.cartoonConfidence);
+    if (cartoonConfidence >= CARTOON_STRONG_THRESHOLD) {
+      applyOutcome('ALLOW', ['animated_explicit_allowed'], cartoonConfidence);
+    } else if (cartoonConfidence >= 0.45 && nudityConfidence >= 0.3) {
+      applyOutcome('REVIEW', ['animated_uncertain_age'], Math.max(cartoonConfidence, nudityConfidence));
     }
   }
 


### PR DESCRIPTION
## Summary
- relax the moderation flow by computing illustration confidence before skin heuristics to avoid false real-nudity blocks on stylized uploads
- gate the cartoon review path on detected skin exposure so solid-color "contener" fills no longer trigger review_required

## Testing
- node --test tests/api-handlers.test.js *(fails: ERR_MODULE_NOT_FOUND for api/_lib/env.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cec70d284883278ccf669a240039f7