### PR TITLE
Update exported PDF filenames with material and original size

### DIFF
--- a/mgm-front/src/lib/filename.ts
+++ b/mgm-front/src/lib/filename.ts
@@ -1,10 +1,26 @@
-function sanitizeName(s='') {
-  return s.replace(/[\\/:*?"<>|]+/g,' ')
-          .replace(/\s+/g,' ')
-          .trim()
-          .slice(0, 80);
+function sanitizeName(s = '') {
+  return s
+    .replace(/[\\/:*?"<>|]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 80);
 }
-export function buildExportBaseName(designName: string, w_cm: number, h_cm: number) {
-  const clean = sanitizeName(designName || 'Diseño');
-  return `${clean} ${Number(w_cm)}x${Number(h_cm)}`;
+
+function formatDimension(value: number) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return '0';
+  const fixed = numeric.toFixed(2);
+  return fixed.replace(/\.0+$/, '').replace(/(\.\d*?)0+$/, '$1');
+}
+
+export function buildExportBaseName(
+  designName: string,
+  w_cm: number,
+  h_cm: number,
+  material?: string | null,
+) {
+  const cleanName = sanitizeName(designName || 'Diseño');
+  const cleanMaterial = sanitizeName(material || '');
+  const measurement = `${formatDimension(w_cm)}x${formatDimension(h_cm)}`;
+  return cleanMaterial ? `${cleanName} ${measurement} ${cleanMaterial}` : `${cleanName} ${measurement}`;
 }

--- a/mgm-front/src/pages/DevCanvasPreview.jsx
+++ b/mgm-front/src/pages/DevCanvasPreview.jsx
@@ -38,7 +38,7 @@ export default function DevCanvasPreview() {
     const h_cm = render_v2.h_cm;
     const out_w_cm = w_cm + 2;
     const out_h_cm = h_cm + 2;
-    const baseName = buildExportBaseName(designName, w_cm, h_cm);
+    const baseName = buildExportBaseName(designName, w_cm, h_cm, mode);
     const dpi = 300;
     const out_w_px = Math.round((out_w_cm * dpi) / 2.54);
     const out_h_px = Math.round((out_h_cm * dpi) / 2.54);

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -96,7 +96,12 @@ export default function Mockup() {
       page.drawImage(embedded, { x: 0, y: 0, width: pageWidthPt, height: pageHeightPt });
       const pdfBytes = await pdfDoc.save();
       const pdfBlob = new Blob([pdfBytes], { type: 'application/pdf' });
-      const baseName = buildExportBaseName(flow.designName || '', targetWidthCm, targetHeightCm);
+      const baseName = buildExportBaseName(
+        flow.designName || '',
+        widthCmRaw,
+        heightCmRaw,
+        flow.material,
+      );
       downloadBlob(pdfBlob, `${baseName}.pdf`);
     } catch (error) {
       console.error('[download-pdf]', error);


### PR DESCRIPTION
## Summary
- extend the export filename helper to include material information alongside the chosen size
- use the client's original dimensions when building filenames for PDF downloads
- pass material data through the PDF export flows so the downloaded name matches the required pattern

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf03a802588327a86ba74a95493520