### PR TITLE
Improve custom product publishing flow

### DIFF
--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -6,17 +6,27 @@ function ensureBody(req) {
   return b;
 }
 
+function normalizeVariantId(value) {
+  if (value == null) return '';
+  const raw = String(value).trim();
+  if (!raw) return '';
+  if (/^\d+$/.test(raw)) return raw;
+  const match = raw.match(/(\d+)(?:[^\d]*)$/);
+  return match ? match[1] : '';
+}
+
 export default async function createCartLink(req, res) {
   if (req.method !== 'POST') {
     res.statusCode = 405;
     return res.json({ ok: false, error: 'method_not_allowed' });
   }
   try {
-    const { variantId, quantity } = ensureBody(req);
-    if (!variantId) return res.status(400).json({ ok: false, error: 'missing_variant' });
+    const { variantId, quantity, variantGid } = ensureBody(req);
+    const normalizedVariantId = normalizeVariantId(variantId || variantGid);
+    if (!normalizedVariantId) return res.status(400).json({ ok: false, error: 'missing_variant' });
     const qty = Number(quantity) > 0 ? Number(quantity) : 1;
     const base = process.env.SHOPIFY_PUBLIC_BASE || `https://${process.env.SHOPIFY_STORE_DOMAIN}`;
-    const url = `${base}/cart/add?items[0][id]=${encodeURIComponent(variantId)}&items[0][quantity]=${qty}&return_to=%2Fcart`;
+    const url = `${base}/cart/add?items[0][id]=${encodeURIComponent(normalizedVariantId)}&items[0][quantity]=${qty}&return_to=%2Fcart`;
     return res.status(200).json({ ok: true, url });
   } catch (e) {
     console.error('create_cart_link_error', e);

--- a/lib/handlers/createCheckout.js
+++ b/lib/handlers/createCheckout.js
@@ -6,17 +6,27 @@ function ensureBody(req) {
   return b;
 }
 
+function normalizeVariantId(value) {
+  if (value == null) return '';
+  const raw = String(value).trim();
+  if (!raw) return '';
+  if (/^\d+$/.test(raw)) return raw;
+  const match = raw.match(/(\d+)(?:[^\d]*)$/);
+  return match ? match[1] : '';
+}
+
 export default async function createCheckout(req, res) {
   if (req.method !== 'POST') {
     res.statusCode = 405;
     return res.json({ ok: false, error: 'method_not_allowed' });
   }
   try {
-    const { variantId, quantity } = ensureBody(req);
-    if (!variantId) return res.status(400).json({ ok: false, error: 'missing_variant' });
+    const { variantId, quantity, variantGid } = ensureBody(req);
+    const normalizedVariantId = normalizeVariantId(variantId || variantGid);
+    if (!normalizedVariantId) return res.status(400).json({ ok: false, error: 'missing_variant' });
     const qty = Number(quantity) > 0 ? Number(quantity) : 1;
     const base = process.env.SHOPIFY_PUBLIC_BASE || `https://${process.env.SHOPIFY_STORE_DOMAIN}`;
-    const url = `${base}/cart/add?items[0][id]=${encodeURIComponent(variantId)}&items[0][quantity]=${qty}&return_to=%2Fcheckout`;
+    const url = `${base}/cart/add?items[0][id]=${encodeURIComponent(normalizedVariantId)}&items[0][quantity]=${qty}&return_to=%2Fcheckout`;
     return res.status(200).json({ ok: true, url });
   } catch (e) {
     console.error('create_checkout_error', e);

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1,37 +1,210 @@
 import { shopifyAdmin } from '../shopify.js';
 
+const DEFAULT_VENDOR = 'MGM Personalizados';
+
+function ensureBody(body) {
+  if (body && typeof body === 'object') return body;
+  if (typeof body === 'string') {
+    try { return JSON.parse(body) || {}; } catch { return {}; }
+  }
+  return {};
+}
+
+function escapeHtml(str) {
+  return String(str || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function slugifyTag(str) {
+  return String(str || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40)
+    .toLowerCase();
+}
+
+function toNumber(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function formatPrice(value) {
+  if (!Number.isFinite(value)) return null;
+  const normalized = Math.round(value * 100) / 100;
+  return normalized.toFixed(2);
+}
+
+function pickProductType(raw) {
+  const v = String(raw || '').trim().toLowerCase();
+  if (v === 'glasspad' || v === 'glass') {
+    return { key: 'glasspad', label: 'Glasspad' };
+  }
+  return { key: 'mousepad', label: 'Mousepad' };
+}
+
+function buildDescription({ description, designName, productTypeLabel, widthCm, heightCm, approxDpi }) {
+  if (description) return description;
+  const sections = [
+    '<p>Producto personalizado generado con el configurador de MGM.</p>',
+  ];
+  if (designName) {
+    sections.push(`<p><strong>Diseño:</strong> ${escapeHtml(designName)}</p>`);
+  }
+  if (Number.isFinite(widthCm) && Number.isFinite(heightCm) && widthCm > 0 && heightCm > 0) {
+    const dim = `${widthCm.toFixed(1)} × ${heightCm.toFixed(1)} cm`;
+    sections.push(`<p><strong>Medidas:</strong> ${escapeHtml(dim)}</p>`);
+  }
+  sections.push(`<p><strong>Tipo:</strong> ${escapeHtml(productTypeLabel)}</p>`);
+  if (Number.isFinite(approxDpi) && approxDpi > 0) {
+    sections.push(`<p><strong>Resolución aproximada:</strong> ${Math.round(approxDpi)}</p>`);
+  }
+  return sections.join('');
+}
+
+function buildTags({ baseTags, productTypeKey, designName, widthCm, heightCm }) {
+  const tags = new Set(['configurador', 'personalizado']);
+  if (productTypeKey) tags.add(`tipo-${productTypeKey}`);
+  if (Number.isFinite(widthCm) && Number.isFinite(heightCm) && widthCm > 0 && heightCm > 0) {
+    const sizeTag = `size-${Math.round(widthCm)}x${Math.round(heightCm)}cm`;
+    tags.add(sizeTag);
+  }
+  if (designName) {
+    const slug = slugifyTag(designName);
+    if (slug) tags.add(`design-${slug}`);
+  }
+  if (Array.isArray(baseTags)) {
+    baseTags.map((t) => String(t || '').trim()).filter(Boolean).forEach((t) => tags.add(t));
+  } else if (typeof baseTags === 'string') {
+    baseTags.split(',').map((t) => t.trim()).filter(Boolean).forEach((t) => tags.add(t));
+  }
+  return Array.from(tags).filter(Boolean);
+}
+
+function buildProductUrl(handle) {
+  if (!handle) return undefined;
+  const base =
+    process.env.SHOPIFY_PUBLIC_BASE
+    || (process.env.SHOPIFY_STOREFRONT_DOMAIN ? `https://${process.env.SHOPIFY_STOREFRONT_DOMAIN}` : '')
+    || (process.env.SHOPIFY_STORE_DOMAIN ? `https://${process.env.SHOPIFY_STORE_DOMAIN}` : '');
+  if (!base) return undefined;
+  return `${base.replace(/\/$/, '')}/products/${handle}`;
+}
+
 export async function publishProduct(req, res) {
   if (req.method !== 'POST') {
     res.statusCode = 405;
     return res.json({ ok: false, error: 'method_not_allowed' });
   }
   try {
-    // Safe JSON parse
-    let body = req.body;
-    if (!body || typeof body !== 'object') {
-      try { body = JSON.parse(String(body || '')) || {}; } catch { body = {}; }
-    }
+    const body = ensureBody(req.body);
 
-    const title = typeof body.title === 'string' ? body.title : '';
-    const description = typeof body.description === 'string' ? body.description : '';
     const mockupDataUrl = typeof body.mockupDataUrl === 'string' ? body.mockupDataUrl : '';
     const filename = typeof body.filename === 'string' && body.filename ? body.filename : 'mockup.png';
-    const productType = typeof body.productType === 'string' && body.productType ? body.productType : 'Mousepad';
-    const price = body.price != null ? String(body.price) : undefined;
 
-    if (!title || !mockupDataUrl) {
-      return res.status(400).json({ ok: false, reason: 'missing_fields' });
+    if (!mockupDataUrl) {
+      return res.status(400).json({ ok: false, reason: 'missing_mockup_dataurl' });
     }
     const b64 = (mockupDataUrl.split(',')[1] || '').trim();
     if (!b64) return res.status(400).json({ ok: false, reason: 'invalid_mockup_dataurl' });
 
+    const designNameRaw = typeof body.designName === 'string' ? body.designName.trim() : '';
+    const { key: productTypeKey, label: productTypeLabel } = pickProductType(body.productType);
+    const approxDpi = toNumber(body.approxDpi ?? body.approx_dpi);
+    const widthCm = toNumber(body.widthCm ?? body.width_cm);
+    const heightCm = toNumber(body.heightCm ?? body.height_cm);
+
+    const baseTitle = typeof body.title === 'string' ? body.title.trim() : '';
+    const fallbackTitle = designNameRaw
+      ? `${productTypeLabel} personalizado - ${designNameRaw}`
+      : `${productTypeLabel} personalizado`;
+    const title = (baseTitle || fallbackTitle).slice(0, 254);
+
+    const priceTransfer = toNumber(body.priceTransfer ?? body.price);
+    const priceNormal = toNumber(body.priceNormal ?? body.compareAtPrice ?? body.priceNormalAmount);
+    const priceCurrency = typeof body.priceCurrency === 'string' && body.priceCurrency.trim()
+      ? body.priceCurrency.trim().toUpperCase()
+      : 'ARS';
+
+    const description = buildDescription({
+      description: typeof body.description === 'string' ? body.description : '',
+      designName: designNameRaw,
+      productTypeLabel,
+      widthCm,
+      heightCm,
+      approxDpi,
+    });
+
+    const tags = buildTags({
+      baseTags: body.tags,
+      productTypeKey,
+      designName: designNameRaw,
+      widthCm,
+      heightCm,
+    });
+
+    const priceValue = Number.isFinite(priceTransfer) && priceTransfer > 0 ? formatPrice(priceTransfer) : '0.00';
+    const compareAt = Number.isFinite(priceNormal) && priceNormal > (priceTransfer || 0)
+      ? formatPrice(priceNormal)
+      : null;
+
+    const imageAlt = typeof body.imageAlt === 'string' && body.imageAlt.trim()
+      ? body.imageAlt.trim().slice(0, 254)
+      : title;
+
+    const variant = {
+      price: priceValue,
+      ...(compareAt ? { compare_at_price: compareAt } : {}),
+      requires_shipping: true,
+      taxable: true,
+      inventory_management: null,
+      inventory_policy: 'continue',
+      option1: 'Default Title',
+    };
+    if (body.sku) {
+      variant.sku = String(body.sku).slice(0, 64);
+    }
+
     const payload = {
       product: {
         title,
-        body_html: description || '',
-        product_type: productType,
-        images: [{ attachment: b64, filename, alt: title }],
-        ...(price ? { variants: [{ price: String(price) }] } : {}),
+        body_html: description,
+        product_type: productTypeLabel,
+        status: 'active',
+        published_scope: 'web',
+        tags: tags.join(', '),
+        vendor: typeof body.vendor === 'string' && body.vendor.trim() ? body.vendor.trim() : DEFAULT_VENDOR,
+        template_suffix: '',
+        variants: [variant],
+        images: [
+          {
+            attachment: b64,
+            filename,
+            alt: imageAlt,
+          },
+        ],
+        metafields: [
+          ...(designNameRaw
+            ? [{ key: 'design_name', value: designNameRaw.slice(0, 250), type: 'single_line_text_field', namespace: 'custom' }]
+            : []),
+          ...(Number.isFinite(widthCm) && widthCm > 0
+            ? [{ key: 'width_cm', value: String(widthCm), type: 'single_line_text_field', namespace: 'custom' }]
+            : []),
+          ...(Number.isFinite(heightCm) && heightCm > 0
+            ? [{ key: 'height_cm', value: String(heightCm), type: 'single_line_text_field', namespace: 'custom' }]
+            : []),
+          ...(Number.isFinite(approxDpi) && approxDpi > 0
+            ? [{ key: 'approx_dpi', value: String(Math.round(approxDpi)), type: 'single_line_text_field', namespace: 'custom' }]
+            : []),
+          ...(priceCurrency
+            ? [{ key: 'price_currency', value: priceCurrency, type: 'single_line_text_field', namespace: 'custom' }]
+            : []),
+        ],
       },
     };
 
@@ -42,14 +215,25 @@ export async function publishProduct(req, res) {
 
     if (!resp.ok) {
       const text = await resp.text().catch(() => '');
-      return res.status(502).json({ ok: false, reason: 'shopify_error', status: resp.status, body: text.slice(0, 1000) });
+      return res.status(502).json({ ok: false, reason: 'shopify_error', status: resp.status, body: text.slice(0, 2000) });
     }
-    const data = await resp.json();
+    const data = await resp.json().catch(() => ({}));
     const product = data?.product || {};
-    return res.status(200).json({ ok: true, product: { id: product.id, handle: product.handle, admin_graphql_api_id: product.admin_graphql_api_id } });
+    const variantResp = Array.isArray(product?.variants) ? product.variants[0] || {} : {};
+
+    return res.status(200).json({
+      ok: true,
+      productId: product?.id ? String(product.id) : undefined,
+      productHandle: product?.handle || undefined,
+      productAdminId: product?.admin_graphql_api_id,
+      variantId: variantResp?.id ? String(variantResp.id) : undefined,
+      variantAdminId: variantResp?.admin_graphql_api_id,
+      productUrl: product?.handle ? buildProductUrl(product.handle) : undefined,
+      status: product?.status,
+    });
   } catch (e) {
     if (e?.message === 'SHOPIFY_ENV_MISSING') {
-      return res.status(400).json({ ok: false, reason: 'shopify_env_missing', missing: e?.missing || ['SHOPIFY_STORE_DOMAIN','SHOPIFY_ADMIN_TOKEN'] });
+      return res.status(400).json({ ok: false, reason: 'shopify_env_missing', missing: e?.missing || ['SHOPIFY_STORE_DOMAIN', 'SHOPIFY_ADMIN_TOKEN'] });
     }
     console.error('publish_product_error', e);
     return res.status(500).json({ ok: false, reason: 'internal_error' });

--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -1,6 +1,28 @@
 import { apiFetch } from './api';
 import { FlowState } from '@/state/flow';
 
+const PRODUCT_LABELS = {
+  mousepad: 'Mousepad',
+  glasspad: 'Glasspad',
+} as const;
+
+function slugify(value: string, fallback = 'mockup') {
+  const base = (value || '').toString();
+  const cleaned = base
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+  return (cleaned || fallback).slice(0, 60);
+}
+
+function safeNumber(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : undefined;
+}
+
 export async function blobToBase64(b: Blob): Promise<string> {
   return new Promise((res, rej) => {
     const r = new FileReader();
@@ -13,46 +35,112 @@ export async function blobToBase64(b: Blob): Promise<string> {
 export async function createJobAndProduct(mode: 'checkout' | 'cart', flow: FlowState) {
   if (!flow.mockupBlob) throw new Error('missing_mockup');
   const mockupDataUrl = await blobToBase64(flow.mockupBlob);
-  const publish = await apiFetch('/api/publish-product', {
+  const productType = flow.productType === 'glasspad' ? 'glasspad' : 'mousepad';
+  const productLabel = PRODUCT_LABELS[productType];
+  const designName = (flow.designName || '').trim();
+  const productTitle = designName
+    ? `${productLabel} personalizado - ${designName}`
+    : `${productLabel} personalizado`;
+  const widthCm = safeNumber((flow.editorState as any)?.size_cm?.w);
+  const heightCm = safeNumber((flow.editorState as any)?.size_cm?.h);
+  const approxDpi = safeNumber(flow.approxDpi);
+  const priceTransfer = safeNumber(flow.priceTransfer);
+  const priceNormal = safeNumber(flow.priceNormal);
+  const priceCurrencyRaw = typeof flow.priceCurrency === 'string' ? flow.priceCurrency : 'ARS';
+  const priceCurrency = priceCurrencyRaw.trim() || 'ARS';
+  const extraTags: string[] = [`currency-${priceCurrency.toLowerCase()}`];
+  if (flow.lowQualityAck) extraTags.push('calidad-baja');
+  const filename = `${slugify(designName || productTitle)}.png`;
+  const imageAlt = `Mockup ${productTitle}`;
+
+  const publishResp = await apiFetch('/api/publish-product', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      productType: flow.productType,
+      productType,
       mockupDataUrl,
+      designName,
+      title: productTitle,
+      widthCm,
+      heightCm,
+      approxDpi,
+      priceTransfer,
+      priceNormal,
+      priceCurrency,
+      lowQualityAck: Boolean(flow.lowQualityAck),
+      imageAlt,
+      filename,
+      tags: extraTags,
     }),
-  }).then((r) => r.json());
-
-  if (!publish?.ok) throw new Error(publish?.error || 'publish_failed');
-
-  let result: { checkoutUrl?: string; cartUrl?: string; productId?: string; variantId?: string } = {
-    productId: publish.productId,
-    variantId: publish.variantId,
-  };
-
-  if (mode === 'checkout') {
-    const ck = await apiFetch('/api/create-checkout', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        productId: publish.productId,
-        variantId: publish.variantId,
-        quantity: 1,
-      }),
-    }).then((r) => r.json());
-    if (ck?.url) result.checkoutUrl = ck.url;
-  } else {
-    const cl = await apiFetch('/api/create-cart-link', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        productId: publish.productId,
-        variantId: publish.variantId,
-        quantity: 1,
-      }),
-    }).then((r) => r.json());
-    if (cl?.url) result.cartUrl = cl.url;
+  });
+  const publish = await publishResp.json().catch(() => null);
+  if (!publishResp.ok || !publish?.ok) {
+    const reason = publish?.reason || publish?.error || `publish_failed_${publishResp.status}`;
+    throw new Error(reason);
   }
 
-  flow.set({ lastProduct: { ...result } });
-  return result;
+  const productId: string | undefined = publish.productId ? String(publish.productId) : undefined;
+  const variantId: string | undefined = publish.variantId ? String(publish.variantId) : undefined;
+  if (!variantId) {
+    flow.set({ lastProduct: { productId, productUrl: publish.productUrl, productHandle: publish.productHandle } });
+    throw new Error('missing_variant');
+  }
+
+  const result: {
+    checkoutUrl?: string;
+    cartUrl?: string;
+    productId?: string;
+    variantId?: string;
+    productUrl?: string;
+  } = {
+    productId,
+    variantId,
+    productUrl: publish.productUrl,
+  };
+
+  try {
+    if (mode === 'checkout') {
+      const ckResp = await apiFetch('/api/create-checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          productId,
+          variantId,
+          quantity: 1,
+        }),
+      });
+      const ck = await ckResp.json().catch(() => null);
+      if (!ckResp.ok || !ck?.url) {
+        throw new Error('checkout_link_failed');
+      }
+      result.checkoutUrl = ck.url;
+    } else {
+      const clResp = await apiFetch('/api/create-cart-link', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          productId,
+          variantId,
+          quantity: 1,
+        }),
+      });
+      const cl = await clResp.json().catch(() => null);
+      if (!clResp.ok || !cl?.url) {
+        throw new Error('cart_link_failed');
+      }
+      result.cartUrl = cl.url;
+    }
+    return result;
+  } finally {
+    flow.set({
+      lastProduct: {
+        productId,
+        variantId,
+        cartUrl: result.cartUrl,
+        checkoutUrl: result.checkoutUrl,
+        productUrl: publish.productUrl,
+        productHandle: publish.productHandle,
+      },
+    });
+  }
 }

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -206,6 +206,9 @@ export default function Home() {
       });
       const mockupUrl = URL.createObjectURL(blob);
 
+      const transferPrice = Number(priceAmount) > 0 ? Number(priceAmount) : 0;
+      const normalPrice = transferPrice > 0 ? Math.max(transferPrice, Math.round(transferPrice / 0.8)) : 0;
+
       flow.set({
         productType: material === 'Glasspad' ? 'glasspad' : 'mousepad',
         editorState: layout,
@@ -215,6 +218,9 @@ export default function Home() {
         designName: trimmedDesignName,
         lowQualityAck: level === 'bad' ? Boolean(ackLow) : false,
         approxDpi: effDpi || null,
+        priceTransfer: transferPrice,
+        priceNormal: normalPrice,
+        priceCurrency: PRICE_CURRENCY,
       });
       navigate('/mockup');
     } catch (e) {

--- a/mgm-front/src/state/flow.js
+++ b/mgm-front/src/state/flow.js
@@ -9,6 +9,9 @@ const defaultState = {
   designName: '',
   lowQualityAck: false,
   approxDpi: null,
+  priceTransfer: 0,
+  priceNormal: 0,
+  priceCurrency: 'ARS',
   lastProduct: null,
 };
 

--- a/mgm-front/src/state/flow.tsx
+++ b/mgm-front/src/state/flow.tsx
@@ -9,7 +9,17 @@ export type FlowState = {
   designName?: string;
   lowQualityAck?: boolean;
   approxDpi?: number | null;
-  lastProduct?: { productId?: string; variantId?: string; cartUrl?: string; checkoutUrl?: string };
+  priceTransfer?: number;
+  priceNormal?: number;
+  priceCurrency?: string;
+  lastProduct?: {
+    productId?: string;
+    variantId?: string;
+    cartUrl?: string;
+    checkoutUrl?: string;
+    productUrl?: string;
+    productHandle?: string;
+  };
   set: (p: Partial<FlowState>) => void;
   reset: () => void;
 };
@@ -23,6 +33,9 @@ const defaultState: Omit<FlowState, 'set' | 'reset'> = {
   designName: '',
   lowQualityAck: false,
   approxDpi: null,
+  priceTransfer: 0,
+  priceNormal: 0,
+  priceCurrency: 'ARS',
   lastProduct: undefined,
 };
 


### PR DESCRIPTION
## Summary
- enrich the `/api/publish-product` handler so Shopify products are created as active items with metadata, pricing details, and returned handles/variant IDs for downstream use
- normalize variant identifiers in the cart and checkout link endpoints and surface the new Shopify data to the frontend flow state
- update the React flow to persist pricing details and rely on a single helper to publish products and build cart/checkout links when the user confirms their design

## Testing
- `npm run lint` *(fails: pre-existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ceda06ad5c83278a858886cf9e1ca2