### PR TITLE
Implement Supabase asset uploads for finalized jobs

### DIFF
--- a/lib/_lib/composeImage.js
+++ b/lib/_lib/composeImage.js
@@ -1,14 +1,8 @@
 import sharp from 'sharp';
 
-export type ComposeResult = {
-  innerBuf: Buffer;
-  printBuf: Buffer;
-  debug: Record<string, any>;
-};
-
 const DPI = 300;
 
-export async function composeImage({ render_v2, srcBuf }: { render_v2: any; srcBuf: Buffer; }): Promise<ComposeResult> {
+export async function composeImage({ render_v2, srcBuf }) {
   const c = render_v2.canvas_px;
   const pad = render_v2.pad_px;
   const p = render_v2.place_px;
@@ -66,7 +60,7 @@ export async function composeImage({ render_v2, srcBuf }: { render_v2: any; srcB
       clipW,
       clipH,
     };
-    const err: any = new Error('invalid_bbox');
+    const err = new Error('invalid_bbox');
     err.debug = debug;
     throw err;
   }

--- a/lib/api/handlers/assets.js
+++ b/lib/api/handlers/assets.js
@@ -22,7 +22,7 @@ export async function searchAssets({ query }, { supa } = {}) {
     const client = supa || (await getDefaultClient());
     const { data, error } = await client
       .from('jobs')
-      .select('job_id,design_name,material,w_cm,h_cm,file_original_url,created_at')
+      .select('job_id,design_name,material,w_cm,h_cm,file_original_url,print_jpg_url,pdf_url,preview_url,created_at')
       .or(`design_name.ilike.%${term}%,material.ilike.%${term}%`)
       .order('created_at', { ascending: false })
       .limit(20);

--- a/lib/api/handlers/system.js
+++ b/lib/api/handlers/system.js
@@ -1,4 +1,4 @@
-import { getEnv, mask } from '../../../api/_lib/env.js';
+import { getEnv, mask } from '../../_lib/env.js';
 
 /**
  * GET /api/env-check → envCheck

--- a/lib/handlers/finalizeAssets.js
+++ b/lib/handlers/finalizeAssets.js
@@ -1,14 +1,295 @@
+import { randomUUID } from 'node:crypto';
+import sharp from 'sharp';
+import getSupabaseAdmin from '../_lib/supabaseAdmin.js';
+import { slugifyName, sizeLabel } from '../_lib/slug.js';
+import composeImage from '../_lib/composeImage.js';
+
+const OUTPUT_BUCKET = 'outputs';
+
+function toObject(input) {
+  if (input && typeof input === 'object') return input;
+  if (typeof input === 'string') {
+    try { return JSON.parse(input); } catch { return {}; }
+  }
+  return {};
+}
+
+function readRawBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => { data += chunk; });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+function parseDataUrl(url) {
+  const match = /^data:(.+?);base64,(.+)$/.exec(String(url || ''));
+  if (!match) throw new Error('invalid_data_url');
+  return Buffer.from(match[2], 'base64');
+}
+
+async function fetchBuffer(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    const err = new Error(`download_failed_${response.status}`);
+    err.status = response.status;
+    throw err;
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
+function toNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function buildBaseName(job, body, renderDescriptor) {
+  const parts = [];
+  const nameSource = body?.design_name
+    || body?.designName
+    || renderDescriptor?.design_name
+    || job?.design_name
+    || '';
+  const nameSlug = slugifyName(nameSource);
+  if (nameSlug) parts.push(nameSlug);
+
+  const width = toNumber(
+    body?.width_cm ?? body?.widthCm ?? renderDescriptor?.w_cm ?? job?.w_cm,
+  );
+  const height = toNumber(
+    body?.height_cm ?? body?.heightCm ?? renderDescriptor?.h_cm ?? job?.h_cm,
+  );
+  if (width && height) parts.push(sizeLabel(width, height));
+
+  const materialSource = body?.mode
+    || body?.material
+    || renderDescriptor?.material
+    || job?.material
+    || '';
+  const materialSlug = slugifyName(materialSource);
+  if (materialSlug) parts.push(materialSlug);
+
+  const base = parts.filter(Boolean).join('-');
+  if (base) return base;
+  const fallback = slugifyName(job?.job_id || '');
+  return fallback || 'design';
+}
+
+function buildObjectKeys(job, baseName) {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const folder = `${year}/${month}/${job.job_id}`;
+  const safeBase = baseName || 'design';
+  return {
+    printKey: `${folder}/${safeBase}/print.jpg`,
+    previewKey: `${folder}/${safeBase}/preview.png`,
+    pdfKey: `${folder}/${safeBase}/print.pdf`,
+  };
+}
+
+function publicUrl(key) {
+  return `${process.env.SUPABASE_URL}/storage/v1/object/public/${OUTPUT_BUCKET}/${key}`;
+}
+
 export default async function finalizeAssets(req, res) {
+  const diagId = randomUUID();
+  res.setHeader('X-Diag-Id', diagId);
+
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
-    return res.status(405).json({ error: 'method_not_allowed' });
+    return res.status(405).json({ ok: false, diag_id: diagId, message: 'method_not_allowed' });
   }
+
+  let payload = toObject(req.body);
+  if (!payload || !Object.keys(payload).length) {
+    try {
+      const raw = await readRawBody(req);
+      payload = toObject(raw);
+    } catch (err) {
+      console.error('finalize-assets read_body', { diagId, error: err?.message || err });
+      return res.status(400).json({ ok: false, diag_id: diagId, message: 'invalid_body' });
+    }
+  }
+
+  const jobId = typeof payload.job_id === 'string' ? payload.job_id.trim() : '';
+  if (!jobId) {
+    return res.status(400).json({ ok: false, diag_id: diagId, message: 'missing_job_id' });
+  }
+
+  let renderDescriptor = null;
+  if (payload.render_v2) {
+    if (typeof payload.render_v2 === 'string') {
+      try { renderDescriptor = JSON.parse(payload.render_v2); } catch { renderDescriptor = null; }
+    } else if (typeof payload.render_v2 === 'object') {
+      renderDescriptor = payload.render_v2;
+    }
+  }
+
+  let supabase;
   try {
-    const payload = typeof req.body === 'string' ? JSON.parse(req.body || '{}') : (req.body || {});
-    // TODO: implement finalize-assets business logic or keep as stub
-    return res.status(200).json({ ok: true });
-  } catch (e) {
-    return res.status(500).json({ error: 'internal_error', message: e?.message || 'unknown' });
+    supabase = getSupabaseAdmin();
+  } catch (err) {
+    console.error('finalize-assets env', { diagId, error: err?.message || err });
+    return res.status(500).json({ ok: false, diag_id: diagId, message: 'missing_env' });
   }
+
+  const { data: job, error: jobErr } = await supabase
+    .from('jobs')
+    .select('id,job_id,design_name,material,w_cm,h_cm,bleed_mm,file_original_url')
+    .eq('job_id', jobId)
+    .maybeSingle();
+
+  if (jobErr) {
+    console.error('finalize-assets select', { diagId, error: jobErr.message });
+    return res.status(500).json({ ok: false, diag_id: diagId, message: 'db_error' });
+  }
+  if (!job) {
+    return res.status(404).json({ ok: false, diag_id: diagId, message: 'job_not_found' });
+  }
+
+  const candidateUrls = [
+    typeof payload.design_url === 'string' ? payload.design_url : '',
+    typeof payload.designUrl === 'string' ? payload.designUrl : '',
+    renderDescriptor?.design_url ? String(renderDescriptor.design_url) : '',
+    job.file_original_url || '',
+  ];
+  const designUrl = candidateUrls.find(u => typeof u === 'string' && u.trim());
+
+  if (!designUrl) {
+    return res.status(400).json({ ok: false, diag_id: diagId, message: 'missing_design_url' });
+  }
+
+  let sourceBuffer;
+  try {
+    if (String(designUrl).startsWith('data:')) {
+      sourceBuffer = parseDataUrl(designUrl);
+    } else {
+      sourceBuffer = await fetchBuffer(designUrl);
+    }
+  } catch (err) {
+    console.error('finalize-assets fetch', { diagId, error: err?.message || err });
+    return res.status(400).json({ ok: false, diag_id: diagId, message: 'download_failed' });
+  }
+
+  if (!sourceBuffer || !sourceBuffer.length) {
+    return res.status(400).json({ ok: false, diag_id: diagId, message: 'empty_source' });
+  }
+
+  let printBuffer = sourceBuffer;
+  let innerBuffer = null;
+  let composeDebug = null;
+  if (renderDescriptor && typeof renderDescriptor === 'object') {
+    try {
+      const composed = await composeImage({ render_v2: renderDescriptor, srcBuf: sourceBuffer });
+      printBuffer = composed?.printBuf || sourceBuffer;
+      innerBuffer = composed?.innerBuf || null;
+      composeDebug = composed?.debug || null;
+    } catch (err) {
+      console.warn('finalize-assets compose', { diagId, error: err?.message || err });
+      printBuffer = sourceBuffer;
+      innerBuffer = null;
+    }
+  }
+  if (!innerBuffer) innerBuffer = printBuffer;
+
+  let previewBuffer;
+  try {
+    previewBuffer = await sharp(innerBuffer)
+      .resize({ width: 1200, height: 1200, fit: 'inside', withoutEnlargement: true })
+      .png()
+      .toBuffer();
+  } catch (err) {
+    console.warn('finalize-assets preview', { diagId, error: err?.message || err });
+    try {
+      previewBuffer = await sharp(innerBuffer).png().toBuffer();
+    } catch {
+      previewBuffer = innerBuffer;
+    }
+  }
+
+  let printJpgBuffer;
+  let pdfBuffer;
+  try {
+    printJpgBuffer = await sharp(printBuffer)
+      .flatten({ background: '#ffffff' })
+      .jpeg({ quality: 95 })
+      .toBuffer();
+    pdfBuffer = await sharp(printBuffer)
+      .flatten({ background: '#ffffff' })
+      .withMetadata({ density: 300 })
+      .toFormat('pdf')
+      .toBuffer();
+  } catch (err) {
+    console.error('finalize-assets render', { diagId, error: err?.message || err });
+    return res.status(500).json({ ok: false, diag_id: diagId, message: 'render_failed' });
+  }
+
+  const baseName = buildBaseName(job, payload, renderDescriptor);
+  const { printKey, previewKey, pdfKey } = buildObjectKeys(job, baseName);
+
+  const storage = supabase.storage.from(OUTPUT_BUCKET);
+  async function upload(key, buffer, contentType) {
+    const { error } = await storage.upload(key, buffer, { contentType, upsert: true });
+    if (error) throw error;
+    return publicUrl(key);
+  }
+
+  let printUrl;
+  let previewUrl;
+  let pdfUrl;
+  try {
+    [printUrl, previewUrl, pdfUrl] = await Promise.all([
+      upload(printKey, printJpgBuffer, 'image/jpeg'),
+      upload(previewKey, previewBuffer, 'image/png'),
+      upload(pdfKey, pdfBuffer, 'application/pdf'),
+    ]);
+  } catch (err) {
+    console.error('finalize-assets upload', { diagId, error: err?.message || err });
+    return res.status(500).json({ ok: false, diag_id: diagId, message: 'upload_failed' });
+  }
+
+  const updates = {
+    status: 'ASSETS_READY',
+    print_jpg_url: printUrl,
+    pdf_url: pdfUrl,
+    preview_url: previewUrl,
+  };
+
+  const { error: updateErr } = await supabase.from('jobs').update(updates).eq('job_id', jobId);
+  if (updateErr) {
+    console.error('finalize-assets update', { diagId, error: updateErr.message });
+    return res.status(500).json({ ok: false, diag_id: diagId, message: 'db_update_error' });
+  }
+
+  try {
+    if (job.id) {
+      await supabase.from('job_events').insert({
+        job_id: job.id,
+        event: 'assets_finalized',
+        detail: {
+          print_jpg_url: printUrl,
+          pdf_url: pdfUrl,
+          preview_url: previewUrl,
+          ...(composeDebug ? { compose: composeDebug } : {}),
+        },
+      });
+    }
+  } catch (err) {
+    console.warn('finalize-assets event', { diagId, error: err?.message || err });
+  }
+
+  return res.status(200).json({
+    ok: true,
+    diag_id: diagId,
+    job_id: jobId,
+    assets: {
+      print_jpg_url: printUrl,
+      pdf_url: pdfUrl,
+      preview_url: previewUrl,
+    },
+  });
 }
 

--- a/lib/handlers/submitJob.js
+++ b/lib/handlers/submitJob.js
@@ -65,7 +65,8 @@ export default async function submitJob(req, res) {
   }
   const input = v.data;
 
-  const designName = typeof body?.design_name === 'string' ? body.design_name : undefined;
+  const designNameRaw = typeof body?.design_name === 'string' ? body.design_name.trim() : '';
+  const designName = designNameRaw ? designNameRaw : undefined;
   const payloadInsert = {
     job_id: input.job_id,
     customer_email: input.customer_email ?? null,
@@ -88,6 +89,7 @@ export default async function submitJob(req, res) {
     payloadInsert.low_quality_ack = input.low_quality_ack;
   }
   if (designName) {
+    payloadInsert.design_name = designName.slice(0, 250);
     payloadInsert.notes = (payloadInsert.notes ? payloadInsert.notes + ' | ' : '') + `design_name:${designName}`;
     if (payloadInsert.notes.length > 1000) payloadInsert.notes = payloadInsert.notes.slice(0, 1000);
   }


### PR DESCRIPTION
## Summary
- replace the finalize-assets handler with logic that downloads the design, composes print/preview assets, uploads them to Supabase Storage, and updates the job record
- expose composeImage as a runtime JS helper and store the submitted design name on jobs for easier lookups
- extend the search-assets response with preview, print, and pdf URLs and fix the system handler import so the tests run locally

## Testing
- node --test tests/api-handlers.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf0a4d5d4883278f931c96ef406183