### PR TITLE
Fix Shopify channel configuration for cart and checkout links

### DIFF
--- a/docs/vercel.md
+++ b/docs/vercel.md
@@ -18,4 +18,8 @@ SHOPIFY_API_VERSION=2024-07
 # (opcionales si usas Storefront API en otro lugar)
 STOREFRONT_TOKEN=
 STOREFRONT_DOMAIN=
+# (opcional) Canal de ventas usado en los links de carrito/checkout
+# SHOPIFY_SALES_CHANNEL=online_store
+# SHOPIFY_CART_CHANNEL=
+# SHOPIFY_CHECKOUT_CHANNEL=
 ```

--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -1,4 +1,5 @@
 import { getPublicStorefrontBase } from '../publicStorefront.js';
+import { getShopifySalesChannel } from '../shopify.js';
 
 function ensureBody(req) {
   let b = req.body;
@@ -43,7 +44,8 @@ export default async function createCartLink(req, res) {
     if (!cartFollowUrl) {
       return res.status(500).json({ ok: false, error: 'invalid_store_domain' });
     }
-    cartFollowUrl.searchParams.set('channel', 'buy_button');
+    const cartChannel = getShopifySalesChannel('cart');
+    if (cartChannel) cartFollowUrl.searchParams.set('channel', cartChannel);
 
     const cartPlainUrl = buildUrl('/cart');
     const checkoutPlainUrl = buildUrl('/checkout');
@@ -64,7 +66,8 @@ export default async function createCartLink(req, res) {
 
     const checkoutNowUrl = buildUrl(`/cart/${normalizedVariantId}:${qty}`);
     if (checkoutNowUrl) {
-      checkoutNowUrl.searchParams.set('channel', 'buy_button');
+      const checkoutChannel = getShopifySalesChannel('checkout');
+      if (checkoutChannel) checkoutNowUrl.searchParams.set('channel', checkoutChannel);
       const checkoutReturnToRaw = typeof process.env.SHOPIFY_CHECKOUT_RETURN_TO === 'string'
         ? process.env.SHOPIFY_CHECKOUT_RETURN_TO.trim()
         : '';

--- a/lib/handlers/createCheckout.js
+++ b/lib/handlers/createCheckout.js
@@ -1,4 +1,5 @@
 import { getPublicStorefrontBase } from '../publicStorefront.js';
+import { getShopifySalesChannel } from '../shopify.js';
 
 function ensureBody(req) {
   let b = req.body;
@@ -38,7 +39,8 @@ export default async function createCheckout(req, res) {
       return res.status(500).json({ ok: false, error: 'invalid_store_domain' });
     }
 
-    checkoutUrl.searchParams.set('channel', 'buy_button');
+    const checkoutChannel = getShopifySalesChannel('checkout');
+    if (checkoutChannel) checkoutUrl.searchParams.set('channel', checkoutChannel);
     const checkoutReturnToRaw = typeof process.env.SHOPIFY_CHECKOUT_RETURN_TO === 'string'
       ? process.env.SHOPIFY_CHECKOUT_RETURN_TO.trim()
       : '';

--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -41,5 +41,24 @@ export async function shopifyAdminGraphQL(query, variables = {}, idemKey) {
   return fetch(base, { method: 'POST', headers, body: JSON.stringify({ query, variables }) });
 }
 
+function pickEnv(names) {
+  for (const name of names) {
+    if (!name) continue;
+    const raw = typeof process.env[name] === 'string' ? process.env[name].trim() : '';
+    if (raw) return raw;
+  }
+  return '';
+}
+
+export function getShopifySalesChannel(scope = '') {
+  const preferred = pickEnv([
+    scope === 'cart' ? 'SHOPIFY_CART_CHANNEL' : '',
+    scope === 'checkout' ? 'SHOPIFY_CHECKOUT_CHANNEL' : '',
+    'SHOPIFY_SALES_CHANNEL',
+  ]);
+  if (preferred) return preferred;
+  return 'online_store';
+}
+
 export default { shopifyAdmin, shopifyAdminGraphQL };
 


### PR DESCRIPTION
## Summary
- add a helper to resolve the Shopify sales channel with environment overrides and default to the online store
- update the cart and checkout link generators to use the selected channel and document the optional environment variables

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf198bd5808327b56ed78ae142a64a