### PR TITLE
Add mockup PDF download option

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -168,7 +168,7 @@ export default function Home() {
           setBusy(false);
           return;
         }
-      } catch (_) { /* best-effort */ }
+      } catch { /* best-effort */ }
 
       const moderationUrl = `${import.meta.env.VITE_API_URL || ''}/api/moderate-image`;
       console.info('[continue] POST', moderationUrl);
@@ -208,6 +208,7 @@ export default function Home() {
         mockupBlob: blob,
         mockupUrl,
         printFullResDataUrl: master,
+        designName: trimmedDesignName,
         lowQualityAck: level === 'bad' ? Boolean(ackLow) : false,
         approxDpi: effDpi || null,
       });

--- a/mgm-front/src/state/flow.js
+++ b/mgm-front/src/state/flow.js
@@ -6,6 +6,7 @@ const defaultState = {
   mockupBlob: null,
   mockupUrl: null,
   printFullResDataUrl: null,
+  designName: '',
   lowQualityAck: false,
   approxDpi: null,
   lastProduct: null,
@@ -25,7 +26,7 @@ export function FlowProvider({ children }) {
     reset: () => {
       try {
         if (state.mockupUrl) URL.revokeObjectURL(state.mockupUrl);
-      } catch (_) {
+      } catch {
         // ignore
       }
       setState({ ...defaultState });

--- a/mgm-front/src/state/flow.tsx
+++ b/mgm-front/src/state/flow.tsx
@@ -6,6 +6,7 @@ export type FlowState = {
   mockupBlob?: Blob;
   mockupUrl?: string;
   printFullResDataUrl?: string;
+  designName?: string;
   lowQualityAck?: boolean;
   approxDpi?: number | null;
   lastProduct?: { productId?: string; variantId?: string; cartUrl?: string; checkoutUrl?: string };
@@ -19,6 +20,7 @@ const defaultState: Omit<FlowState, 'set' | 'reset'> = {
   mockupBlob: undefined,
   mockupUrl: undefined,
   printFullResDataUrl: undefined,
+  designName: '',
   lowQualityAck: false,
   approxDpi: null,
   lastProduct: undefined,


### PR DESCRIPTION
## Summary
- store the design name in the shared flow state when continuing to the mockup view
- add a provisional "Descargar PDF" button that builds a PDF from the stored print image and downloads it automatically

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*
- npx eslint src/pages/Mockup.jsx src/pages/Home.jsx src/state/flow.js src/state/flow.tsx *(warns: TypeScript file ignored because no ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68ceccff9d2483279a7ba44b30c013c5