### PR TITLE
Add bleed margin and keep quality for PDF export

### DIFF
--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -89,17 +89,26 @@ export default function Mockup() {
       const pdfDoc = await PDFDocument.create();
       const widthCm = widthCmRaw;
       const heightCm = heightCmRaw;
-      const pageWidthPt = (widthCm / 2.54) * 72;
-      const pageHeightPt = (heightCm / 2.54) * 72;
+      const extraBleedCm = 2;
+      const marginCm = extraBleedCm / 2;
+      const pageWidthCm = widthCm + extraBleedCm;
+      const pageHeightCm = heightCm + extraBleedCm;
+      const cmToPt = (cm) => (cm / 2.54) * 72;
+      const pageWidthPt = cmToPt(pageWidthCm);
+      const pageHeightPt = cmToPt(pageHeightCm);
+      const innerWidthPt = cmToPt(widthCm);
+      const innerHeightPt = cmToPt(heightCm);
+      const marginPt = cmToPt(marginCm);
       const page = pdfDoc.addPage([pageWidthPt, pageHeightPt]);
       const embedded =
         imageBlob.type === 'image/jpeg' || imageBlob.type === 'image/jpg'
           ? await pdfDoc.embedJpg(imageBytes)
           : await pdfDoc.embedPng(imageBytes);
       page.drawImage(embedded, { x: 0, y: 0, width: pageWidthPt, height: pageHeightPt });
+      page.drawImage(embedded, { x: marginPt, y: marginPt, width: innerWidthPt, height: innerHeightPt });
       const pdfBytes = await pdfDoc.save();
       const pdfBlob = new Blob([pdfBytes], { type: 'application/pdf' });
-      const baseName = buildExportBaseName(flow.designName || '', widthCm, heightCm);
+      const baseName = buildExportBaseName(flow.designName || '', pageWidthCm, pageHeightCm);
       downloadBlob(pdfBlob, `${baseName}.pdf`);
     } catch (error) {
       console.error('[download-pdf]', error);


### PR DESCRIPTION
## Summary
- expand the generated PDF page by 2 cm on each axis and draw the stretched image so the new bleed is filled
- reuse the embedded full-resolution image data and update the exported filename with the new dimensions

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ced7724aa083278cb716e0f14e23d7