### PR TITLE
Add password-protected Supabase search page

### DIFF
--- a/api/[...slug].js
+++ b/api/[...slug].js
@@ -53,6 +53,13 @@ export default withCors(async function handler(req, res) {
         const m = await import('../lib/handlers/jobStatus.js');
         return m.default(req, res);
       }
+      case 'GET search-assets': {
+        const { searchAssets } = await import('../lib/api/handlers/assets.js');
+        const { status, body } = await searchAssets({ query: req.query });
+        res.statusCode = status;
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        return res.end(JSON.stringify(body));
+      }
       case 'GET job-summary': {
         const m = await import('../lib/handlers/jobSummary.js');
         return m.default(req, res);

--- a/lib/api/handlers/assets.js
+++ b/lib/api/handlers/assets.js
@@ -18,12 +18,22 @@ export async function searchAssets({ query }, { supa } = {}) {
     return { status: 400, body: { error: 'missing_term' } };
   }
   try {
-    const term = termRaw.replace(/%/g, '');
+    const term = termRaw.replace(/[%'"`]/g, '');
+    if (!term) {
+      return { status: 400, body: { error: 'missing_term' } };
+    }
+    const filters = [
+      `design_name.ilike.%${term}%`,
+      `material.ilike.%${term}%`,
+      `job_id.ilike.%${term}%`,
+      `customer_email.ilike.%${term}%`,
+      `customer_name.ilike.%${term}%`,
+    ].join(',');
     const client = supa || (await getDefaultClient());
     const { data, error } = await client
       .from('jobs')
-      .select('job_id,design_name,material,w_cm,h_cm,file_original_url,print_jpg_url,pdf_url,preview_url,created_at')
-      .or(`design_name.ilike.%${term}%,material.ilike.%${term}%`)
+      .select('job_id,design_name,material,w_cm,h_cm,file_original_url,print_jpg_url,pdf_url,preview_url,created_at,customer_email,customer_name')
+      .or(filters)
       .order('created_at', { ascending: false })
       .limit(20);
     if (error) throw error;

--- a/mgm-front/README.md
+++ b/mgm-front/README.md
@@ -10,6 +10,7 @@ Antes de iniciar el entorno de desarrollo crea un archivo `.env.local` con:
 VITE_API_URL=URL_de_tu_API
 VITE_SUPABASE_URL=URL_de_tu_proyecto_Supabase
 VITE_SUPABASE_ANON_KEY=clave_anon_de_Supabase
+VITE_BUSQUEDA_PASSWORD=contraseña_para_el_buscador
 ```
 
 Luego ejecuta `npm run dev` para iniciar el frontend.

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -13,6 +13,7 @@ import MousepadsPersonalizados from './pages/MousepadsPersonalizados.jsx';
 import ComoFunciona from './pages/ComoFunciona.jsx';
 import PreguntasFrecuentes from './pages/PreguntasFrecuentes.jsx';
 import Contacto from './pages/Contacto.jsx';
+import Busqueda from './pages/Busqueda.jsx';
 import { OrderFlowProvider } from './store/orderFlow';
 import { FlowProvider } from './state/flow.js';
 import './globals.css';
@@ -27,6 +28,7 @@ const routes = [
       { path: '/como-funciona', element: <ComoFunciona /> },
       { path: '/preguntas-frecuentes', element: <PreguntasFrecuentes /> },
       { path: '/contacto', element: <Contacto /> },
+      { path: '/busqueda', element: <Busqueda /> },
       { path: '/confirm', element: <Confirm /> },
       { path: '/mockup', element: <Mockup /> },
       { path: '/creating/:jobId', element: <Creating /> },

--- a/mgm-front/src/pages/Busqueda.jsx
+++ b/mgm-front/src/pages/Busqueda.jsx
@@ -1,0 +1,251 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { apiFetch } from '@/lib/api.js';
+import styles from './Busqueda.module.css';
+
+const STORAGE_KEY = 'mgmBusquedaAuth:v1';
+const REQUIRED_PASSWORD = (import.meta.env.VITE_BUSQUEDA_PASSWORD || '').trim();
+
+function readStoredAuth(passwordRequired) {
+  if (!passwordRequired) return true;
+  if (typeof window === 'undefined') return false;
+  return window.localStorage.getItem(STORAGE_KEY) === '1';
+}
+
+function formatDate(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  try {
+    return new Intl.DateTimeFormat('es-AR', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(date);
+  } catch {
+    return date.toLocaleString();
+  }
+}
+
+function ResultCard({ item }) {
+  const createdAt = formatDate(item.created_at);
+  const sizeText = useMemo(() => {
+    const w = Number(item.w_cm);
+    const h = Number(item.h_cm);
+    if (Number.isFinite(w) && Number.isFinite(h)) {
+      return `${w}×${h} cm`;
+    }
+    return null;
+  }, [item.h_cm, item.w_cm]);
+  const customerName = (item.customer_name || '').trim();
+  const customerEmail = (item.customer_email || '').trim();
+  const hasCustomer = customerName || customerEmail;
+
+  return (
+    <li className={styles.resultItem}>
+      <div className={styles.resultHeader}>
+        <div className={styles.resultTitleBlock}>
+          <span className={styles.jobId}>{item.job_id}</span>
+          <h3 className={styles.resultTitle}>{item.design_name || 'Sin nombre'}</h3>
+          <p className={styles.resultMeta}>
+            <span>{item.material || '—'}</span>
+            {sizeText ? <span> · {sizeText}</span> : null}
+          </p>
+          {hasCustomer ? (
+            <p className={styles.customerInfo}>
+              Cliente: {customerName ? <span>{customerName}</span> : null}
+              {customerName && customerEmail ? ' · ' : ''}
+              {customerEmail ? (
+                <a href={`mailto:${customerEmail}`} className={styles.customerEmail}>
+                  {customerEmail}
+                </a>
+              ) : null}
+            </p>
+          ) : null}
+        </div>
+        <div className={styles.resultDate}>
+          <span>{createdAt}</span>
+        </div>
+      </div>
+      <div className={styles.linksRow}>
+        {item.file_original_url ? (
+          <a className={styles.link} href={item.file_original_url} target="_blank" rel="noreferrer">
+            Archivo original
+          </a>
+        ) : null}
+        {item.print_jpg_url ? (
+          <a className={styles.link} href={item.print_jpg_url} target="_blank" rel="noreferrer">
+            Print JPG
+          </a>
+        ) : null}
+        {item.pdf_url ? (
+          <a className={styles.link} href={item.pdf_url} target="_blank" rel="noreferrer">
+            PDF
+          </a>
+        ) : null}
+        {item.preview_url ? (
+          <a className={styles.link} href={item.preview_url} target="_blank" rel="noreferrer">
+            Vista previa
+          </a>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+export default function Busqueda() {
+  const passwordRequired = REQUIRED_PASSWORD.length > 0;
+  const [isAuthorized, setIsAuthorized] = useState(() => readStoredAuth(passwordRequired));
+  const [passwordInput, setPasswordInput] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+
+  const [term, setTerm] = useState('');
+  const [lastTerm, setLastTerm] = useState('');
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!passwordRequired) return;
+    if (typeof window === 'undefined') return;
+    if (isAuthorized) {
+      window.localStorage.setItem(STORAGE_KEY, '1');
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [isAuthorized, passwordRequired]);
+
+  function handlePasswordSubmit(event) {
+    event.preventDefault();
+    if (!passwordRequired) {
+      setIsAuthorized(true);
+      return;
+    }
+    const candidate = passwordInput.trim();
+    if (candidate && candidate === REQUIRED_PASSWORD) {
+      setIsAuthorized(true);
+      setPasswordInput('');
+      setPasswordError('');
+    } else {
+      setPasswordError('Contraseña incorrecta.');
+    }
+  }
+
+  async function handleSearch(event) {
+    event.preventDefault();
+    const cleanTerm = term.trim();
+    if (!cleanTerm) {
+      setError('Ingresá un término para buscar.');
+      setResults([]);
+      setLastTerm('');
+      return;
+    }
+    setLoading(true);
+    setError('');
+    try {
+      const response = await apiFetch(`/api/search-assets?term=${encodeURIComponent(cleanTerm)}`);
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const message = payload?.error ? String(payload.error) : `Error ${response.status}`;
+        setError(message === 'missing_term' ? 'Ingresá un término para buscar.' : `No se pudo realizar la búsqueda (${message}).`);
+        setResults([]);
+        setLastTerm(cleanTerm);
+      } else {
+        setResults(Array.isArray(payload?.items) ? payload.items : []);
+        setLastTerm(cleanTerm);
+      }
+    } catch (err) {
+      setError(`No se pudo realizar la búsqueda. ${String(err?.message || err)}`);
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!isAuthorized) {
+    return (
+      <div className={styles.page}>
+        <Helmet>
+          <title>Búsqueda • MGM GAMERS</title>
+        </Helmet>
+        <h1 className={styles.heading}>Búsqueda interna</h1>
+        <form className={styles.card} onSubmit={handlePasswordSubmit}>
+          <p className={styles.description}>
+            Ingresá la contraseña para acceder al buscador interno de archivos generados en Supabase.
+          </p>
+          {!passwordRequired ? (
+            <p className={styles.passwordHint}>
+              No hay contraseña configurada. Definí <code>VITE_BUSQUEDA_PASSWORD</code> para activar la protección.
+            </p>
+          ) : null}
+          <label className={styles.label}>
+            Contraseña
+            <input
+              className={styles.input}
+              type="password"
+              value={passwordInput}
+              autoComplete="current-password"
+              onChange={(event) => {
+                setPasswordInput(event.target.value);
+                if (passwordError) setPasswordError('');
+              }}
+            />
+          </label>
+          {passwordError ? <p className={styles.error}>{passwordError}</p> : null}
+          <button type="submit" className={styles.primaryButton}>
+            Entrar
+          </button>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.page}>
+      <Helmet>
+        <title>Búsqueda de archivos • MGM GAMERS</title>
+      </Helmet>
+      <h1 className={styles.heading}>Búsqueda de archivos</h1>
+      <div className={styles.card}>
+        <form className={styles.searchForm} onSubmit={handleSearch}>
+          <label className={styles.label}>
+            Término de búsqueda
+            <input
+              className={styles.input}
+              type="search"
+              placeholder="Nombre del diseño, material o ID"
+              value={term}
+              onChange={(event) => setTerm(event.target.value)}
+              disabled={loading}
+            />
+          </label>
+          <button type="submit" className={styles.primaryButton} disabled={loading}>
+            {loading ? 'Buscando…' : 'Buscar'}
+          </button>
+        </form>
+        {error ? <p className={styles.error}>{error}</p> : null}
+        {!error && lastTerm ? (
+          <p className={styles.summary}>
+            Mostrando <strong>{results.length}</strong> resultados para <mark className={styles.term}>&ldquo;{lastTerm}&rdquo;</mark>
+          </p>
+        ) : null}
+        {results.length > 0 ? (
+          <ul className={styles.resultsList}>
+            {results.map((item, index) => {
+              const key =
+                item.job_id ||
+                item.file_original_url ||
+                item.preview_url ||
+                item.pdf_url ||
+                item.print_jpg_url ||
+                `resultado-${index}`;
+              return <ResultCard key={key} item={item} />;
+            })}
+          </ul>
+        ) : null}
+        {!loading && !error && lastTerm && results.length === 0 ? (
+          <p className={styles.emptyState}>No se encontraron resultados para ese término.</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/mgm-front/src/pages/Busqueda.module.css
+++ b/mgm-front/src/pages/Busqueda.module.css
@@ -1,0 +1,232 @@
+.page {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 24px 16px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.heading {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.card {
+  background: #111827;
+  border: 1px solid #1f2937;
+  border-radius: 16px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.35);
+}
+
+.description {
+  margin: 0;
+  color: #d1d5db;
+  line-height: 1.5;
+}
+
+.passwordHint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #facc15;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-weight: 600;
+  color: #e5e7eb;
+}
+
+.input {
+  border-radius: 10px;
+  border: 1px solid #334155;
+  background: #0f172a;
+  color: #f8fafc;
+  padding: 12px 14px;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #60a5fa;
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.25);
+}
+
+.primaryButton {
+  align-self: flex-start;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #f8fafc;
+  border: none;
+  border-radius: 10px;
+  padding: 12px 20px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primaryButton:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.35);
+}
+
+.primaryButton:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.searchForm {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-end;
+}
+
+.error {
+  color: #f87171;
+  margin: 0;
+}
+
+.summary {
+  margin: 0;
+  color: #cbd5f5;
+}
+
+.term {
+  background: rgba(59, 130, 246, 0.2);
+  color: #e0e7ff;
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+.resultsList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.resultItem {
+  border: 1px solid #1f2937;
+  border-radius: 14px;
+  padding: 16px 18px;
+  background: rgba(17, 24, 39, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.resultHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.resultTitleBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.jobId {
+  font-family: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.85rem;
+  color: #a5b4fc;
+  background: rgba(76, 29, 149, 0.35);
+  border: 1px solid rgba(165, 180, 252, 0.4);
+  padding: 2px 8px;
+  border-radius: 999px;
+  width: fit-content;
+}
+
+.resultTitle {
+  font-size: 1.15rem;
+  margin: 0;
+  font-weight: 600;
+}
+
+.resultMeta {
+  margin: 0;
+  color: #cbd5f5;
+  font-size: 0.95rem;
+}
+
+.customerInfo {
+  margin: 0;
+  color: #e2e8f0;
+  font-size: 0.9rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+
+.customerEmail {
+  color: #93c5fd;
+  text-decoration: none;
+}
+
+.customerEmail:hover {
+  text-decoration: underline;
+}
+
+.resultDate {
+  color: #94a3b8;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: flex-start;
+}
+
+.linksRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.link {
+  text-decoration: none;
+  font-weight: 500;
+  color: #bfdbfe;
+  background: rgba(37, 99, 235, 0.18);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  padding: 8px 12px;
+  border-radius: 10px;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.link:hover {
+  background: rgba(37, 99, 235, 0.32);
+  border-color: rgba(96, 165, 250, 0.6);
+}
+
+.emptyState {
+  margin: 0;
+  color: #9ca3af;
+  font-style: italic;
+}
+
+@media (max-width: 640px) {
+  .card {
+    padding: 20px;
+  }
+
+  .searchForm {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .primaryButton {
+    width: 100%;
+  }
+}

--- a/tests/api-handlers.test.js
+++ b/tests/api-handlers.test.js
@@ -33,3 +33,26 @@ test('searchAssets returns data', async () => {
   assert.equal(res.status, 200);
   assert.deepEqual(res.body.items, [{ id: 1 }]);
 });
+
+test('searchAssets sanitizes the term before building filters', async () => {
+  let receivedFilter = '';
+  const fakeSupa = {
+    from: () => ({
+      select: () => ({
+        or: (value) => {
+          receivedFilter = value;
+          return {
+            order: () => ({
+              limit: () => ({ data: [], error: null })
+            })
+          };
+        }
+      })
+    })
+  };
+  const res = await searchAssets({ query: { term: " f%'o` " } }, { supa: fakeSupa });
+  assert.equal(res.status, 200);
+  assert(receivedFilter.includes('fo'));
+  assert(!receivedFilter.includes("%'"));
+  assert(!receivedFilter.includes('`'));
+});


### PR DESCRIPTION
## Summary
- add the `/busqueda` route with a password-gated UI to query Supabase assets and show download links
- expose the existing search handler through the API router, extend it to sanitize the term and match more fields, and document the password env var
- cover the new sanitization logic with a node:test spec

## Testing
- node --test tests/api-handlers.test.js
- npm run lint *(fails: legacy lint issues in the project unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cf13c4f7588327a3b8f27d8641d776