### PR TITLE
feat: ajustar nombre y efecto de glasspad

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -46,6 +46,37 @@ function buildMeasurement(widthCm, heightCm) {
   return `${w}x${h}`;
 }
 
+function ensureQuoted(value) {
+  const base = typeof value === 'string' ? value.trim() : '';
+  if (!base) return '';
+  const safe = base.replace(/"/g, "'");
+  return `"${safe}"`;
+}
+
+function withCmSuffix(measurement) {
+  if (!measurement) return '';
+  const normalized = measurement.trim();
+  if (!normalized) return '';
+  return /cm$/i.test(normalized) ? normalized : `${normalized} cm`;
+}
+
+function buildGlasspadTitle({ designName, measurement }) {
+  const sections = ['GLASSPAD'];
+  const quotedName = ensureQuoted(designName);
+  if (quotedName) sections.push(quotedName);
+  const quotedMeasurement = ensureQuoted(withCmSuffix(measurement));
+  if (quotedMeasurement) sections.push(quotedMeasurement);
+  return `${sections.join(' ')} | PERSONALIZADO`;
+}
+
+function buildDefaultTitle({ productTypeLabel, designName, measurement, materialLabel }) {
+  const parts = [productTypeLabel];
+  if (designName) parts.push(designName);
+  if (measurement) parts.push(measurement);
+  if (materialLabel) parts.push(materialLabel);
+  return `${parts.join(' ')} | PERSONALIZADO`;
+}
+
 function buildMetaDescription({ productTypeLabel, designName, widthCm, heightCm, materialLabel }) {
   const measurement = buildMeasurement(widthCm, heightCm);
   const baseLabel = productTypeLabel === 'Glasspad'
@@ -85,11 +116,14 @@ export async function publishProduct(req, res) {
     const materialLabel = materialRaw || (productTypeKey === 'glasspad' ? 'Glasspad' : '');
 
     const baseTitle = typeof body.title === 'string' ? body.title.trim() : '';
-    const fallbackTitleParts = [productTypeLabel];
-    if (designNameRaw) fallbackTitleParts.push(designNameRaw);
-    if (measurementLabel) fallbackTitleParts.push(measurementLabel);
-    if (materialLabel) fallbackTitleParts.push(materialLabel);
-    const fallbackTitle = `${fallbackTitleParts.join(' ')} | PERSONALIZADO`;
+    const fallbackTitle = productTypeKey === 'glasspad'
+      ? buildGlasspadTitle({ designName: designNameRaw, measurement: measurementLabel })
+      : buildDefaultTitle({
+        productTypeLabel,
+        designName: designNameRaw,
+        measurement: measurementLabel,
+        materialLabel,
+      });
     const title = (baseTitle || fallbackTitle).slice(0, 254);
 
     const priceTransfer = toNumber(body.priceTransfer ?? body.price);

--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -868,11 +868,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
     const baseCanvas = exportStageRef.current.toCanvas({ pixelRatio });
     let uploadCanvas = baseCanvas;
     if (material === "Glasspad") {
-      uploadCanvas = renderGlasspadPNG(baseCanvas, {
-        blurPx: 2,
-        whiteA: 0.28,
-        hiA: 0.14,
-      });
+      uploadCanvas = renderGlasspadPNG(baseCanvas);
     }
     const blob = await new Promise((resolve) =>
       uploadCanvas.toBlob((b) => resolve(b), "image/png", 1)

--- a/mgm-front/src/pages/DevCanvasPreview.jsx
+++ b/mgm-front/src/pages/DevCanvasPreview.jsx
@@ -102,11 +102,7 @@ export default function DevCanvasPreview() {
     baseCanvas.width = bmp.width;
     baseCanvas.height = bmp.height;
     baseCanvas.getContext('2d')?.drawImage(bmp, 0, 0);
-    const canvas = renderGlasspadPNG(baseCanvas, {
-      blurPx: 2,
-      whiteA: 0.28,
-      hiA: 0.14,
-    });
+    const canvas = renderGlasspadPNG(baseCanvas);
     canvas.toBlob(b => {
       if (b) {
         const url = URL.createObjectURL(b);


### PR DESCRIPTION
## Summary
- formatear el título de productos glasspad como `GLASSPAD "Nombre" "Medida" | PERSONALIZADO` tanto en el frontend como en la API
- aplicar el mismo formato al crear borradores directos en Shopify
- actualizar el renderizado del glasspad para usar un desenfoque leve y una sombra sutil sin aclarar la imagen

## Testing
- npm run lint *(falla: hay errores existentes no relacionados con estos cambios)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3b3b8120832782ecdf9987108f57