### PR TITLE
Adjust glasspad blur effect

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -74,6 +74,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
   const stageRef = useRef(null);
   const exportStageRef = useRef(null);
   const padGroupRef = useRef(null);
+  const glassOverlayRef = useRef(null);
   const [wrapSize, setWrapSize] = useState({ w: 960, h: 540 });
   const hasAdjustedViewRef = useRef(false);
   useEffect(() => {
@@ -366,6 +367,37 @@ const EditorCanvas = forwardRef(function EditorCanvas(
   // medidas visuales (para offset centro)
   const dispW = imgBaseCm ? imgBaseCm.w * imgTx.scaleX : 0;
   const dispH = imgBaseCm ? imgBaseCm.h * imgTx.scaleY : 0;
+  const hasGlassOverlay =
+    material === "Glasspad" &&
+    !!imgEl &&
+    !!imgBaseCm &&
+    dispW > 0 &&
+    dispH > 0;
+
+  useEffect(() => {
+    const node = glassOverlayRef.current;
+    if (!node) return;
+    if (!hasGlassOverlay) {
+      node.clearCache();
+      node.filters([]);
+      node.getLayer()?.batchDraw();
+      return;
+    }
+    const pixelRatio = Math.max(1, 2 * baseScale * viewScale);
+    node.cache({ pixelRatio });
+    node.filters([Konva.Filters.Blur]);
+    node.blurRadius(4);
+    node.getLayer()?.batchDraw();
+  }, [
+    hasGlassOverlay,
+    baseScale,
+    viewScale,
+    imgTx.x_cm,
+    imgTx.y_cm,
+    imgTx.rotation_deg,
+    imgTx.scaleX,
+    imgTx.scaleY,
+  ]);
 
   const theta = (imgTx.rotation_deg * Math.PI) / 180;
   const rotAABBHalf = (w, h, ang) => ({
@@ -1329,10 +1361,11 @@ const EditorCanvas = forwardRef(function EditorCanvas(
 
             {/* máscara fuera del área */}
           </Layer>
-          {material === "Glasspad" && (
+          {hasGlassOverlay && (
             <Layer id="glasspadOverlayLayer" listening={false}>
               <Group
                 id="glassOverlayGroup"
+                ref={glassOverlayRef}
                 x={bleedCm}
                 y={bleedCm}
                 width={wCm}
@@ -1340,32 +1373,17 @@ const EditorCanvas = forwardRef(function EditorCanvas(
                 clipFunc={(ctx) => {
                   ctx.rect(0, 0, wCm, hCm);
                 }}
-                ref={(node) => {
-                  if (!node) return;
-                  const k = baseScale * viewScale;
-                  node.cache({ pixelRatio: 2 * k });
-                  node.filters([Konva.Filters.Blur]);
-                  node.blurRadius(2);
-                }}
               >
-                <Rect width={wCm} height={hCm} fill="rgba(255,255,255,0.28)" />
-                <Rect
-                  width={wCm}
-                  height={hCm}
-                  fillLinearGradientStartPoint={{ x: 0, y: 0 }}
-                  fillLinearGradientEndPoint={{ x: wCm, y: hCm }}
-                  fillLinearGradientColorStops={[
-                    0, 'rgba(255,255,255,0.16)',
-                    0.45, 'rgba(255,255,255,0.06)',
-                    1, 'rgba(255,255,255,0)',
-                  ]}
-                  globalCompositeOperation="lighter"
-                />
-                <Rect
-                  width={wCm}
-                  height={hCm}
-                  stroke="rgba(255,255,255,0.22)"
-                  strokeWidth={1}
+                <KonvaImage
+                  image={imgEl}
+                  x={imgTx.x_cm - bleedCm + dispW / 2}
+                  y={imgTx.y_cm - bleedCm + dispH / 2}
+                  width={dispW}
+                  height={dispH}
+                  offsetX={dispW / 2}
+                  offsetY={dispH / 2}
+                  rotation={imgTx.rotation_deg}
+                  listening={false}
                 />
               </Group>
             </Layer>

--- a/mgm-front/src/lib/mockup.js
+++ b/mgm-front/src/lib/mockup.js
@@ -111,27 +111,13 @@ export async function renderMockup1080(opts) {
 
     if (glassCtx) {
       const longestSide = Math.max(drawW, drawH);
-      const blurPx = Math.max(4, Math.round(Math.min(longestSide * 0.035, 26)));
+      const blurPx = Math.max(5, Math.round(Math.min(longestSide * 0.045, 30)));
 
       glassCtx.filter = `blur(${blurPx}px)`;
-      glassCtx.globalAlpha = 0.9;
       glassCtx.drawImage(image, 0, 0, drawW, drawH);
       glassCtx.filter = 'none';
 
-      glassCtx.globalAlpha = 0.45;
-      glassCtx.drawImage(image, 0, 0, drawW, drawH);
-      glassCtx.globalAlpha = 1;
-
-      const highlight = glassCtx.createLinearGradient(0, 0, drawW, drawH);
-      highlight.addColorStop(0, 'rgba(255,255,255,0.04)');
-      highlight.addColorStop(0.5, 'rgba(255,255,255,0.015)');
-      highlight.addColorStop(1, 'rgba(0,0,0,0.04)');
-      glassCtx.fillStyle = highlight;
-      glassCtx.fillRect(0, 0, drawW, drawH);
-
-      ctx.globalAlpha = 0.95;
       ctx.drawImage(glassCanvas, dx, dy, drawW, drawH);
-      ctx.globalAlpha = 1;
       drewGlassEffect = true;
     }
   }

--- a/mgm-front/src/lib/mockup.ts
+++ b/mgm-front/src/lib/mockup.ts
@@ -140,27 +140,13 @@ export async function renderMockup1080(opts: MockupOptions): Promise<Blob> {
 
     if (glassCtx) {
       const longestSide = Math.max(drawW, drawH);
-      const blurPx = Math.max(4, Math.round(Math.min(longestSide * 0.035, 26)));
+      const blurPx = Math.max(5, Math.round(Math.min(longestSide * 0.045, 30)));
 
       glassCtx.filter = `blur(${blurPx}px)`;
-      glassCtx.globalAlpha = 0.9;
       glassCtx.drawImage(image, 0, 0, drawW, drawH);
       glassCtx.filter = 'none';
 
-      glassCtx.globalAlpha = 0.45;
-      glassCtx.drawImage(image, 0, 0, drawW, drawH);
-      glassCtx.globalAlpha = 1;
-
-      const highlight = glassCtx.createLinearGradient(0, 0, drawW, drawH);
-      highlight.addColorStop(0, 'rgba(255,255,255,0.04)');
-      highlight.addColorStop(0.5, 'rgba(255,255,255,0.015)');
-      highlight.addColorStop(1, 'rgba(0,0,0,0.04)');
-      glassCtx.fillStyle = highlight;
-      glassCtx.fillRect(0, 0, drawW, drawH);
-
-      ctx.globalAlpha = 0.95;
       ctx.drawImage(glassCanvas, dx, dy, drawW, drawH);
-      ctx.globalAlpha = 1;
       drewGlassEffect = true;
     }
   }


### PR DESCRIPTION
## Summary
- replace the glasspad overlay with a blurred copy of the artwork so the preview loses the bright wash and increases the blur radius
- align the mockup generators to remove highlight overlays and boost the blur strength for glasspad outputs

## Testing
- `npm run lint` *(fails: existing lint errors unrelated to the glasspad changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b4fbb8ec8327a4c106be6147421a