### PR TITLE
Adjust Shopify cart flow and product metadata

### DIFF
--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -25,8 +25,11 @@ export default async function createCartLink(req, res) {
     const normalizedVariantId = normalizeVariantId(variantId || variantGid);
     if (!normalizedVariantId) return res.status(400).json({ ok: false, error: 'missing_variant' });
     const qty = Number(quantity) > 0 ? Number(quantity) : 1;
-    const base = process.env.SHOPIFY_PUBLIC_BASE || `https://${process.env.SHOPIFY_STORE_DOMAIN}`;
-    const url = `${base}/cart/add?items[0][id]=${encodeURIComponent(normalizedVariantId)}&items[0][quantity]=${qty}&return_to=%2Fcart`;
+    const baseRaw = process.env.SHOPIFY_PUBLIC_BASE || (process.env.SHOPIFY_STORE_DOMAIN ? `https://${process.env.SHOPIFY_STORE_DOMAIN}` : '');
+    if (!baseRaw) return res.status(500).json({ ok: false, error: 'missing_store_domain' });
+    const base = baseRaw.replace(/\/$/, '');
+    const returnToRaw = process.env.SHOPIFY_CART_RETURN_TO || 'https://www.mgmgamers.store/';
+    const url = `${base}/cart/add?items[0][id]=${encodeURIComponent(normalizedVariantId)}&items[0][quantity]=${qty}&return_to=${encodeURIComponent(returnToRaw)}`;
     return res.status(200).json({ ok: true, url });
   } catch (e) {
     console.error('create_cart_link_error', e);

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -10,15 +10,6 @@ function ensureBody(body) {
   return {};
 }
 
-function escapeHtml(str) {
-  return String(str || '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
 function slugifyTag(str) {
   return String(str || '')
     .normalize('NFD')
@@ -48,26 +39,35 @@ function pickProductType(raw) {
   return { key: 'mousepad', label: 'Mousepad' };
 }
 
-function buildDescription({ description, designName, productTypeLabel, widthCm, heightCm, approxDpi }) {
-  if (description) return description;
-  const sections = [
-    '<p>Producto personalizado generado con el configurador de MGM.</p>',
-  ];
-  if (designName) {
-    sections.push(`<p><strong>Diseño:</strong> ${escapeHtml(designName)}</p>`);
+function formatDimension(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return null;
+  const rounded = Math.round(value * 10) / 10;
+  if (Math.abs(rounded - Math.round(rounded)) < 1e-6) {
+    return String(Math.round(rounded));
   }
-  if (Number.isFinite(widthCm) && Number.isFinite(heightCm) && widthCm > 0 && heightCm > 0) {
-    const dim = `${widthCm.toFixed(1)} × ${heightCm.toFixed(1)} cm`;
-    sections.push(`<p><strong>Medidas:</strong> ${escapeHtml(dim)}</p>`);
-  }
-  sections.push(`<p><strong>Tipo:</strong> ${escapeHtml(productTypeLabel)}</p>`);
-  if (Number.isFinite(approxDpi) && approxDpi > 0) {
-    sections.push(`<p><strong>Resolución aproximada:</strong> ${Math.round(approxDpi)}</p>`);
-  }
-  return sections.join('');
+  return rounded.toFixed(1).replace(/\.0+$/, '');
 }
 
-function buildTags({ baseTags, productTypeKey, designName, widthCm, heightCm }) {
+function buildMeasurement(widthCm, heightCm) {
+  const w = formatDimension(widthCm);
+  const h = formatDimension(heightCm);
+  if (!w || !h) return null;
+  return `${w}x${h}`;
+}
+
+function buildMetaDescription({ productTypeLabel, designName, widthCm, heightCm, materialLabel }) {
+  const measurement = buildMeasurement(widthCm, heightCm);
+  const baseLabel = productTypeLabel === 'Glasspad'
+    ? 'Glasspad gamer personalizado'
+    : 'Mousepad gamer personalizado';
+  const sections = [baseLabel];
+  if (designName) sections.push(`Diseño ${designName}`);
+  if (measurement) sections.push(`Medida ${measurement} cm`);
+  if (materialLabel) sections.push(`Material ${materialLabel}`);
+  return `${sections.join('. ')}.`;
+}
+
+function buildTags({ baseTags, productTypeKey, designName, widthCm, heightCm, materialLabel }) {
   const tags = new Set(['configurador', 'personalizado']);
   if (productTypeKey) tags.add(`tipo-${productTypeKey}`);
   if (Number.isFinite(widthCm) && Number.isFinite(heightCm) && widthCm > 0 && heightCm > 0) {
@@ -77,6 +77,10 @@ function buildTags({ baseTags, productTypeKey, designName, widthCm, heightCm }) 
   if (designName) {
     const slug = slugifyTag(designName);
     if (slug) tags.add(`design-${slug}`);
+  }
+  if (materialLabel) {
+    const slug = slugifyTag(materialLabel);
+    if (slug) tags.add(`material-${slug}`);
   }
   if (Array.isArray(baseTags)) {
     baseTags.map((t) => String(t || '').trim()).filter(Boolean).forEach((t) => tags.add(t));
@@ -118,11 +122,16 @@ export async function publishProduct(req, res) {
     const approxDpi = toNumber(body.approxDpi ?? body.approx_dpi);
     const widthCm = toNumber(body.widthCm ?? body.width_cm);
     const heightCm = toNumber(body.heightCm ?? body.height_cm);
+    const measurementLabel = buildMeasurement(widthCm, heightCm);
+    const materialRaw = typeof body.material === 'string' ? body.material.trim() : '';
+    const materialLabel = materialRaw || (productTypeKey === 'glasspad' ? 'Glasspad' : '');
 
     const baseTitle = typeof body.title === 'string' ? body.title.trim() : '';
-    const fallbackTitle = designNameRaw
-      ? `${productTypeLabel} personalizado - ${designNameRaw}`
-      : `${productTypeLabel} personalizado`;
+    const fallbackTitleParts = [productTypeLabel];
+    if (designNameRaw) fallbackTitleParts.push(designNameRaw);
+    if (measurementLabel) fallbackTitleParts.push(measurementLabel);
+    if (materialLabel) fallbackTitleParts.push(materialLabel);
+    const fallbackTitle = `${fallbackTitleParts.join(' ')} | PERSONALIZADO`;
     const title = (baseTitle || fallbackTitle).slice(0, 254);
 
     const priceTransfer = toNumber(body.priceTransfer ?? body.price);
@@ -131,14 +140,7 @@ export async function publishProduct(req, res) {
       ? body.priceCurrency.trim().toUpperCase()
       : 'ARS';
 
-    const description = buildDescription({
-      description: typeof body.description === 'string' ? body.description : '',
-      designName: designNameRaw,
-      productTypeLabel,
-      widthCm,
-      heightCm,
-      approxDpi,
-    });
+    const description = typeof body.description === 'string' ? body.description : '';
 
     const tags = buildTags({
       baseTags: body.tags,
@@ -146,7 +148,18 @@ export async function publishProduct(req, res) {
       designName: designNameRaw,
       widthCm,
       heightCm,
+      materialLabel,
     });
+
+    const metaDescriptionRaw = typeof body.seoDescription === 'string' ? body.seoDescription.trim() : '';
+    const generatedMeta = buildMetaDescription({
+      productTypeLabel,
+      designName: designNameRaw,
+      widthCm,
+      heightCm,
+      materialLabel,
+    });
+    const metaDescription = (metaDescriptionRaw || generatedMeta || '').trim().slice(0, 320);
 
     const priceValue = Number.isFinite(priceTransfer) && priceTransfer > 0 ? formatPrice(priceTransfer) : '0.00';
     const compareAt = Number.isFinite(priceNormal) && priceNormal > (priceTransfer || 0)
@@ -180,6 +193,8 @@ export async function publishProduct(req, res) {
         tags: tags.join(', '),
         vendor: typeof body.vendor === 'string' && body.vendor.trim() ? body.vendor.trim() : DEFAULT_VENDOR,
         template_suffix: '',
+        metafields_global_title_tag: title,
+        ...(metaDescription ? { metafields_global_description_tag: metaDescription } : {}),
         variants: [variant],
         images: [
           {
@@ -197,6 +212,9 @@ export async function publishProduct(req, res) {
             : []),
           ...(Number.isFinite(heightCm) && heightCm > 0
             ? [{ key: 'height_cm', value: String(heightCm), type: 'single_line_text_field', namespace: 'custom' }]
+            : []),
+          ...(materialLabel
+            ? [{ key: 'material', value: materialLabel.slice(0, 60), type: 'single_line_text_field', namespace: 'custom' }]
             : []),
           ...(Number.isFinite(approxDpi) && approxDpi > 0
             ? [{ key: 'approx_dpi', value: String(Math.round(approxDpi)), type: 'single_line_text_field', namespace: 'custom' }]

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -207,7 +207,7 @@ export default function Home() {
       const mockupUrl = URL.createObjectURL(blob);
 
       const transferPrice = Number(priceAmount) > 0 ? Number(priceAmount) : 0;
-      const normalPrice = transferPrice > 0 ? Math.max(transferPrice, Math.round(transferPrice / 0.8)) : 0;
+      const normalPrice = transferPrice;
 
       flow.set({
         productType: material === 'Glasspad' ? 'glasspad' : 'mousepad',
@@ -216,6 +216,7 @@ export default function Home() {
         mockupUrl,
         printFullResDataUrl: master,
         designName: trimmedDesignName,
+        material,
         lowQualityAck: level === 'bad' ? Boolean(ackLow) : false,
         approxDpi: effDpi || null,
         priceTransfer: transferPrice,

--- a/mgm-front/src/state/flow.js
+++ b/mgm-front/src/state/flow.js
@@ -7,6 +7,7 @@ const defaultState = {
   mockupUrl: null,
   printFullResDataUrl: null,
   designName: '',
+  material: 'Classic',
   lowQualityAck: false,
   approxDpi: null,
   priceTransfer: 0,

--- a/mgm-front/src/state/flow.tsx
+++ b/mgm-front/src/state/flow.tsx
@@ -7,6 +7,7 @@ export type FlowState = {
   mockupUrl?: string;
   printFullResDataUrl?: string;
   designName?: string;
+  material?: string;
   lowQualityAck?: boolean;
   approxDpi?: number | null;
   priceTransfer?: number;
@@ -31,6 +32,7 @@ const defaultState: Omit<FlowState, 'set' | 'reset'> = {
   mockupUrl: undefined,
   printFullResDataUrl: undefined,
   designName: '',
+  material: 'Classic',
   lowQualityAck: false,
   approxDpi: null,
   priceTransfer: 0,


### PR DESCRIPTION
## Summary
- ensure generated cart links redirect back to the store home while keeping the created product in the cart
- enrich Shopify product payloads with material/size data, blank descriptions, and SEO meta descriptions aligned with the configurator output
- persist the selected material and transfer price in the flow state so product titles and pricing use the correct values

## Testing
- npm run lint *(fails: existing lint issues in unrelated files such as ColorPopover.jsx, SeoJsonLd.jsx, jobPayload.js, DevRenderPreview.jsx, Result.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cefa9106f08327a3293437a8f92572