### PR TITLE
Actualizar controles de escalado de imagen

### DIFF
--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -119,16 +119,10 @@
   margin-top: 8px;
 }
 
-.freeScale {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
 .qualityBadge {
   padding: 6px 10px;
   border-radius: 999px;
+  margin-left: auto;
 }
 
 .qualityUnknown { background: #9ca3af22; color: #9ca3af; border: 1px solid #9ca3af; }
@@ -211,14 +205,6 @@
 .qualityBadge {
   white-space: nowrap;
   flex: 0 0 auto;
-}
-
-/* El label del checkbox en línea sin crecer raro */
-.freeScale {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  white-space: nowrap;
 }
 
 /* Medios y textos largos no deben empujar layout */


### PR DESCRIPTION
## Summary
- alterna automáticamente entre escalado proporcional y libre según el ancla activo del Transformer
- habilita nuevos tiradores laterales y centrales, y quita el botón de rotación y el modo de escala libre
- ajusta los estilos para eliminar la clase del modo libre y mantener el badge de calidad alineado

## Testing
- npm run lint *(falla: errores preexistentes fuera de estos cambios)*

------
https://chatgpt.com/codex/tasks/task_e_68cef516aa7c83279238a9391f97a5eb