### PR TITLE
Relax wallpaper false positives in nudity filter

### DIFF
--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -23,6 +23,7 @@ Prioridad de las reglas:
   - Búsqueda de términos prohibidos en nombre del archivo/modelo y en el texto detectado vía OCR (`tesseract.js`).
   - Búsqueda de símbolos de odio (esvásticas, banderas) con `pHash` y heurísticas de color.
 - Los desnudos se filtran mediante detección de piel. También se estima si la imagen es animada vs. real para aplicar las reglas anteriores.
+- Se penalizan automáticamente fondos de color muy uniforme y con poca textura (p. ej. wallpapers) para evitar falsos positivos de "desnudez real".
 
 Variables opcionales en `.env`:
 

--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -617,6 +617,35 @@ export async function evaluateImage(buffer, filename, designName = '', options =
   const toneVariance = skin?.toneVariance ?? 0;
   const paletteRatio = illustration?.paletteRatio ?? 0;
   const edgeRatio = illustration?.edgeRatio ?? 0;
+
+  // Penalize extremely uniform, low-texture scenes that mimic skin tones (e.g. wallpapers)
+  // so they do not trigger the "real nudity" gate.
+  const TONE_FLAT_MAX = 0.01;
+  const EDGE_SOFT_MAX = 0.022;
+  const PALETTE_SOFT_MAX = 0.0035;
+  let flatSceneReduction = 0;
+  if (
+    toneVariance <= TONE_FLAT_MAX &&
+    edgeRatio <= EDGE_SOFT_MAX &&
+    paletteRatio <= PALETTE_SOFT_MAX &&
+    skinPercent >= 0.32 &&
+    largestBlob >= 0.32 &&
+    centerSkinPercent >= 0.55
+  ) {
+    // `largestBlobCenterRatio` closer to ~0.65 is typical for real people framed in the center.
+    // Extreme deviations combined with flat tones usually correspond to solid backgrounds.
+    const centerBias = clamp((Math.abs(largestBlobCenterRatio - 0.65) - 0.08) / 0.22);
+    if (centerBias > 0) {
+      const coverageIntensity = clamp((skinPercent - 0.32) / 0.68);
+      const edgeLack = clamp((EDGE_SOFT_MAX - edgeRatio) / EDGE_SOFT_MAX);
+      const toneFlatness = clamp((TONE_FLAT_MAX - toneVariance) / TONE_FLAT_MAX);
+      const uniformity =
+        Math.max(edgeLack, toneFlatness) * 0.65 +
+        coverageIntensity * 0.2 +
+        centerBias * 0.15;
+      flatSceneReduction = clamp(0.3 + uniformity * 0.6, 0.3, 0.9);
+    }
+  }
   const meetsReviewCoverage =
     skinPercent >= REAL_NUDITY_MIN_COVERAGE_FOR_REVIEW ||
     largestBlob >= REAL_NUDITY_MIN_BLOB_FOR_REVIEW ||
@@ -633,6 +662,10 @@ export async function evaluateImage(buffer, filename, designName = '', options =
   const secondaryBoost = clamp(((largestBlob + secondLargestBlob) - 0.45) / 0.4);
   const combinedBoost = Math.max(centerBoost * 0.5 + blobBoost * 0.5, boxBoost, secondaryBoost);
   nudityConfidence = Math.max(nudityConfidence, combinedBoost);
+  if (flatSceneReduction > 0) {
+    nudityConfidence *= 1 - flatSceneReduction;
+    debug.scores.realNudityPenalty = flatSceneReduction;
+  }
   debug.scores.realNudity = nudityConfidence;
 
   const canRelaxForCartoon =


### PR DESCRIPTION
## Summary
- add a flat-scene penalty to the server moderation heuristics so monochrome wallpapers no longer get flagged as real nudity
- document the new penalty in the moderation guide

## Testing
- MODERATION_SKIP_OCR=1 node --test tests/moderation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf2cfabf2483278ea1be604bb0366f