### PR TITLE
Set Shopify vendor to MgMGamers

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1,7 +1,7 @@
 import { shopifyAdmin } from '../shopify.js';
 import { buildProductUrl } from '../publicStorefront.js';
 
-const DEFAULT_VENDOR = 'MGM Personalizados';
+const DEFAULT_VENDOR = 'MgMGamers';
 
 function ensureBody(body) {
   if (body && typeof body === 'object') return body;
@@ -136,7 +136,7 @@ export async function publishProduct(req, res) {
     const templateSuffix = typeof process.env.SHOPIFY_TEMPLATE_SUFFIX === 'string'
       && process.env.SHOPIFY_TEMPLATE_SUFFIX.trim()
       ? process.env.SHOPIFY_TEMPLATE_SUFFIX.trim()
-      : 'Mousepads';
+      : 'mousepads';
 
     const payload = {
       product: {
@@ -146,7 +146,7 @@ export async function publishProduct(req, res) {
         status: 'active',
         published_scope: 'web',
         tags: '',
-        vendor: typeof body.vendor === 'string' && body.vendor.trim() ? body.vendor.trim() : DEFAULT_VENDOR,
+        vendor: DEFAULT_VENDOR,
         template_suffix: templateSuffix,
         metafields_global_title_tag: title,
         ...(metaDescription ? { metafields_global_description_tag: metaDescription } : {}),


### PR DESCRIPTION
## Summary
- update the Shopify publishing handler so products always use MgMGamers as the vendor
- set the default Shopify template suffix to `mousepads` when publishing products

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf12e3ea3c83279595d1c1c91d891c