### PR TITLE
Relax low-resolution review when DPI is sufficient

### DIFF
--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -204,6 +204,9 @@ async function detectNazi(buffer) {
 
 // Ensure the moderation heuristics evaluate at least a medium sized canvas.
 const MIN_PADDED_DIMENSION = 512;
+// Allow small source images when the effective DPI is acceptable (matches front-end thresholds).
+const LOW_RES_MIN_DIMENSION = 256;
+const LOW_RES_MIN_APPROX_DPI = 100;
 
 async function prepareModerationImage(buffer) {
   try {
@@ -411,12 +414,16 @@ export async function evaluateImage(buffer, filename, designName = '', options =
   const originalMeta = debug.metadata?.original || null;
   const normalizedMeta = debug.metadata?.normalized || null;
   const meta = originalMeta || normalizedMeta || debug.metadata || {};
+  const approxDpiValid = Number.isFinite(approxDpi);
+  const approxDpiSufficient = approxDpiValid && approxDpi >= LOW_RES_MIN_APPROX_DPI;
   let lowResolutionOverrideRequested = false;
   if (SEVERITY_RANK[label] < SEVERITY_RANK.BLOCK) {
-    const lowResolution = Boolean(
-      (meta.width && meta.width < 256) || (meta.height && meta.height < 256)
+    const lowResolutionDimensions = Boolean(
+      (meta.width && meta.width < LOW_RES_MIN_DIMENSION) ||
+      (meta.height && meta.height < LOW_RES_MIN_DIMENSION)
     );
-    if (lowResolution) {
+    const lowResolutionConcern = lowResolutionDimensions && !approxDpiSufficient;
+    if (lowResolutionConcern) {
       debug.scores.lowResolution = 0.45;
       if (lowQualityAck) {
         debug.flags = { ...debug.flags, lowResolutionOverride: true };
@@ -425,6 +432,15 @@ export async function evaluateImage(buffer, filename, designName = '', options =
       } else {
         applyOutcome('REVIEW', ['low_resolution_uncertain'], 0.45);
       }
+    } else if (lowResolutionDimensions) {
+      debug.flags = {
+        ...debug.flags,
+        lowResolutionBypassed: {
+          approxDpi: approxDpiValid ? approxDpi : null,
+          width: meta.width || null,
+          height: meta.height || null,
+        },
+      };
     }
   }
 


### PR DESCRIPTION
## Summary
- skip the low-resolution review outcome when the source dimensions are small but the effective DPI is acceptable
- expose debug metadata whenever the low-resolution check is bypassed because of sufficient DPI

## Testing
- node --test tests/api-handlers.test.js *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/workspace/MGM-PERSONALIZADOS/api/_lib/env.js')*

------
https://chatgpt.com/codex/tasks/task_e_68cef269df308327afa940deb558ad36