### PR TITLE
Improve Shopify env configuration feedback

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -233,7 +233,15 @@ export async function publishProduct(req, res) {
     });
   } catch (e) {
     if (e?.message === 'SHOPIFY_ENV_MISSING') {
-      return res.status(400).json({ ok: false, reason: 'shopify_env_missing', missing: e?.missing || ['SHOPIFY_STORE_DOMAIN', 'SHOPIFY_ADMIN_TOKEN'] });
+      const missing = Array.isArray(e?.missing) && e.missing.length
+        ? e.missing
+        : ['SHOPIFY_STORE_DOMAIN', 'SHOPIFY_ADMIN_TOKEN'];
+      return res.status(400).json({
+        ok: false,
+        reason: 'shopify_env_missing',
+        missing,
+        message: `Faltan variables de entorno para Shopify: ${missing.join(', ')}.`,
+      });
     }
     console.error('publish_product_error', e);
     return res.status(500).json({ ok: false, reason: 'internal_error' });

--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -76,7 +76,15 @@ export async function createJobAndProduct(mode: 'checkout' | 'cart', flow: FlowS
   const publish = await publishResp.json().catch(() => null);
   if (!publishResp.ok || !publish?.ok) {
     const reason = publish?.reason || publish?.error || `publish_failed_${publishResp.status}`;
-    throw new Error(reason);
+    const err: Error & { reason?: string; friendlyMessage?: string; missing?: string[] } = new Error(reason);
+    err.reason = reason;
+    if (typeof publish?.message === 'string' && publish.message.trim()) {
+      err.friendlyMessage = publish.message.trim();
+    }
+    if (Array.isArray(publish?.missing) && publish.missing.length) {
+      err.missing = publish.missing;
+    }
+    throw err;
   }
 
   const productId: string | undefined = publish.productId ? String(publish.productId) : undefined;

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -42,14 +42,23 @@ export default function Mockup() {
       alert('El producto se creó pero no se pudo obtener un enlace.');
     } catch (e) {
       console.error('[mockup-handle]', e);
-      const message = String(e?.message || 'Error');
-      let friendly = message;
-      if (message === 'missing_mockup') friendly = 'No se encontró el mockup para publicar.';
-      else if (message === 'missing_variant') friendly = 'No se pudo obtener la variante del producto creado en Shopify.';
-      else if (message === 'cart_link_failed') friendly = 'No se pudo generar el enlace del carrito. Revisá la configuración de Shopify.';
-      else if (message === 'checkout_link_failed') friendly = 'No se pudo generar el enlace de compra.';
-      else if (message.startsWith('publish_failed')) friendly = 'Shopify rechazó la creación del producto. Revisá los datos enviados.';
-      else if (message === 'shopify_error') friendly = 'Shopify devolvió un error al crear el producto.';
+      const reasonRaw = typeof e?.reason === 'string' && e.reason ? e.reason : String(e?.message || 'Error');
+      const messageRaw = typeof e?.friendlyMessage === 'string' && e.friendlyMessage
+        ? e.friendlyMessage
+        : String(e?.message || 'Error');
+      let friendly = messageRaw;
+      if (reasonRaw === 'missing_mockup') friendly = 'No se encontró el mockup para publicar.';
+      else if (reasonRaw === 'missing_variant') friendly = 'No se pudo obtener la variante del producto creado en Shopify.';
+      else if (reasonRaw === 'cart_link_failed') friendly = 'No se pudo generar el enlace del carrito. Revisá la configuración de Shopify.';
+      else if (reasonRaw === 'checkout_link_failed') friendly = 'No se pudo generar el enlace de compra.';
+      else if (reasonRaw.startsWith('publish_failed')) friendly = 'Shopify rechazó la creación del producto. Revisá los datos enviados.';
+      else if (reasonRaw === 'shopify_error') friendly = 'Shopify devolvió un error al crear el producto.';
+      else if (reasonRaw === 'shopify_env_missing') {
+        const missing = Array.isArray(e?.missing) && e.missing.length
+          ? e.missing.join(', ')
+          : 'SHOPIFY_STORE_DOMAIN, SHOPIFY_ADMIN_TOKEN';
+        friendly = `La integración con Shopify no está configurada. Faltan las variables: ${missing}.`;
+      }
       alert(friendly);
     } finally {
       setBusy(false);


### PR DESCRIPTION
## Summary
- add a descriptive message to the publish-product endpoint when Shopify environment variables are missing
- propagate Shopify error metadata to the front-end helper and surface a friendly alert when the integration is not configured

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cef3e0876083279e9fa0d3fda783de