### PR TITLE
Fix checkout URL for buy now button

### DIFF
--- a/lib/handlers/createCheckout.js
+++ b/lib/handlers/createCheckout.js
@@ -29,8 +29,19 @@ export default async function createCheckout(req, res) {
     const qty = Number(quantity) > 0 ? Number(quantity) : 1;
     const base = getPublicStorefrontBase();
     if (!base) return res.status(500).json({ ok: false, error: 'missing_store_domain' });
-    const url = `${base.replace(/\/$/, '')}/cart/add?items[0][id]=${encodeURIComponent(normalizedVariantId)}&items[0][quantity]=${qty}&return_to=%2Fcheckout`;
-    return res.status(200).json({ ok: true, url });
+
+    let checkoutUrl;
+    try {
+      checkoutUrl = new URL(`/cart/${normalizedVariantId}:${qty}`, base);
+    } catch (err) {
+      console.error('create_checkout_url_error', err);
+      return res.status(500).json({ ok: false, error: 'invalid_store_domain' });
+    }
+
+    checkoutUrl.searchParams.set('channel', 'buy_button');
+    checkoutUrl.searchParams.set('return_to', '/checkout');
+
+    return res.status(200).json({ ok: true, url: checkoutUrl.toString() });
   } catch (e) {
     console.error('create_checkout_error', e);
     return res.status(500).json({ ok: false, error: 'create_checkout_failed' });


### PR DESCRIPTION
## Summary
- build the checkout link with Shopify's buy button endpoint so the Buy Now action reaches checkout with the product preloaded
- guard against invalid storefront base URLs when generating the checkout target

## Testing
- node --test tests/api-handlers.test.js *(fails: missing module `api/_lib/env.js` in test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68cf04a2234c83278705e4d4986917d4