### PR TITLE
Relax nazi color heuristic to avoid dark art false positives

### DIFF
--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -196,8 +196,23 @@ async function detectNazi(buffer) {
   const redRatio = redDom / total;
   const whiteCircleRatio = (inCircleCount ? (whiteInCircle / inCircleCount) : 0);
   const blackStrokeRatio = (inRingCount ? (blackStroke / inRingCount) : 0);
-  if (redRatio > 0.45 && whiteCircleRatio > 0.6 && blackStrokeRatio > 0.08) {
-    return { nazi: true, reason: 'flag_heuristic', score: { redRatio, whiteCircleRatio, blackStrokeRatio } };
+  const COLOR_MATCH_THRESHOLDS = {
+    red: 0.5,
+    white: 0.75,
+    black: 0.18,
+    minDist: 24,
+  };
+  if (
+    minDist <= COLOR_MATCH_THRESHOLDS.minDist &&
+    redRatio >= COLOR_MATCH_THRESHOLDS.red &&
+    whiteCircleRatio >= COLOR_MATCH_THRESHOLDS.white &&
+    blackStrokeRatio >= COLOR_MATCH_THRESHOLDS.black
+  ) {
+    return {
+      nazi: true,
+      reason: 'flag_heuristic',
+      score: { redRatio, whiteCircleRatio, blackStrokeRatio, minDist },
+    };
   }
   return { nazi: false, reason: 'none', score: minDist };
 }


### PR DESCRIPTION
## Summary
- tighten the color-based nazi flag heuristic so that it only triggers when the image also roughly matches the swastika perceptual hash and has stronger red/white/black ratios
- include the pHash distance in the debug score payload when the heuristic fires to aid future tuning

## Testing
- node --test tests/api-handlers.test.js *(fails: requires api/_lib/env.js fixture)*

------
https://chatgpt.com/codex/tasks/task_e_68cf06218cf08327b7b27a4bfa5cdad7