### PR TITLE
Adjust glasspad mockup blur effect

### DIFF
--- a/mgm-front/src/lib/mockup.js
+++ b/mgm-front/src/lib/mockup.js
@@ -101,12 +101,45 @@ export async function renderMockup1080(opts) {
 
   ctx.save();
   clipRoundedRect(ctx, dx, dy, drawW, drawH, 12);
-  ctx.drawImage(image, dx, dy, drawW, drawH);
 
+  let drewGlassEffect = false;
   if (opts.productType === 'glasspad') {
-    ctx.fillStyle = 'rgba(255,255,255,0.18)';
-    ctx.fillRect(dx, dy, drawW, drawH);
+    const glassCanvas = document.createElement('canvas');
+    glassCanvas.width = drawW;
+    glassCanvas.height = drawH;
+    const glassCtx = glassCanvas.getContext('2d');
+
+    if (glassCtx) {
+      const longestSide = Math.max(drawW, drawH);
+      const blurPx = Math.max(4, Math.round(Math.min(longestSide * 0.035, 26)));
+
+      glassCtx.filter = `blur(${blurPx}px)`;
+      glassCtx.globalAlpha = 0.9;
+      glassCtx.drawImage(image, 0, 0, drawW, drawH);
+      glassCtx.filter = 'none';
+
+      glassCtx.globalAlpha = 0.45;
+      glassCtx.drawImage(image, 0, 0, drawW, drawH);
+      glassCtx.globalAlpha = 1;
+
+      const highlight = glassCtx.createLinearGradient(0, 0, drawW, drawH);
+      highlight.addColorStop(0, 'rgba(255,255,255,0.04)');
+      highlight.addColorStop(0.5, 'rgba(255,255,255,0.015)');
+      highlight.addColorStop(1, 'rgba(0,0,0,0.04)');
+      glassCtx.fillStyle = highlight;
+      glassCtx.fillRect(0, 0, drawW, drawH);
+
+      ctx.globalAlpha = 0.95;
+      ctx.drawImage(glassCanvas, dx, dy, drawW, drawH);
+      ctx.globalAlpha = 1;
+      drewGlassEffect = true;
+    }
   }
+
+  if (!drewGlassEffect) {
+    ctx.drawImage(image, dx, dy, drawW, drawH);
+  }
+
   ctx.restore();
 
   const blob = await new Promise((res) => canvas.toBlob(res, 'image/png', 1));

--- a/mgm-front/src/lib/mockup.ts
+++ b/mgm-front/src/lib/mockup.ts
@@ -130,12 +130,45 @@ export async function renderMockup1080(opts: MockupOptions): Promise<Blob> {
 
   ctx.save();
   clipRoundedRect(ctx, dx, dy, drawW, drawH, 12);
-  ctx.drawImage(image, dx, dy, drawW, drawH);
 
+  let drewGlassEffect = false;
   if (opts.productType === 'glasspad') {
-    ctx.fillStyle = 'rgba(255,255,255,0.18)';
-    ctx.fillRect(dx, dy, drawW, drawH);
+    const glassCanvas = document.createElement('canvas');
+    glassCanvas.width = drawW;
+    glassCanvas.height = drawH;
+    const glassCtx = glassCanvas.getContext('2d');
+
+    if (glassCtx) {
+      const longestSide = Math.max(drawW, drawH);
+      const blurPx = Math.max(4, Math.round(Math.min(longestSide * 0.035, 26)));
+
+      glassCtx.filter = `blur(${blurPx}px)`;
+      glassCtx.globalAlpha = 0.9;
+      glassCtx.drawImage(image, 0, 0, drawW, drawH);
+      glassCtx.filter = 'none';
+
+      glassCtx.globalAlpha = 0.45;
+      glassCtx.drawImage(image, 0, 0, drawW, drawH);
+      glassCtx.globalAlpha = 1;
+
+      const highlight = glassCtx.createLinearGradient(0, 0, drawW, drawH);
+      highlight.addColorStop(0, 'rgba(255,255,255,0.04)');
+      highlight.addColorStop(0.5, 'rgba(255,255,255,0.015)');
+      highlight.addColorStop(1, 'rgba(0,0,0,0.04)');
+      glassCtx.fillStyle = highlight;
+      glassCtx.fillRect(0, 0, drawW, drawH);
+
+      ctx.globalAlpha = 0.95;
+      ctx.drawImage(glassCanvas, dx, dy, drawW, drawH);
+      ctx.globalAlpha = 1;
+      drewGlassEffect = true;
+    }
   }
+
+  if (!drewGlassEffect) {
+    ctx.drawImage(image, dx, dy, drawW, drawH);
+  }
+
   ctx.restore();
 
   return toBlob();


### PR DESCRIPTION
## Summary
- render the glasspad mockup through a dedicated blurred offscreen canvas to strengthen the frosted effect without over-brightening
- keep the original artwork rendering as a fallback whenever the glass effect cannot be produced

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cf42a1e1788327bb81abf0b95e1ded