### PR TITLE
Improve moderation heuristics for nudity and hate imagery

### DIFF
--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -61,38 +61,129 @@ async function detectSkin(buffer) {
   const total = w * h;
   const mask = new Uint8Array(total);
   let skinCount = 0;
+  const centerMarginX = Math.floor(w * 0.2);
+  const centerMarginY = Math.floor(h * 0.2);
+  const cx0 = centerMarginX;
+  const cx1 = w - centerMarginX;
+  const cy0 = centerMarginY;
+  const cy1 = h - centerMarginY;
+  let centerTotal = 0;
+  let centerSkin = 0;
+  const skinToneSamples = [];
+
   for (let i = 0, p = 0; p < total; i += info.channels, p++) {
-    const R = data[i], G = data[i+1], B = data[i+2];
-    const Y  = 0.299*R + 0.587*G + 0.114*B;
-    const Cb = 128 - 0.168736*R - 0.331264*G + 0.5*B;
-    const Cr = 128 + 0.5*R - 0.418688*G - 0.081312*B;
-    const isSkin = (Cb >= 77 && Cb <= 127 && Cr >= 133 && Cr <= 173);
-    if (isSkin) { mask[p] = 1; skinCount++; }
+    const R = data[i], G = data[i + 1], B = data[i + 2];
+    const Y = 0.299 * R + 0.587 * G + 0.114 * B;
+    const Cb = 128 - 0.168736 * R - 0.331264 * G + 0.5 * B;
+    const Cr = 128 + 0.5 * R - 0.418688 * G - 0.081312 * B;
+    const isSkin = Cb >= 77 && Cb <= 127 && Cr >= 133 && Cr <= 173;
+    const x = p % w;
+    const y = Math.floor(p / w);
+    const inCenter = x >= cx0 && x < cx1 && y >= cy0 && y < cy1;
+    if (inCenter) centerTotal++;
+    if (isSkin) {
+      mask[p] = 1;
+      skinCount++;
+      if (inCenter) centerSkin++;
+      skinToneSamples.push({ Y, Cb, Cr });
+    }
   }
+
   // largest connected component (4-neigh)
   const vis = new Uint8Array(total);
   let maxBlob = 0;
+  let secondBlob = 0;
+  let maxBlobBox = null;
+  let maxBlobCenterHits = 0;
   const qx = new Int32Array(total);
   const qy = new Int32Array(total);
   for (let p = 0; p < total; p++) {
     if (!mask[p] || vis[p]) continue;
-    let head = 0, tail = 0;
-    qx[tail] = p % w; qy[tail] = Math.floor(p / w); tail++;
+    let head = 0;
+    let tail = 0;
+    qx[tail] = p % w;
+    qy[tail] = Math.floor(p / w);
+    tail++;
     vis[p] = 1;
     let area = 0;
+    let minX = w, maxX = 0, minY = h, maxY = 0;
+    let centerHits = 0;
     while (head < tail) {
-      const x = qx[head], y = qy[head]; head++;
+      const x = qx[head];
+      const y = qy[head];
+      head++;
       area++;
-      const neighbors = [ [x+1,y], [x-1,y], [x,y+1], [x,y-1] ];
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+      if (x >= cx0 && x < cx1 && y >= cy0 && y < cy1) centerHits++;
+      const neighbors = [
+        [x + 1, y],
+        [x - 1, y],
+        [x, y + 1],
+        [x, y - 1],
+      ];
       for (const [nx, ny] of neighbors) {
         if (nx < 0 || ny < 0 || nx >= w || ny >= h) continue;
         const np = ny * w + nx;
-        if (mask[np] && !vis[np]) { vis[np] = 1; qx[tail] = nx; qy[tail] = ny; tail++; }
+        if (mask[np] && !vis[np]) {
+          vis[np] = 1;
+          qx[tail] = nx;
+          qy[tail] = ny;
+          tail++;
+        }
       }
     }
-    if (area > maxBlob) maxBlob = area;
+    if (area > maxBlob) {
+      secondBlob = maxBlob;
+      maxBlob = area;
+      maxBlobBox = { minX, maxX, minY, maxY };
+      maxBlobCenterHits = centerHits;
+    } else if (area > secondBlob) {
+      secondBlob = area;
+    }
   }
-  return { skinPercent: skinCount / total, largestBlob: maxBlob / total };
+
+  const centerSkinPercent = centerTotal ? centerSkin / centerTotal : 0;
+  const largestBlobBoxArea = maxBlobBox
+    ? (maxBlobBox.maxX - maxBlobBox.minX + 1) * (maxBlobBox.maxY - maxBlobBox.minY + 1)
+    : 0;
+  const largestBlobBoxCoverage = maxBlobBox && total ? largestBlobBoxArea / total : 0;
+  const largestBlob = total ? maxBlob / total : 0;
+  const secondLargestBlob = total ? secondBlob / total : 0;
+  const largestBlobCenterRatio = maxBlob ? maxBlobCenterHits / maxBlob : 0;
+
+  let toneVariance = 0;
+  if (skinToneSamples.length > 1) {
+    let sumCb = 0;
+    let sumCr = 0;
+    for (const sample of skinToneSamples) {
+      sumCb += sample.Cb;
+      sumCr += sample.Cr;
+    }
+    const meanCb = sumCb / skinToneSamples.length;
+    const meanCr = sumCr / skinToneSamples.length;
+    let varCb = 0;
+    let varCr = 0;
+    for (const sample of skinToneSamples) {
+      const dCb = sample.Cb - meanCb;
+      const dCr = sample.Cr - meanCr;
+      varCb += dCb * dCb;
+      varCr += dCr * dCr;
+    }
+    toneVariance = Math.sqrt((varCb + varCr) / (skinToneSamples.length - 1)) / 100;
+  }
+
+  return {
+    skinPercent: total ? skinCount / total : 0,
+    largestBlob,
+    secondLargestBlob,
+    centerSkinPercent,
+    largestBlobBoxCoverage,
+    largestBlobCenterRatio,
+    toneVariance,
+  };
 }
 
 async function detectIllustration(buffer) {
@@ -184,21 +275,38 @@ async function detectNazi(buffer) {
   }
   // Color/shape heuristic for flag
   const { data: d2, info: i2 } = await sharp(buffer).removeAlpha().resize({ width: 128 }).raw().toBuffer({ resolveWithObject: true });
-  const w = i2.width, h = i2.height, total = w*h;
+  const w = i2.width, h = i2.height, total = w * h;
   let redDom = 0, whiteInCircle = 0, blackStroke = 0, inCircleCount = 0, inRingCount = 0;
-  const cx = Math.floor(w/2), cy = Math.floor(h/2);
-  const r = Math.floor(Math.min(w,h)*0.3);
+  const redMask = new Uint8Array(total);
+  const whiteMask = new Uint8Array(total);
+  const blackMask = new Uint8Array(total);
+  const cx = Math.floor(w / 2), cy = Math.floor(h / 2);
+  const r = Math.floor(Math.min(w, h) * 0.3);
   for (let p = 0, idx = 0; p < total; p++, idx += i2.channels) {
-    const R = d2[idx], G = d2[idx+1], B = d2[idx+2];
-    if (R > 200 && G < 80 && B < 80) redDom++;
+    const R = d2[idx], G = d2[idx + 1], B = d2[idx + 2];
+    const isRed = R > 200 && G < 90 && B < 90;
+    const isWhite = R > 220 && G > 220 && B > 220;
+    const isBlack = R < 55 && G < 55 && B < 55;
+    if (isRed) {
+      redDom++;
+      redMask[p] = 1;
+    }
+    if (isWhite) whiteMask[p] = 1;
+    if (isBlack) blackMask[p] = 1;
     const x = p % w, y = Math.floor(p / w);
     const dist = Math.hypot(x - cx, y - cy);
-    if (dist <= r) { inCircleCount++; if (R>220 && G>220 && B>220) whiteInCircle++; }
-    if (dist > r*0.85 && dist < r*1.1) { inRingCount++; if (R<40 && G<40 && B<40) blackStroke++; }
+    if (dist <= r) {
+      inCircleCount++;
+      if (isWhite) whiteInCircle++;
+    }
+    if (dist > r * 0.85 && dist < r * 1.1) {
+      inRingCount++;
+      if (isBlack) blackStroke++;
+    }
   }
   const redRatio = redDom / total;
-  const whiteCircleRatio = (inCircleCount ? (whiteInCircle / inCircleCount) : 0);
-  const blackStrokeRatio = (inRingCount ? (blackStroke / inRingCount) : 0);
+  const whiteCircleRatio = inCircleCount ? whiteInCircle / inCircleCount : 0;
+  const blackStrokeRatio = inRingCount ? blackStroke / inRingCount : 0;
   const COLOR_MATCH_THRESHOLDS = {
     red: 0.5,
     white: 0.75,
@@ -216,6 +324,101 @@ async function detectNazi(buffer) {
       reason: 'flag_heuristic',
       score: { redRatio, whiteCircleRatio, blackStrokeRatio, minDist },
     };
+  }
+
+  const stride = w + 1;
+  const buildIntegral = (mask) => {
+    const integral = new Uint32Array((w + 1) * (h + 1));
+    for (let y = 1; y <= h; y++) {
+      let rowSum = 0;
+      for (let x = 1; x <= w; x++) {
+        const idx = (y - 1) * w + (x - 1);
+        rowSum += mask[idx];
+        integral[y * (w + 1) + x] = integral[(y - 1) * (w + 1) + x] + rowSum;
+      }
+    }
+    return integral;
+  };
+
+  const rectSum = (integral, x0, y0, x1, y1) => {
+    const clampedX0 = Math.max(0, Math.min(w, x0));
+    const clampedY0 = Math.max(0, Math.min(h, y0));
+    const clampedX1 = Math.max(0, Math.min(w, x1));
+    const clampedY1 = Math.max(0, Math.min(h, y1));
+    if (clampedX1 <= clampedX0 || clampedY1 <= clampedY0) return 0;
+    return (
+      integral[clampedY1 * stride + clampedX1] -
+      integral[clampedY0 * stride + clampedX1] -
+      integral[clampedY1 * stride + clampedX0] +
+      integral[clampedY0 * stride + clampedX0]
+    );
+  };
+
+  const integralRed = buildIntegral(redMask);
+  const integralWhite = buildIntegral(whiteMask);
+  const integralBlack = buildIntegral(blackMask);
+  const minWindow = Math.max(18, Math.floor(Math.min(w, h) * 0.18));
+  const maxWindow = Math.max(minWindow, Math.floor(Math.min(w, h) * 0.6));
+
+  for (let size = minWindow; size <= maxWindow; size += Math.max(6, Math.floor(size * 0.35))) {
+    const step = Math.max(4, Math.floor(size * 0.25));
+    for (let y = 0; y <= h - size; y += step) {
+      for (let x = 0; x <= w - size; x += step) {
+        const area = size * size;
+        const redCountLocal = rectSum(integralRed, x, y, x + size, y + size);
+        const redRatioLocal = redCountLocal / area;
+        if (redRatioLocal < 0.32) continue;
+        const innerSize = Math.max(8, Math.floor(size * 0.52));
+        const innerX = x + Math.floor((size - innerSize) / 2);
+        const innerY = y + Math.floor((size - innerSize) / 2);
+        const innerArea = innerSize * innerSize;
+        const whiteInner = rectSum(integralWhite, innerX, innerY, innerX + innerSize, innerY + innerSize);
+        const blackInner = rectSum(integralBlack, innerX, innerY, innerX + innerSize, innerY + innerSize);
+        const whiteInnerRatio = whiteInner / innerArea;
+        const blackInnerRatio = blackInner / innerArea;
+        if (whiteInnerRatio < 0.4 || blackInnerRatio < 0.1 || blackInnerRatio > 0.45) continue;
+        const half = Math.floor(innerSize / 2);
+        const leftBlack = rectSum(integralBlack, innerX, innerY, innerX + half, innerY + innerSize);
+        const rightBlack = rectSum(integralBlack, innerX + half, innerY, innerX + innerSize, innerY + innerSize);
+        const topBlack = rectSum(integralBlack, innerX, innerY, innerX + innerSize, innerY + half);
+        const bottomBlack = rectSum(integralBlack, innerX, innerY + half, innerX + innerSize, innerY + innerSize);
+        if (!leftBlack || !rightBlack || !topBlack || !bottomBlack) continue;
+        const centerBand = Math.max(3, Math.floor(innerSize * 0.18));
+        const centerX0 = innerX + Math.floor((innerSize - centerBand) / 2);
+        const centerY0 = innerY + Math.floor((innerSize - centerBand) / 2);
+        const centerVertical = rectSum(
+          integralBlack,
+          centerX0,
+          innerY,
+          centerX0 + centerBand,
+          innerY + innerSize
+        );
+        const centerHorizontal = rectSum(
+          integralBlack,
+          innerX,
+          centerY0,
+          innerX + innerSize,
+          centerY0 + centerBand
+        );
+        const verticalDensity = centerVertical / (centerBand * innerSize);
+        const horizontalDensity = centerHorizontal / (centerBand * innerSize);
+        if (verticalDensity < 0.05 || horizontalDensity < 0.05) continue;
+        return {
+          nazi: true,
+          reason: 'flag_patch',
+          score: {
+            patchSize: size,
+            innerSize,
+            redRatioLocal,
+            whiteInnerRatio,
+            blackInnerRatio,
+            verticalDensity,
+            horizontalDensity,
+            minDist,
+          },
+        };
+      }
+    }
   }
   return { nazi: false, reason: 'none', score: minDist };
 }
@@ -298,10 +501,34 @@ async function prepareModerationImage(buffer) {
   }
 }
 
-function computeNudityConfidence({ skinPercent = 0, largestBlob = 0 }) {
-  const skinScore = clamp((skinPercent - 0.35) / 0.45);
-  const blobScore = clamp((largestBlob - 0.1) / 0.4);
-  return clamp(skinScore * 0.6 + blobScore * 0.4);
+function computeNudityConfidence({
+  skinPercent = 0,
+  largestBlob = 0,
+  secondLargestBlob = 0,
+  centerSkinPercent = 0,
+  largestBlobBoxCoverage = 0,
+  largestBlobCenterRatio = 0,
+  toneVariance = 0,
+} = {}) {
+  const skinScore = clamp((skinPercent - 0.28) / 0.35);
+  const blobScore = clamp((largestBlob - 0.12) / 0.28);
+  const centerScore = clamp((centerSkinPercent - 0.2) / 0.3);
+  const boxScore = clamp((largestBlobBoxCoverage - 0.24) / 0.3);
+  const focusScore = clamp((largestBlobCenterRatio - 0.25) / 0.35);
+  const secondaryScore = clamp(((largestBlob + secondLargestBlob) - 0.35) / 0.45);
+  const variancePenalty = clamp(1 - toneVariance * 1.8);
+
+  let combined =
+    skinScore * 0.28 +
+    blobScore * 0.26 +
+    centerScore * 0.2 +
+    boxScore * 0.14 +
+    focusScore * 0.12;
+  combined = Math.max(combined, blobScore * 0.55 + centerScore * 0.45);
+  combined = Math.max(combined, centerScore * 0.5 + boxScore * 0.5);
+  combined = Math.max(combined, secondaryScore * 0.75);
+  combined *= variancePenalty;
+  return clamp(combined);
 }
 
 const SEVERITY_RANK = { ALLOW: 0, REVIEW: 1, BLOCK: 2 };
@@ -367,43 +594,76 @@ export async function evaluateImage(buffer, filename, designName = '', options =
   // A) skin-based real nudity heuristic with illustration-based relaxations
   const skin = await detectSkin(workingBuffer);
   debug.skin = skin;
-  const nudityConfidence = computeNudityConfidence(skin);
-  debug.scores.realNudity = nudityConfidence;
+  let nudityConfidence = computeNudityConfidence(skin);
 
-  const CARTOON_STRONG_THRESHOLD = 0.7;
-  const CARTOON_RELAX_THRESHOLD = 0.5;
-  const REAL_NUDITY_BLOCK_THRESHOLD = 0.6;
-  const REAL_NUDITY_REVIEW_THRESHOLD = 0.5;
-  const REAL_NUDITY_MIN_COVERAGE_FOR_REVIEW = 0.35;
-  const REAL_NUDITY_MIN_BLOB_FOR_REVIEW = 0.18;
-  const REAL_NUDITY_MIN_COVERAGE_FOR_BLOCK = 0.42;
-  const REAL_NUDITY_MIN_BLOB_FOR_BLOCK = 0.24;
+  const CARTOON_STRONG_THRESHOLD = 0.78;
+  const CARTOON_RELAX_THRESHOLD = 0.6;
+  const CARTOON_RELAX_MAX_PALETTE_RATIO = 0.018;
+  const REAL_NUDITY_BLOCK_THRESHOLD = 0.55;
+  const REAL_NUDITY_REVIEW_THRESHOLD = 0.45;
+  const REAL_NUDITY_MIN_COVERAGE_FOR_REVIEW = 0.28;
+  const REAL_NUDITY_MIN_BLOB_FOR_REVIEW = 0.16;
+  const REAL_NUDITY_MIN_CENTER_FOR_REVIEW = 0.22;
+  const REAL_NUDITY_MIN_COVERAGE_FOR_BLOCK = 0.35;
+  const REAL_NUDITY_MIN_BLOB_FOR_BLOCK = 0.22;
+  const REAL_NUDITY_MIN_CENTER_FOR_BLOCK = 0.28;
 
   const skinPercent = skin?.skinPercent ?? 0;
   const largestBlob = skin?.largestBlob ?? 0;
+  const secondLargestBlob = skin?.secondLargestBlob ?? 0;
+  const centerSkinPercent = skin?.centerSkinPercent ?? 0;
+  const largestBlobBoxCoverage = skin?.largestBlobBoxCoverage ?? 0;
+  const largestBlobCenterRatio = skin?.largestBlobCenterRatio ?? 0;
+  const toneVariance = skin?.toneVariance ?? 0;
+  const paletteRatio = illustration?.paletteRatio ?? 0;
+  const edgeRatio = illustration?.edgeRatio ?? 0;
   const meetsReviewCoverage =
-    skinPercent >= REAL_NUDITY_MIN_COVERAGE_FOR_REVIEW || largestBlob >= REAL_NUDITY_MIN_BLOB_FOR_REVIEW;
+    skinPercent >= REAL_NUDITY_MIN_COVERAGE_FOR_REVIEW ||
+    largestBlob >= REAL_NUDITY_MIN_BLOB_FOR_REVIEW ||
+    centerSkinPercent >= REAL_NUDITY_MIN_CENTER_FOR_REVIEW;
   const meetsBlockCoverage =
-    skinPercent >= REAL_NUDITY_MIN_COVERAGE_FOR_BLOCK || largestBlob >= REAL_NUDITY_MIN_BLOB_FOR_BLOCK;
+    skinPercent >= REAL_NUDITY_MIN_COVERAGE_FOR_BLOCK ||
+    largestBlob >= REAL_NUDITY_MIN_BLOB_FOR_BLOCK ||
+    centerSkinPercent >= REAL_NUDITY_MIN_CENTER_FOR_BLOCK ||
+    largestBlobBoxCoverage >= 0.28;
+
+  const centerBoost = clamp((centerSkinPercent - 0.26) / 0.28);
+  const blobBoost = clamp((largestBlob - 0.24) / 0.22);
+  const boxBoost = clamp((largestBlobBoxCoverage - 0.3) / 0.26);
+  const secondaryBoost = clamp(((largestBlob + secondLargestBlob) - 0.45) / 0.4);
+  const combinedBoost = Math.max(centerBoost * 0.5 + blobBoost * 0.5, boxBoost, secondaryBoost);
+  nudityConfidence = Math.max(nudityConfidence, combinedBoost);
+  debug.scores.realNudity = nudityConfidence;
+
+  const canRelaxForCartoon =
+    cartoonConfidence >= CARTOON_RELAX_THRESHOLD &&
+    paletteRatio <= CARTOON_RELAX_MAX_PALETTE_RATIO &&
+    edgeRatio >= 0.028 &&
+    toneVariance <= 0.12 &&
+    centerSkinPercent <= 0.32 &&
+    largestBlob <= 0.28 &&
+    largestBlobCenterRatio <= 0.35;
 
   if (nudityConfidence >= REAL_NUDITY_BLOCK_THRESHOLD) {
-    if (cartoonConfidence >= CARTOON_RELAX_THRESHOLD) {
-      const allowConfidence = clamp(0.65 + (cartoonConfidence - CARTOON_RELAX_THRESHOLD) * 0.3);
+    if (canRelaxForCartoon) {
+      const allowConfidence = clamp(0.6 + (cartoonConfidence - CARTOON_RELAX_THRESHOLD) * 0.25);
       applyOutcome('ALLOW', ['animated_explicit_allowed'], allowConfidence);
     } else if (meetsBlockCoverage) {
       const nudityReasons = ['real_nudity'];
-      if (largestBlob >= 0.4) nudityReasons.push('genitals_visible');
-      if (skinPercent >= 0.75) nudityReasons.push('sex_act');
-      applyOutcome('BLOCK', nudityReasons, nudityConfidence);
+      if (largestBlob >= 0.38 || largestBlobBoxCoverage >= 0.38) nudityReasons.push('genitals_visible');
+      if (skinPercent >= 0.7 || centerSkinPercent >= 0.4) nudityReasons.push('sex_act');
+      if (centerSkinPercent >= 0.32) nudityReasons.push('high_center_skin');
+      applyOutcome('BLOCK', nudityReasons, Math.max(nudityConfidence, centerBoost));
     } else if (meetsReviewCoverage) {
       applyOutcome('REVIEW', ['real_nudity_suspected'], nudityConfidence);
     }
   } else if (nudityConfidence >= REAL_NUDITY_REVIEW_THRESHOLD && meetsReviewCoverage) {
-    if (cartoonConfidence >= CARTOON_RELAX_THRESHOLD) {
-      const allowConfidence = clamp(0.6 + (cartoonConfidence - CARTOON_RELAX_THRESHOLD) * 0.25);
+    if (canRelaxForCartoon && cartoonConfidence >= CARTOON_RELAX_THRESHOLD + 0.05) {
+      const allowConfidence = clamp(0.58 + (cartoonConfidence - CARTOON_RELAX_THRESHOLD) * 0.22);
       applyOutcome('ALLOW', ['animated_skin_visible'], allowConfidence);
     } else {
-      applyOutcome('REVIEW', ['real_nudity_suspected'], nudityConfidence);
+      const reasons = centerSkinPercent >= 0.28 ? ['real_nudity_suspected', 'high_center_skin'] : ['real_nudity_suspected'];
+      applyOutcome('REVIEW', reasons, nudityConfidence);
     }
   }
 

--- a/tests/moderation.test.js
+++ b/tests/moderation.test.js
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import sharp from 'sharp';
+
+process.env.MODERATION_SKIP_OCR = '1';
+
+const { evaluateImage } = await import('../lib/handlers/moderateImage.js');
+
+async function createSyntheticNudityBuffer() {
+  const width = 512;
+  const height = 512;
+  const channels = 3;
+  const data = Buffer.alloc(width * height * channels);
+  const cx = width / 2;
+  const cy = height / 2;
+  const radiusX = width * 0.38;
+  const radiusY = height * 0.44;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * channels;
+      const nx = (x - cx) / radiusX;
+      const ny = (y - cy) / radiusY;
+      const inside = nx * nx + ny * ny <= 1;
+      if (inside) {
+        const noise = Math.sin(x * 0.025) * 6 + Math.cos(y * 0.018) * 4;
+        const baseR = 210 + noise;
+        const baseG = 170 + noise * 0.6;
+        const baseB = 140 + noise * 0.35;
+        data[idx] = Math.max(0, Math.min(255, Math.round(baseR)));
+        data[idx + 1] = Math.max(0, Math.min(255, Math.round(baseG)));
+        data[idx + 2] = Math.max(0, Math.min(255, Math.round(baseB)));
+      } else {
+        const bg = 28 + ((x + y) % 5);
+        data[idx] = bg;
+        data[idx + 1] = bg + 2;
+        data[idx + 2] = bg + 4;
+      }
+    }
+  }
+
+  return sharp(data, { raw: { width, height, channels } }).png().toBuffer();
+}
+
+async function createNeutralBuffer() {
+  return sharp({
+    create: {
+      width: 320,
+      height: 320,
+      channels: 3,
+      background: { r: 45, g: 90, b: 140 },
+    },
+  })
+    .png()
+    .toBuffer();
+}
+
+function swastikaSVG({ size = 256, stroke = 26, flag = true } = {}) {
+  const s = size;
+  const m = s / 2;
+  const bg = flag ? '#c00' : '#fff';
+  const circle = flag
+    ? `<circle cx="${m}" cy="${m}" r="${s * 0.34}" fill="#fff" stroke="#000" stroke-width="${Math.max(
+        2,
+        s * 0.04,
+      )}"/>`
+    : '';
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<svg xmlns="http://www.w3.org/2000/svg" width="${s}" height="${s}" viewBox="0 0 ${s} ${s}">\n  <rect width="100%" height="100%" fill="${bg}"/>\n  ${circle}\n  <g transform="rotate(0, ${m}, ${m})" fill="#000">\n    <rect x="${m - stroke / 2}" y="${m - s * 0.36}" width="${stroke}" height="${s * 0.72}"/>\n    <rect x="${m - s * 0.36}" y="${m - stroke / 2}" width="${s * 0.72}" height="${stroke}"/>\n    <rect x="${m + stroke * 0.45}" y="${m - s * 0.36}" width="${s * 0.2}" height="${stroke}"/>\n    <rect x="${m - stroke / 2}" y="${m + stroke * 0.45}" width="${stroke}" height="${s * 0.2}"/>\n    <rect x="${m - s * 0.36}" y="${m - stroke * 0.45 - s * 0.2}" width="${s * 0.2}" height="${stroke}"/>\n    <rect x="${m - stroke * 0.45 - s * 0.2}" y="${m - stroke / 2}" width="${stroke}" height="${s * 0.2}"/>\n  </g>\n</svg>`;
+}
+
+async function createSwastikaBuffer() {
+  const svg = swastikaSVG();
+  return sharp(Buffer.from(svg)).png().toBuffer();
+}
+
+test('evaluateImage blocks obvious skin exposure', async () => {
+  const buf = await createSyntheticNudityBuffer();
+  const result = await evaluateImage(buf, 'design.png');
+  assert.equal(result.label, 'BLOCK');
+  assert(result.reasons.some((r) => r.startsWith('real_nudity')));
+  assert(result.confidence >= 0.55);
+});
+
+test('evaluateImage allows neutral graphics', async () => {
+  const buf = await createNeutralBuffer();
+  const result = await evaluateImage(buf, 'poster.png');
+  assert.equal(result.label, 'ALLOW');
+  assert.equal(result.reasons.includes('no_violation_detected'), true);
+});
+
+test('evaluateImage blocks nazi symbols', async () => {
+  const buf = await createSwastikaBuffer();
+  const result = await evaluateImage(buf, 'flag.png');
+  assert.equal(result.label, 'BLOCK');
+  assert(result.reasons.includes('extremism_nazi'));
+});
+
+test('evaluateImage blocks nazi text metadata', async () => {
+  const buf = await createNeutralBuffer();
+  const result = await evaluateImage(buf, 'safe.png', 'Heil Hitler banner');
+  assert.equal(result.label, 'BLOCK');
+  assert(result.reasons.includes('extremism_nazi_text'));
+});
+


### PR DESCRIPTION
## Summary
- enhance the skin detection pipeline with central coverage metrics, tone variance checks, and updated thresholds so real nudity is blocked while animated relaxations stay safe
- expand nazi imagery detection with localized flag pattern matching using integral images and keep pHash/metadata gates
- add moderation regression tests that cover obvious nudity, safe graphics, nazi flag imagery, and nazi text metadata

## Testing
- `node --test tests/api-handlers.test.js tests/moderation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68cf1d07c7f483278ef0fda3f73e2267