### PR TITLE
Adjust Shopify product defaults

### DIFF
--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -1,3 +1,5 @@
+import { getPublicStorefrontBase } from '../publicStorefront.js';
+
 function ensureBody(req) {
   let b = req.body;
   if (!b || typeof b !== 'object') {
@@ -25,11 +27,10 @@ export default async function createCartLink(req, res) {
     const normalizedVariantId = normalizeVariantId(variantId || variantGid);
     if (!normalizedVariantId) return res.status(400).json({ ok: false, error: 'missing_variant' });
     const qty = Number(quantity) > 0 ? Number(quantity) : 1;
-    const baseRaw = process.env.SHOPIFY_PUBLIC_BASE || (process.env.SHOPIFY_STORE_DOMAIN ? `https://${process.env.SHOPIFY_STORE_DOMAIN}` : '');
-    if (!baseRaw) return res.status(500).json({ ok: false, error: 'missing_store_domain' });
-    const base = baseRaw.replace(/\/$/, '');
+    const base = getPublicStorefrontBase();
+    if (!base) return res.status(500).json({ ok: false, error: 'missing_store_domain' });
     const returnToRaw = process.env.SHOPIFY_CART_RETURN_TO || 'https://www.mgmgamers.store/';
-    const url = `${base}/cart/add?items[0][id]=${encodeURIComponent(normalizedVariantId)}&items[0][quantity]=${qty}&return_to=${encodeURIComponent(returnToRaw)}`;
+    const url = `${base.replace(/\/$/, '')}/cart/add?items[0][id]=${encodeURIComponent(normalizedVariantId)}&items[0][quantity]=${qty}&return_to=${encodeURIComponent(returnToRaw)}`;
     return res.status(200).json({ ok: true, url });
   } catch (e) {
     console.error('create_cart_link_error', e);

--- a/lib/handlers/createCheckout.js
+++ b/lib/handlers/createCheckout.js
@@ -1,3 +1,5 @@
+import { getPublicStorefrontBase } from '../publicStorefront.js';
+
 function ensureBody(req) {
   let b = req.body;
   if (!b || typeof b !== 'object') {
@@ -25,8 +27,9 @@ export default async function createCheckout(req, res) {
     const normalizedVariantId = normalizeVariantId(variantId || variantGid);
     if (!normalizedVariantId) return res.status(400).json({ ok: false, error: 'missing_variant' });
     const qty = Number(quantity) > 0 ? Number(quantity) : 1;
-    const base = process.env.SHOPIFY_PUBLIC_BASE || `https://${process.env.SHOPIFY_STORE_DOMAIN}`;
-    const url = `${base}/cart/add?items[0][id]=${encodeURIComponent(normalizedVariantId)}&items[0][quantity]=${qty}&return_to=%2Fcheckout`;
+    const base = getPublicStorefrontBase();
+    if (!base) return res.status(500).json({ ok: false, error: 'missing_store_domain' });
+    const url = `${base.replace(/\/$/, '')}/cart/add?items[0][id]=${encodeURIComponent(normalizedVariantId)}&items[0][quantity]=${qty}&return_to=%2Fcheckout`;
     return res.status(200).json({ ok: true, url });
   } catch (e) {
     console.error('create_checkout_error', e);

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1,4 +1,5 @@
 import { shopifyAdmin } from '../shopify.js';
+import { buildProductUrl } from '../publicStorefront.js';
 
 const DEFAULT_VENDOR = 'MGM Personalizados';
 
@@ -8,16 +9,6 @@ function ensureBody(body) {
     try { return JSON.parse(body) || {}; } catch { return {}; }
   }
   return {};
-}
-
-function slugifyTag(str) {
-  return String(str || '')
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^a-zA-Z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 40)
-    .toLowerCase();
 }
 
 function toNumber(value) {
@@ -67,39 +58,6 @@ function buildMetaDescription({ productTypeLabel, designName, widthCm, heightCm,
   return `${sections.join('. ')}.`;
 }
 
-function buildTags({ baseTags, productTypeKey, designName, widthCm, heightCm, materialLabel }) {
-  const tags = new Set(['configurador', 'personalizado']);
-  if (productTypeKey) tags.add(`tipo-${productTypeKey}`);
-  if (Number.isFinite(widthCm) && Number.isFinite(heightCm) && widthCm > 0 && heightCm > 0) {
-    const sizeTag = `size-${Math.round(widthCm)}x${Math.round(heightCm)}cm`;
-    tags.add(sizeTag);
-  }
-  if (designName) {
-    const slug = slugifyTag(designName);
-    if (slug) tags.add(`design-${slug}`);
-  }
-  if (materialLabel) {
-    const slug = slugifyTag(materialLabel);
-    if (slug) tags.add(`material-${slug}`);
-  }
-  if (Array.isArray(baseTags)) {
-    baseTags.map((t) => String(t || '').trim()).filter(Boolean).forEach((t) => tags.add(t));
-  } else if (typeof baseTags === 'string') {
-    baseTags.split(',').map((t) => t.trim()).filter(Boolean).forEach((t) => tags.add(t));
-  }
-  return Array.from(tags).filter(Boolean);
-}
-
-function buildProductUrl(handle) {
-  if (!handle) return undefined;
-  const base =
-    process.env.SHOPIFY_PUBLIC_BASE
-    || (process.env.SHOPIFY_STOREFRONT_DOMAIN ? `https://${process.env.SHOPIFY_STOREFRONT_DOMAIN}` : '')
-    || (process.env.SHOPIFY_STORE_DOMAIN ? `https://${process.env.SHOPIFY_STORE_DOMAIN}` : '');
-  if (!base) return undefined;
-  return `${base.replace(/\/$/, '')}/products/${handle}`;
-}
-
 export async function publishProduct(req, res) {
   if (req.method !== 'POST') {
     res.statusCode = 405;
@@ -142,15 +100,6 @@ export async function publishProduct(req, res) {
 
     const description = typeof body.description === 'string' ? body.description : '';
 
-    const tags = buildTags({
-      baseTags: body.tags,
-      productTypeKey,
-      designName: designNameRaw,
-      widthCm,
-      heightCm,
-      materialLabel,
-    });
-
     const metaDescriptionRaw = typeof body.seoDescription === 'string' ? body.seoDescription.trim() : '';
     const generatedMeta = buildMetaDescription({
       productTypeLabel,
@@ -175,13 +124,19 @@ export async function publishProduct(req, res) {
       ...(compareAt ? { compare_at_price: compareAt } : {}),
       requires_shipping: true,
       taxable: true,
-      inventory_management: null,
+      inventory_management: 'shopify',
       inventory_policy: 'continue',
+      inventory_quantity: 9999,
       option1: 'Default Title',
     };
     if (body.sku) {
       variant.sku = String(body.sku).slice(0, 64);
     }
+
+    const templateSuffix = typeof process.env.SHOPIFY_TEMPLATE_SUFFIX === 'string'
+      && process.env.SHOPIFY_TEMPLATE_SUFFIX.trim()
+      ? process.env.SHOPIFY_TEMPLATE_SUFFIX.trim()
+      : 'Mousepads';
 
     const payload = {
       product: {
@@ -190,9 +145,9 @@ export async function publishProduct(req, res) {
         product_type: productTypeLabel,
         status: 'active',
         published_scope: 'web',
-        tags: tags.join(', '),
+        tags: '',
         vendor: typeof body.vendor === 'string' && body.vendor.trim() ? body.vendor.trim() : DEFAULT_VENDOR,
-        template_suffix: '',
+        template_suffix: templateSuffix,
         metafields_global_title_tag: title,
         ...(metaDescription ? { metafields_global_description_tag: metaDescription } : {}),
         variants: [variant],

--- a/lib/publicStorefront.js
+++ b/lib/publicStorefront.js
@@ -1,0 +1,46 @@
+const preferHttps = (value) => {
+  const raw = typeof value === 'string' ? value.trim() : '';
+  if (!raw) return '';
+  return /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+};
+
+const shouldForceWww = (hostname) => {
+  if (!hostname || typeof hostname !== 'string') return false;
+  if (hostname.startsWith('www.')) return false;
+  if (hostname.endsWith('.myshopify.com')) return false;
+  const parts = hostname.split('.').filter(Boolean);
+  return parts.length === 2;
+};
+
+export function getPublicStorefrontBase() {
+  const candidates = [
+    process.env.SHOPIFY_PUBLIC_BASE,
+    process.env.SHOPIFY_STOREFRONT_DOMAIN,
+    process.env.SHOPIFY_STORE_DOMAIN,
+  ];
+
+  for (const candidate of candidates) {
+    const withProtocol = preferHttps(candidate);
+    if (!withProtocol) continue;
+    try {
+      const url = new URL(withProtocol);
+      if (shouldForceWww(url.hostname)) {
+        url.hostname = `www.${url.hostname}`;
+      }
+      url.pathname = '';
+      url.search = '';
+      url.hash = '';
+      return url.origin;
+    } catch {
+      // ignore and keep trying
+    }
+  }
+  return '';
+}
+
+export function buildProductUrl(handle) {
+  if (!handle) return undefined;
+  const base = getPublicStorefrontBase();
+  if (!base) return undefined;
+  return `${base.replace(/\/$/, '')}/products/${handle}`;
+}


### PR DESCRIPTION
## Summary
- ensure products published via the API use the Mousepads template, track 9,999 units of inventory and leave tags empty
- add a shared helper to normalise the public Shopify domain with a www. fallback and reuse it in the cart and checkout link endpoints

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf01a4a0908327a19db68b3339ff6a