### PR TITLE
Allow animated characters without uncertain age review

### DIFF
--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -457,7 +457,8 @@ export async function evaluateImage(buffer, filename, designName = '', options =
         skinPercent <= ANIMATED_REVIEW_MAX_SKIN &&
         largestBlob >= ANIMATED_REVIEW_MIN_BLOB;
       if (qualifiesAnimatedReview) {
-        applyOutcome('REVIEW', ['animated_uncertain_age'], Math.max(cartoonConfidence, nudityConfidence));
+        const allowConfidence = clamp(Math.max(cartoonConfidence, nudityConfidence));
+        applyOutcome('ALLOW', ['animated_skin_visible'], allowConfidence);
       }
     }
   }
@@ -497,7 +498,7 @@ export async function evaluateImage(buffer, filename, designName = '', options =
   }
 
   if (lowResolutionOverrideRequested && label === 'REVIEW') {
-    const seriousReviewReasons = new Set(['real_nudity_suspected', 'animated_uncertain_age']);
+    const seriousReviewReasons = new Set(['real_nudity_suspected']);
     const hasSeriousReview = reasons.some((reason) => seriousReviewReasons.has(reason));
     if (!hasSeriousReview) {
       label = 'ALLOW';


### PR DESCRIPTION
## Summary
- treat animated designs that meet the illustration heuristics as allowed instead of forcing a review
- restrict the low-resolution override safeguard to real-nudity review reasons only

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf1ad841a48327957e422810528674