### PR TITLE
fix: polyfill buffer for nsfwjs bundling

### DIFF
--- a/mgm-front/package-lock.json
+++ b/mgm-front/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.54.0",
         "@tensorflow/tfjs": "^4.22.0",
+        "buffer": "^6.0.3",
         "konva": "^9.3.22",
         "nanoid": "^5.1.5",
         "nsfwjs": "^4.2.1",
@@ -1803,8 +1804,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -1869,7 +1869,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -2669,8 +2668,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/mgm-front/package.json
+++ b/mgm-front/package.json
@@ -12,9 +12,10 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.54.0",
     "@tensorflow/tfjs": "^4.22.0",
+    "buffer": "^6.0.3",
     "konva": "^9.3.22",
-    "nsfwjs": "^4.2.1",
     "nanoid": "^5.1.5",
+    "nsfwjs": "^4.2.1",
     "pdf-lib": "^1.17.1",
     "react": "^18.3.1",
     "react-colorful": "^5.6.1",

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Buffer } from 'buffer';
 import { createRoot } from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from './App.jsx';
@@ -18,6 +19,10 @@ import { OrderFlowProvider } from './store/orderFlow';
 import { FlowProvider } from './state/flow.js';
 import './globals.css';
 import { HelmetProvider } from 'react-helmet-async';
+
+if (typeof globalThis !== 'undefined' && typeof globalThis.Buffer === 'undefined') {
+  globalThis.Buffer = Buffer;
+}
 
 const routes = [
   {

--- a/mgm-front/vite.config.js
+++ b/mgm-front/vite.config.js
@@ -8,6 +8,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
+      'buffer/': 'buffer',
     }
   },
   server: {


### PR DESCRIPTION
## Summary
- add the buffer dependency so nsfwjs can resolve its Buffer import
- expose the buffer polyfill in Vite and the app entrypoint to make Buffer available at runtime

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf354ebae08327aea6b7b33b7a9de7