### PR TITLE
Ensure cart link returns to storefront home

### DIFF
--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -47,6 +47,7 @@ export default async function createCartLink(req, res) {
     const cartChannel = getShopifySalesChannel('cart');
     if (cartChannel) cartFollowUrl.searchParams.set('channel', cartChannel);
 
+    const homeUrl = buildUrl('/');
     const cartPlainUrl = buildUrl('/cart');
     const checkoutPlainUrl = buildUrl('/checkout');
 
@@ -54,11 +55,15 @@ export default async function createCartLink(req, res) {
       const raw = typeof process.env.SHOPIFY_CART_RETURN_TO === 'string'
         ? process.env.SHOPIFY_CART_RETURN_TO.trim()
         : '';
-      if (raw) return raw;
-      if (cartPlainUrl) return cartPlainUrl.pathname.startsWith('/')
-        ? cartPlainUrl.pathname
-        : cartPlainUrl.toString();
-      return '/cart';
+      const sanitized = raw && !/checkout/i.test(raw) ? raw : '';
+      if (sanitized) return sanitized;
+      if (homeUrl) return homeUrl.toString();
+      if (cartPlainUrl) return cartPlainUrl.toString();
+      try {
+        return new URL('/', base).toString();
+      } catch {
+        return '/';
+      }
     })();
     if (returnToCart) {
       cartFollowUrl.searchParams.set('return_to', returnToCart);


### PR DESCRIPTION
## Summary
- sanitize the Shopify cart redirect so the add-to-cart button no longer jumps straight to checkout
- default the cart follow link to send customers back to the storefront home after adding the product

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cf1c5235d88327b42dd68cb2f3b236