### PR TITLE
Ensure canvas exports respect cropping bounds

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -890,6 +890,10 @@ const EditorCanvas = forwardRef(function EditorCanvas(
         return padGroupRef.current.toDataURL({
           pixelRatio,
           mimeType: 'image/png',
+          x: 0,
+          y: 0,
+          width: padRectPx.w,
+          height: padRectPx.h,
         });
       } catch (e) {
         /* ignore */
@@ -1393,7 +1397,13 @@ const EditorCanvas = forwardRef(function EditorCanvas(
           style={{ display: "none" }}
         >
           <Layer>
-            <Group ref={padGroupRef}>
+            <Group
+              ref={padGroupRef}
+              clipX={0}
+              clipY={0}
+              clipWidth={padRectPx.w}
+              clipHeight={padRectPx.h}
+            >
               <Rect
                 x={0}
                 y={0}


### PR DESCRIPTION
## Summary
- clip the hidden export group to the pad dimensions so generated assets match the visible crop
- provide explicit bounds when exporting the pad group to data URLs so overflowed artwork is trimmed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ced88a98f0832780e3b24cbf01b400