### PR TITLE
Update Glasspad product title formatting

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -46,26 +46,12 @@ function buildMeasurement(widthCm, heightCm) {
   return `${w}x${h}`;
 }
 
-function ensureQuoted(value) {
-  const base = typeof value === 'string' ? value.trim() : '';
-  if (!base) return '';
-  const safe = base.replace(/"/g, "'");
-  return `"${safe}"`;
-}
-
-function withCmSuffix(measurement) {
-  if (!measurement) return '';
-  const normalized = measurement.trim();
-  if (!normalized) return '';
-  return /cm$/i.test(normalized) ? normalized : `${normalized} cm`;
-}
-
 function buildGlasspadTitle({ designName, measurement }) {
-  const sections = ['GLASSPAD'];
-  const quotedName = ensureQuoted(designName);
-  if (quotedName) sections.push(quotedName);
-  const quotedMeasurement = ensureQuoted(withCmSuffix(measurement));
-  if (quotedMeasurement) sections.push(quotedMeasurement);
+  const sections = ['Glasspad'];
+  const normalizedName = typeof designName === 'string' ? designName.trim() : '';
+  if (normalizedName) sections.push(normalizedName);
+  const normalizedMeasurement = typeof measurement === 'string' ? measurement.trim() : '';
+  if (normalizedMeasurement) sections.push(normalizedMeasurement);
   return `${sections.join(' ')} | PERSONALIZADO`;
 }
 

--- a/lib/handlers/shopifyCreateProduct.ts
+++ b/lib/handlers/shopifyCreateProduct.ts
@@ -18,23 +18,10 @@ function formatMeasurement(width: unknown, height: unknown): string | undefined 
   return `${w}x${h}`;
 }
 
-function ensureQuoted(value: string | undefined): string | undefined {
-  const base = (value || '').trim();
-  if (!base) return undefined;
-  return `"${base.replace(/"/g, "'")}"`;
-}
-
-function withCmSuffix(measurement?: string): string | undefined {
-  if (!measurement) return undefined;
-  const trimmed = measurement.trim();
-  if (!trimmed) return undefined;
-  return /cm$/i.test(trimmed) ? trimmed : `${trimmed} cm`;
-}
-
 function buildGlasspadTitle(measurement?: string): string {
-  const parts = ['GLASSPAD'];
-  const quotedMeasurement = ensureQuoted(withCmSuffix(measurement));
-  if (quotedMeasurement) parts.push(quotedMeasurement);
+  const parts = ['Glasspad'];
+  const normalizedMeasurement = (measurement || '').trim();
+  if (normalizedMeasurement) parts.push(normalizedMeasurement);
   return `${parts.join(' ')} | PERSONALIZADO`;
 }
 

--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -39,25 +39,12 @@ function formatMeasurement(width?: number | null, height?: number | null): strin
   return `${w}x${h}`;
 }
 
-function ensureQuoted(value: string | undefined): string | undefined {
-  const base = (value || '').trim();
-  if (!base) return undefined;
-  return `"${base.replace(/"/g, "'")}"`;
-}
-
-function withCmSuffix(measurement?: string): string | undefined {
-  if (!measurement) return undefined;
-  const trimmed = measurement.trim();
-  if (!trimmed) return undefined;
-  return /cm$/i.test(trimmed) ? trimmed : `${trimmed} cm`;
-}
-
 function buildGlasspadTitle(designName?: string, measurement?: string): string {
-  const sections = ['GLASSPAD'];
-  const quotedName = ensureQuoted(designName);
-  if (quotedName) sections.push(quotedName);
-  const quotedMeasurement = ensureQuoted(withCmSuffix(measurement));
-  if (quotedMeasurement) sections.push(quotedMeasurement);
+  const sections = ['Glasspad'];
+  const normalizedName = (designName || '').trim();
+  if (normalizedName) sections.push(normalizedName);
+  const normalizedMeasurement = (measurement || '').trim();
+  if (normalizedMeasurement) sections.push(normalizedMeasurement);
   return `${sections.join(' ')} | PERSONALIZADO`;
 }
 


### PR DESCRIPTION
## Summary
- update the Glasspad title helper to build `Glasspad` titles without quotes or the `cm` suffix
- reuse the new formatting when publishing products and when creating products from the front-end

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3e43f56c83279864c8ff196190ee