### PR TITLE
Adjust cart return link to land on cart page

### DIFF
--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -71,6 +71,7 @@ export default async function createCartLink(req, res) {
 
     const homeUrl = buildUrl('/');
     const cartPlainUrl = buildUrl('/cart');
+    const cartPlainString = cartPlainUrl ? cartPlainUrl.toString() : '';
     const checkoutPlainUrl = buildUrl('/checkout');
 
     let mgmHome = '';
@@ -83,12 +84,17 @@ export default async function createCartLink(req, res) {
       mgmHome = normalizeAbsolute('https://www.mgmgamers.store/', base);
     }
 
+    const mgmCart = mgmHome
+      ? normalizeAbsolute(`${mgmHome.replace(/\/$/, '')}/cart`, base)
+      : '';
+
     const candidates = [
       normalizeAbsolute(process.env.SHOPIFY_CART_RETURN_TO, base),
+      mgmCart,
+      cartPlainString,
       normalizeAbsolute(process.env.SHOPIFY_HOME_URL, base),
       mgmHome,
       homeUrl ? homeUrl.toString() : '',
-      cartPlainUrl ? cartPlainUrl.toString() : '',
       (() => {
         try {
           return new URL('/', base).toString();
@@ -121,7 +127,7 @@ export default async function createCartLink(req, res) {
       url: cartAddUrl.toString(),
       cart_url: cartAddUrl.toString(),
       cart_url_follow: cartAddUrl.toString(),
-      cart_plain: cartPlainUrl ? cartPlainUrl.toString() : undefined,
+      cart_plain: cartPlainString || undefined,
       checkout_url_now: checkoutNowUrl ? checkoutNowUrl.toString() : undefined,
       checkout_plain: checkoutPlainUrl ? checkoutPlainUrl.toString() : undefined,
     });

--- a/tests/create-cart-link.test.js
+++ b/tests/create-cart-link.test.js
@@ -51,7 +51,7 @@ test('create-cart-link uses cart/add and returns mgm home when base is mgmgamers
     assert.equal(parsed.pathname, '/cart/add');
     assert.equal(parsed.searchParams.get('id'), '123456789');
     assert.equal(parsed.searchParams.get('quantity'), '2');
-    assert.equal(parsed.searchParams.get('return_to'), 'https://www.mgmgamers.store/');
+    assert.equal(parsed.searchParams.get('return_to'), 'https://www.mgmgamers.store/cart');
   } finally {
     process.env.SHOPIFY_STORE_DOMAIN = prev.STORE_DOMAIN;
     if (prev.PUBLIC_BASE === undefined) delete process.env.SHOPIFY_PUBLIC_BASE; else process.env.SHOPIFY_PUBLIC_BASE = prev.PUBLIC_BASE;


### PR DESCRIPTION
## Summary
- ensure the generated cart link redirects customers to the cart page after adding items
- prefer MGM's public domain when building the cart return URL
- update the unit test to reflect the new redirect target

## Testing
- `node --test tests/create-cart-link.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68cf3e8088b88327a99c277cd342d635