### PR TITLE
Ensure cart links return to MGM home

### DIFF
--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -18,6 +18,26 @@ function normalizeVariantId(value) {
   return match ? match[1] : '';
 }
 
+function sanitizeReturnTarget(value) {
+  if (!value || typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  if (!trimmed || /checkout/i.test(trimmed)) return '';
+  return trimmed;
+}
+
+function normalizeAbsolute(value, base) {
+  const sanitized = sanitizeReturnTarget(value);
+  if (!sanitized) return '';
+  if (/^https?:\/\//i.test(sanitized)) return sanitized;
+  if (!base) return sanitized;
+  try {
+    const url = new URL(sanitized, base);
+    return url.toString();
+  } catch {
+    return sanitized;
+  }
+}
+
 export default async function createCartLink(req, res) {
   if (req.method !== 'POST') {
     res.statusCode = 405;
@@ -40,33 +60,47 @@ export default async function createCartLink(req, res) {
       }
     };
 
-    const cartFollowUrl = buildUrl(`/cart/${normalizedVariantId}:${qty}`);
-    if (!cartFollowUrl) {
+    const cartAddUrl = buildUrl('/cart/add');
+    if (!cartAddUrl) {
       return res.status(500).json({ ok: false, error: 'invalid_store_domain' });
     }
+    cartAddUrl.searchParams.set('id', normalizedVariantId);
+    cartAddUrl.searchParams.set('quantity', String(qty));
     const cartChannel = getShopifySalesChannel('cart');
-    if (cartChannel) cartFollowUrl.searchParams.set('channel', cartChannel);
+    if (cartChannel) cartAddUrl.searchParams.set('channel', cartChannel);
 
     const homeUrl = buildUrl('/');
     const cartPlainUrl = buildUrl('/cart');
     const checkoutPlainUrl = buildUrl('/checkout');
 
-    const returnToCart = (() => {
-      const raw = typeof process.env.SHOPIFY_CART_RETURN_TO === 'string'
-        ? process.env.SHOPIFY_CART_RETURN_TO.trim()
-        : '';
-      const sanitized = raw && !/checkout/i.test(raw) ? raw : '';
-      if (sanitized) return sanitized;
-      if (homeUrl) return homeUrl.toString();
-      if (cartPlainUrl) return cartPlainUrl.toString();
-      try {
-        return new URL('/', base).toString();
-      } catch {
-        return '/';
+    let mgmHome = '';
+    try {
+      const baseUrl = new URL(base);
+      if (/mgmgamers/i.test(baseUrl.hostname)) {
+        mgmHome = normalizeAbsolute('https://www.mgmgamers.store/', base);
       }
-    })();
+    } catch {
+      mgmHome = normalizeAbsolute('https://www.mgmgamers.store/', base);
+    }
+
+    const candidates = [
+      normalizeAbsolute(process.env.SHOPIFY_CART_RETURN_TO, base),
+      normalizeAbsolute(process.env.SHOPIFY_HOME_URL, base),
+      mgmHome,
+      homeUrl ? homeUrl.toString() : '',
+      cartPlainUrl ? cartPlainUrl.toString() : '',
+      (() => {
+        try {
+          return new URL('/', base).toString();
+        } catch {
+          return '';
+        }
+      })(),
+      '/',
+    ];
+    const returnToCart = candidates.find((value) => sanitizeReturnTarget(value)) || '/';
     if (returnToCart) {
-      cartFollowUrl.searchParams.set('return_to', returnToCart);
+      cartAddUrl.searchParams.set('return_to', returnToCart);
     }
 
     const checkoutNowUrl = buildUrl(`/cart/${normalizedVariantId}:${qty}`);
@@ -84,9 +118,9 @@ export default async function createCartLink(req, res) {
 
     return res.status(200).json({
       ok: true,
-      url: cartFollowUrl.toString(),
-      cart_url: cartFollowUrl.toString(),
-      cart_url_follow: cartFollowUrl.toString(),
+      url: cartAddUrl.toString(),
+      cart_url: cartAddUrl.toString(),
+      cart_url_follow: cartAddUrl.toString(),
       cart_plain: cartPlainUrl ? cartPlainUrl.toString() : undefined,
       checkout_url_now: checkoutNowUrl ? checkoutNowUrl.toString() : undefined,
       checkout_plain: checkoutPlainUrl ? checkoutPlainUrl.toString() : undefined,

--- a/lib/publicStorefront.js
+++ b/lib/publicStorefront.js
@@ -14,9 +14,11 @@ const shouldForceWww = (hostname) => {
 
 export function getPublicStorefrontBase() {
   const candidates = [
+    process.env.SHOPIFY_HOME_URL,
     process.env.SHOPIFY_PUBLIC_BASE,
     process.env.SHOPIFY_STOREFRONT_DOMAIN,
     process.env.SHOPIFY_STORE_DOMAIN,
+    'https://www.mgmgamers.store',
   ];
 
   for (const candidate of candidates) {

--- a/tests/create-cart-link.test.js
+++ b/tests/create-cart-link.test.js
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import createCartLink from '../lib/handlers/createCartLink.js';
+
+function createMockRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    jsonPayload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    setHeader(name, value) {
+      this.headers[name.toLowerCase()] = value;
+    },
+    json(payload) {
+      this.jsonPayload = payload;
+      return payload;
+    },
+  };
+}
+
+test('create-cart-link uses cart/add and returns mgm home when base is mgmgamers', async () => {
+  const prev = {
+    STORE_DOMAIN: process.env.SHOPIFY_STORE_DOMAIN,
+    PUBLIC_BASE: process.env.SHOPIFY_PUBLIC_BASE,
+    HOME_URL: process.env.SHOPIFY_HOME_URL,
+    CART_RETURN: process.env.SHOPIFY_CART_RETURN_TO,
+  };
+  try {
+    process.env.SHOPIFY_STORE_DOMAIN = 'mgmgamers-store.myshopify.com';
+    delete process.env.SHOPIFY_PUBLIC_BASE;
+    delete process.env.SHOPIFY_HOME_URL;
+    delete process.env.SHOPIFY_CART_RETURN_TO;
+
+    const req = {
+      method: 'POST',
+      body: { variantId: '123456789', quantity: 2 },
+    };
+    const res = createMockRes();
+
+    await createCartLink(req, res);
+
+    assert.equal(res.statusCode, 200);
+    assert(res.jsonPayload);
+
+    const { cart_url: cartUrl } = res.jsonPayload;
+    assert(cartUrl);
+    const parsed = new URL(cartUrl);
+    assert.equal(parsed.pathname, '/cart/add');
+    assert.equal(parsed.searchParams.get('id'), '123456789');
+    assert.equal(parsed.searchParams.get('quantity'), '2');
+    assert.equal(parsed.searchParams.get('return_to'), 'https://www.mgmgamers.store/');
+  } finally {
+    process.env.SHOPIFY_STORE_DOMAIN = prev.STORE_DOMAIN;
+    if (prev.PUBLIC_BASE === undefined) delete process.env.SHOPIFY_PUBLIC_BASE; else process.env.SHOPIFY_PUBLIC_BASE = prev.PUBLIC_BASE;
+    if (prev.HOME_URL === undefined) delete process.env.SHOPIFY_HOME_URL; else process.env.SHOPIFY_HOME_URL = prev.HOME_URL;
+    if (prev.CART_RETURN === undefined) delete process.env.SHOPIFY_CART_RETURN_TO; else process.env.SHOPIFY_CART_RETURN_TO = prev.CART_RETURN;
+  }
+});


### PR DESCRIPTION
## Summary
- generate cart URLs using Shopify's `/cart/add` endpoint so the product is added before redirecting
- prioritize `SHOPIFY_HOME_URL` and MGM's main domain when resolving the public storefront base
- add a unit test covering the new cart link behaviour and the required redirect

## Testing
- `node --test tests/api-handlers.test.js tests/create-cart-link.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68cf2de16a188327883cc8eef45acad2