### PR TITLE
Relax image moderation review heuristics

### DIFF
--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -29,6 +29,9 @@ Variables opcionales en `.env`:
 ```
 NUDE_REAL_THRESHOLD=0.75
 HATE_SPEECH_EXPLICIT_THRESHOLD=0.85
+MODERATION_SKIP_OCR=1
 ```
+
+> `MODERATION_SKIP_OCR` se recomienda únicamente para pruebas locales/CI y evita que `tesseract.js` descargue datos pesados.
 
 El objetivo es bloquear únicamente desnudos reales y extremismo nazi; todo lo demás pasa o queda pendiente de revisión según la confianza calculada.

--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -2,6 +2,8 @@ import sharp from 'sharp';
 import { pHashFromGray, hamming } from '../hashing.js';
 import { hateTextCheck } from '../moderation/hate.js';
 
+const SKIP_OCR = process.env.MODERATION_SKIP_OCR === '1';
+
 const clamp = (value, min = 0, max = 1) => Math.max(min, Math.min(max, value));
 
 function toBufferFromDataUrl(dataUrl) {
@@ -31,6 +33,7 @@ async function loadTesseract() {
 }
 
 async function extractTextHints(buffer) {
+  if (SKIP_OCR) return '';
   try {
     const { default: Tesseract } = await loadTesseract();
     const prepped = await sharp(buffer)
@@ -369,18 +372,33 @@ export async function evaluateImage(buffer, filename, designName = '', options =
 
   const CARTOON_STRONG_THRESHOLD = 0.7;
   const CARTOON_RELAX_THRESHOLD = 0.5;
+  const REAL_NUDITY_BLOCK_THRESHOLD = 0.6;
+  const REAL_NUDITY_REVIEW_THRESHOLD = 0.5;
+  const REAL_NUDITY_MIN_COVERAGE_FOR_REVIEW = 0.35;
+  const REAL_NUDITY_MIN_BLOB_FOR_REVIEW = 0.18;
+  const REAL_NUDITY_MIN_COVERAGE_FOR_BLOCK = 0.42;
+  const REAL_NUDITY_MIN_BLOB_FOR_BLOCK = 0.24;
 
-  if (nudityConfidence >= 0.6) {
+  const skinPercent = skin?.skinPercent ?? 0;
+  const largestBlob = skin?.largestBlob ?? 0;
+  const meetsReviewCoverage =
+    skinPercent >= REAL_NUDITY_MIN_COVERAGE_FOR_REVIEW || largestBlob >= REAL_NUDITY_MIN_BLOB_FOR_REVIEW;
+  const meetsBlockCoverage =
+    skinPercent >= REAL_NUDITY_MIN_COVERAGE_FOR_BLOCK || largestBlob >= REAL_NUDITY_MIN_BLOB_FOR_BLOCK;
+
+  if (nudityConfidence >= REAL_NUDITY_BLOCK_THRESHOLD) {
     if (cartoonConfidence >= CARTOON_RELAX_THRESHOLD) {
       const allowConfidence = clamp(0.65 + (cartoonConfidence - CARTOON_RELAX_THRESHOLD) * 0.3);
       applyOutcome('ALLOW', ['animated_explicit_allowed'], allowConfidence);
-    } else {
+    } else if (meetsBlockCoverage) {
       const nudityReasons = ['real_nudity'];
-      if (skin.largestBlob >= 0.4) nudityReasons.push('genitals_visible');
-      if (skin.skinPercent >= 0.75) nudityReasons.push('sex_act');
+      if (largestBlob >= 0.4) nudityReasons.push('genitals_visible');
+      if (skinPercent >= 0.75) nudityReasons.push('sex_act');
       applyOutcome('BLOCK', nudityReasons, nudityConfidence);
+    } else if (meetsReviewCoverage) {
+      applyOutcome('REVIEW', ['real_nudity_suspected'], nudityConfidence);
     }
-  } else if (nudityConfidence >= 0.4) {
+  } else if (nudityConfidence >= REAL_NUDITY_REVIEW_THRESHOLD && meetsReviewCoverage) {
     if (cartoonConfidence >= CARTOON_RELAX_THRESHOLD) {
       const allowConfidence = clamp(0.6 + (cartoonConfidence - CARTOON_RELAX_THRESHOLD) * 0.25);
       applyOutcome('ALLOW', ['animated_skin_visible'], allowConfidence);
@@ -420,8 +438,27 @@ export async function evaluateImage(buffer, filename, designName = '', options =
   if (SEVERITY_RANK[label] < SEVERITY_RANK.BLOCK) {
     if (cartoonConfidence >= CARTOON_STRONG_THRESHOLD) {
       applyOutcome('ALLOW', ['animated_explicit_allowed'], cartoonConfidence);
-    } else if (cartoonConfidence >= 0.45 && nudityConfidence >= 0.3) {
-      applyOutcome('REVIEW', ['animated_uncertain_age'], Math.max(cartoonConfidence, nudityConfidence));
+    } else {
+      const ANIMATED_REVIEW_MIN_CARTOON = 0.5;
+      const ANIMATED_REVIEW_MIN_EDGE = 0.02;
+      const ANIMATED_REVIEW_MIN_PALETTE = 24;
+      const ANIMATED_REVIEW_MIN_SKIN = 0.2;
+      const ANIMATED_REVIEW_MAX_SKIN = 0.9;
+      const ANIMATED_REVIEW_MIN_BLOB = 0.12;
+      const ANIMATED_REVIEW_MIN_PALETTE_RATIO = 0.003;
+      const paletteRatio = illustration?.paletteRatio ?? 0;
+      const qualifiesAnimatedReview =
+        cartoonConfidence >= ANIMATED_REVIEW_MIN_CARTOON &&
+        nudityConfidence >= 0.32 &&
+        illustration?.edgeRatio >= ANIMATED_REVIEW_MIN_EDGE &&
+        illustration?.paletteSize >= ANIMATED_REVIEW_MIN_PALETTE &&
+        paletteRatio >= ANIMATED_REVIEW_MIN_PALETTE_RATIO &&
+        skinPercent >= ANIMATED_REVIEW_MIN_SKIN &&
+        skinPercent <= ANIMATED_REVIEW_MAX_SKIN &&
+        largestBlob >= ANIMATED_REVIEW_MIN_BLOB;
+      if (qualifiesAnimatedReview) {
+        applyOutcome('REVIEW', ['animated_uncertain_age'], Math.max(cartoonConfidence, nudityConfidence));
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- require minimum skin coverage before flagging suspected real nudity to avoid harmless photos going to review
- refine the animated age review heuristic so solid colors and simple backgrounds are no longer held for review
- allow skipping OCR during local tests via the MODERATION_SKIP_OCR env flag and document it

## Testing
- MODERATION_SKIP_OCR=1 node - <<'NODE'
import sharp from 'sharp';
import { evaluateImage } from './lib/handlers/moderateImage.js';

const createSolid = async (color, name) => {
  const buf = await sharp({ create: { width: 512, height: 512, channels: 3, background: color } }).jpeg().toBuffer();
  const out = await evaluateImage(buf, `${name}.jpg`);
  console.log(name, out.label, out.reasons, out.confidence.toFixed(3));
};

const run = async () => {
  await createSolid({ r: 210, g: 180, b: 140 }, 'tan');
  await createSolid({ r: 230, g: 200, b: 170 }, 'beige');
  await createSolid({ r: 120, g: 120, b: 120 }, 'gray');
  await createSolid({ r: 200, g: 150, b: 100 }, 'brownish');
};

run();
NODE


------
https://chatgpt.com/codex/tasks/task_e_68cf1382d13c8327be1a85bcdf41e856