### PR TITLE
Fix Shopify cart and checkout link generation

### DIFF
--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -29,9 +29,60 @@ export default async function createCartLink(req, res) {
     const qty = Number(quantity) > 0 ? Number(quantity) : 1;
     const base = getPublicStorefrontBase();
     if (!base) return res.status(500).json({ ok: false, error: 'missing_store_domain' });
-    const returnToRaw = process.env.SHOPIFY_CART_RETURN_TO || 'https://www.mgmgamers.store/';
-    const url = `${base.replace(/\/$/, '')}/cart/add?items[0][id]=${encodeURIComponent(normalizedVariantId)}&items[0][quantity]=${qty}&return_to=${encodeURIComponent(returnToRaw)}`;
-    return res.status(200).json({ ok: true, url });
+
+    const buildUrl = (path) => {
+      try {
+        return new URL(path, base);
+      } catch (err) {
+        console.error('create_cart_link_url_error', err);
+        return null;
+      }
+    };
+
+    const cartFollowUrl = buildUrl(`/cart/${normalizedVariantId}:${qty}`);
+    if (!cartFollowUrl) {
+      return res.status(500).json({ ok: false, error: 'invalid_store_domain' });
+    }
+    cartFollowUrl.searchParams.set('channel', 'buy_button');
+
+    const cartPlainUrl = buildUrl('/cart');
+    const checkoutPlainUrl = buildUrl('/checkout');
+
+    const returnToCart = (() => {
+      const raw = typeof process.env.SHOPIFY_CART_RETURN_TO === 'string'
+        ? process.env.SHOPIFY_CART_RETURN_TO.trim()
+        : '';
+      if (raw) return raw;
+      if (cartPlainUrl) return cartPlainUrl.pathname.startsWith('/')
+        ? cartPlainUrl.pathname
+        : cartPlainUrl.toString();
+      return '/cart';
+    })();
+    if (returnToCart) {
+      cartFollowUrl.searchParams.set('return_to', returnToCart);
+    }
+
+    const checkoutNowUrl = buildUrl(`/cart/${normalizedVariantId}:${qty}`);
+    if (checkoutNowUrl) {
+      checkoutNowUrl.searchParams.set('channel', 'buy_button');
+      const checkoutReturnToRaw = typeof process.env.SHOPIFY_CHECKOUT_RETURN_TO === 'string'
+        ? process.env.SHOPIFY_CHECKOUT_RETURN_TO.trim()
+        : '';
+      const checkoutReturnTo = checkoutReturnToRaw || '/checkout';
+      if (checkoutReturnTo) {
+        checkoutNowUrl.searchParams.set('return_to', checkoutReturnTo);
+      }
+    }
+
+    return res.status(200).json({
+      ok: true,
+      url: cartFollowUrl.toString(),
+      cart_url: cartFollowUrl.toString(),
+      cart_url_follow: cartFollowUrl.toString(),
+      cart_plain: cartPlainUrl ? cartPlainUrl.toString() : undefined,
+      checkout_url_now: checkoutNowUrl ? checkoutNowUrl.toString() : undefined,
+      checkout_plain: checkoutPlainUrl ? checkoutPlainUrl.toString() : undefined,
+    });
   } catch (e) {
     console.error('create_cart_link_error', e);
     return res.status(500).json({ ok: false, error: 'create_cart_link_failed' });

--- a/lib/handlers/createCheckout.js
+++ b/lib/handlers/createCheckout.js
@@ -39,7 +39,10 @@ export default async function createCheckout(req, res) {
     }
 
     checkoutUrl.searchParams.set('channel', 'buy_button');
-    checkoutUrl.searchParams.set('return_to', '/checkout');
+    const checkoutReturnToRaw = typeof process.env.SHOPIFY_CHECKOUT_RETURN_TO === 'string'
+      ? process.env.SHOPIFY_CHECKOUT_RETURN_TO.trim()
+      : '';
+    checkoutUrl.searchParams.set('return_to', checkoutReturnToRaw || '/checkout');
 
     return res.status(200).json({ ok: true, url: checkoutUrl.toString() });
   } catch (e) {


### PR DESCRIPTION
## Summary
- build Shopify cart links using cart permalinks that include the required buy_button channel parameter
- expose additional cart/checkout URLs so the frontend can re-use the generated permalinks after the first add to cart
- allow the checkout handler to respect an optional SHOPIFY_CHECKOUT_RETURN_TO override while keeping the channel parameter

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf146d5470832787d4832c5572d3a9