### PR TITLE
Remove PDF download button from mockup page

### DIFF
--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -122,7 +122,6 @@ export default function Mockup() {
       />
       <div style={{ marginTop: 16, display: 'flex', gap: 12, justifyContent: 'center' }}>
         <button disabled={busy} onClick={() => { flow.reset(); navigate('/'); }}>Cancelar y volver</button>
-        <button disabled={busy} onClick={handleDownloadPdf}>Descargar PDF</button>
         <button disabled={busy} onClick={() => handle('cart')}>Agregar al carrito y seguir creando</button>
         <button disabled={busy} onClick={() => handle('checkout')}>Comprar ahora</button>
       </div>


### PR DESCRIPTION
## Summary
- remove the "Descargar PDF" button from the mockup controls while preserving the existing PDF generation logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf388082848327a917c9b9b9de6c5e