### PR TITLE
Improve client image moderation heuristics

### DIFF
--- a/lib/moderation/hate.js
+++ b/lib/moderation/hate.js
@@ -37,6 +37,16 @@ const RAW_TERMS = [
   'reichsadler',
   'schutzstaffel',
   'hitlerjugend',
+  '1488',
+  '14/88',
+  'fourteen words',
+  '14 words',
+  'stormfront',
+  'blood and soil',
+  'blut und boden',
+  'white pride worldwide',
+  'wpww',
+  'aryan brotherhood',
 ];
 
 function norm(input = '') {

--- a/mgm-front/src/lib/moderation.ts
+++ b/mgm-front/src/lib/moderation.ts
@@ -45,6 +45,16 @@ const HATE_TERMS = [
   'reichsadler',
   'schutzstaffel',
   'hitlerjugend',
+  '1488',
+  '14/88',
+  'fourteen words',
+  '14 words',
+  'stormfront',
+  'blood and soil',
+  'blut und boden',
+  'white pride worldwide',
+  'wpww',
+  'aryan brotherhood',
 ];
 
 function normalizeHateCheck(input: string | null | undefined) {

--- a/mgm-front/src/lib/moderation/nsfw.client.js
+++ b/mgm-front/src/lib/moderation/nsfw.client.js
@@ -1,25 +1,76 @@
+// Keep a single lazy-loaded model instance in-memory across scans so repeated
+// "Continuar" clicks don't keep downloading TFJS weights.
+let modelPromise = null;
+
+async function loadModel() {
+  if (!modelPromise) {
+    modelPromise = (async () => {
+      await import('@tensorflow/tfjs');
+      const nsfwjs = await import('nsfwjs');
+      return nsfwjs.load();
+    })().catch(err => {
+      modelPromise = null;
+      throw err;
+    });
+  }
+  return modelPromise;
+}
+
+function extractScores(predictions = []) {
+  const scores = {
+    hentai: 0,
+    porn: 0,
+    sexy: 0,
+    drawing: 0,
+    neutral: 0,
+  };
+  for (const pred of predictions) {
+    const key = pred?.className?.toLowerCase();
+    if (!key || !(key in scores)) continue;
+    scores[key] = Math.max(scores[key], Number(pred?.probability) || 0);
+  }
+  return scores;
+}
+
 // Client-only nudity scan using dynamic imports to avoid bundling on server.
 export async function scanNudityClient(dataUrl) {
+  if (!dataUrl) {
+    return { blocked: false, reason: 'no_image' };
+  }
   try {
-    const nsfwjs = await import('nsfwjs');
-    await import('@tensorflow/tfjs');
-
+    const model = await loadModel();
     const img = new Image();
     img.src = dataUrl;
     await img.decode();
 
-    const model = await nsfwjs.load();
-    const preds = await model.classify(img);
-    preds.sort((a,b) => b.probability - a.probability);
-    const top = preds[0] || { className: '', probability: 0 };
-    const hentai = preds.find(p => p.className === 'Hentai')?.probability || 0;
-    if (top.className === 'Porn' && top.probability >= 0.85 && hentai < 0.60) {
-      return { blocked: true, reason: 'client_real_nudity' };
+    const predictions = await model.classify(img);
+    const scores = extractScores(predictions);
+
+    const PORN_THRESHOLD = 0.72;
+    const HENTAI_ALLOW_THRESHOLD = 0.6;
+    const DRAWING_ALLOW_THRESHOLD = 0.55;
+    const SEXY_ESCALATION_THRESHOLD = 0.9;
+    const REAL_OVERRIDE_THRESHOLD = 0.55;
+
+    const isAnimeDominant =
+      scores.hentai >= HENTAI_ALLOW_THRESHOLD ||
+      scores.drawing >= DRAWING_ALLOW_THRESHOLD;
+
+    if (isAnimeDominant && scores.porn < REAL_OVERRIDE_THRESHOLD) {
+      return { blocked: false, reason: 'client_hentai_allowed', scores };
     }
-    if (hentai >= 0.60) {
-      return { blocked: false, reason: 'client_hentai_allowed' };
+
+    const realPornLike = scores.porn >= PORN_THRESHOLD && scores.hentai < 0.55 && scores.drawing < 0.6;
+    if (realPornLike) {
+      return { blocked: true, reason: 'client_real_nudity', scores };
     }
-    return { blocked: false };
+
+    const explicitSexy = scores.sexy >= SEXY_ESCALATION_THRESHOLD && scores.porn >= REAL_OVERRIDE_THRESHOLD && scores.hentai < 0.4;
+    if (explicitSexy) {
+      return { blocked: true, reason: 'client_real_sexual', scores };
+    }
+
+    return { blocked: false, reason: 'client_clear', scores };
   } catch (e) {
     // On failure to load ML libs in browser, default to allow (server will gate as needed)
     console.warn('[scanNudityClient] failed', e?.message || e);

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -167,12 +167,21 @@ export default function Home() {
       // client-side gate: NSFW scan in browser (no server TFJS)
       try {
         const res = await scanNudityClient(master);
+        console.info('[continue] client nudity scan', res);
         if (res?.blocked) {
-          setErr('Contenido adulto detectado.');
+          let message = 'Contenido adulto detectado.';
+          if (res.reason === 'client_real_nudity') {
+            message = 'Contenido adulto explícito con personas reales detectado.';
+          } else if (res.reason === 'client_real_sexual') {
+            message = 'Contenido sexual explícito con personas reales detectado.';
+          }
+          setErr(message);
           setBusy(false);
           return;
         }
-      } catch { /* best-effort */ }
+      } catch (scanErr) {
+        console.warn('[continue] nudity scan failed', scanErr?.message || scanErr);
+      }
 
       const moderationUrl = `${import.meta.env.VITE_API_URL || ''}/api/moderate-image`;
       console.info('[continue] POST', moderationUrl);


### PR DESCRIPTION
## Summary
- cache the client-side nsfwjs model and use nuanced thresholds to only block explicit real-human nudity while permitting anime content
- surface richer client moderation reasons in Home so blocked uploads explain the policy clearly
- expand hate-speech keyword lists on both client and server to catch additional extremist phrases

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b6874074832790a401b71783c016