### PR TITLE
Fix low quality moderation override and require design name

### DIFF
--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -408,7 +408,10 @@ export async function evaluateImage(buffer, filename, designName = '', options =
   }
 
   // E) quality heuristics for review
-  const meta = (debug.metadata && (debug.metadata.normalized || debug.metadata.original)) || debug.metadata || {};
+  const originalMeta = debug.metadata?.original || null;
+  const normalizedMeta = debug.metadata?.normalized || null;
+  const meta = originalMeta || normalizedMeta || debug.metadata || {};
+  let lowResolutionOverrideRequested = false;
   if (SEVERITY_RANK[label] < SEVERITY_RANK.BLOCK) {
     const lowResolution = Boolean(
       (meta.width && meta.width < 256) || (meta.height && meta.height < 256)
@@ -417,10 +420,21 @@ export async function evaluateImage(buffer, filename, designName = '', options =
       debug.scores.lowResolution = 0.45;
       if (lowQualityAck) {
         debug.flags = { ...debug.flags, lowResolutionOverride: true };
+        lowResolutionOverrideRequested = true;
         applyOutcome('ALLOW', ['low_resolution_acknowledged'], 0.55);
       } else {
         applyOutcome('REVIEW', ['low_resolution_uncertain'], 0.45);
       }
+    }
+  }
+
+  if (lowResolutionOverrideRequested && label === 'REVIEW') {
+    const seriousReviewReasons = new Set(['real_nudity_suspected', 'animated_uncertain_age']);
+    const hasSeriousReview = reasons.some((reason) => seriousReviewReasons.has(reason));
+    if (!hasSeriousReview) {
+      label = 'ALLOW';
+      reasons = ['low_resolution_acknowledged'];
+      debug.flags = { ...debug.flags, lowResolutionOverrideApplied: true };
     }
   }
 

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -84,6 +84,7 @@ export default function Home() {
     );
   }, [layout]);
   const level = useMemo(() => (effDpi ? dpiLevel(effDpi, 300, 100) : null), [effDpi]);
+  const trimmedDesignName = useMemo(() => (designName || '').trim(), [designName]);
 
   function handleSizeChange(next) {
     if (next.material && next.material !== material) {
@@ -137,6 +138,10 @@ export default function Home() {
       setErr('Falta imagen o layout');
       return;
     }
+    if (trimmedDesignName.length < 2) {
+      setErr('El nombre del modelo debe tener al menos 2 caracteres.');
+      return;
+    }
     if (level === 'bad' && !ackLow) {
       setErr('Confirmá que aceptás continuar con la calidad baja.');
       return;
@@ -152,7 +157,6 @@ export default function Home() {
       }
 
       // client-side gate: filename keywords
-      const trimmedDesignName = (designName || '').trim();
       const metaForCheck = [uploaded?.file?.name, trimmedDesignName].filter(Boolean).join(' ');
       if (quickHateSymbolCheck(metaForCheck)) {
         setErr('Contenido no permitido (odio nazi detectado)');
@@ -292,7 +296,11 @@ export default function Home() {
         )}
 
         {uploaded && (
-          <button className={styles.continueButton} disabled={busy || priceAmount <= 0} onClick={handleContinue}>
+          <button
+            className={styles.continueButton}
+            disabled={busy || priceAmount <= 0 || trimmedDesignName.length < 2}
+            onClick={handleContinue}
+          >
             Continuar
           </button>
         )}


### PR DESCRIPTION
## Summary
- ensure the moderation service evaluates low resolution using the original image metadata and lets the low-quality acknowledgement downgrade non-serious reviews
- enforce a minimum of two characters for the design name before continuing the customization flow and disable the CTA until that condition is met

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ced5047e488327b213fb3bffd08511