### PR TITLE
Reduce glasspad blur intensity

### DIFF
--- a/mgm-front/src/lib/mockup.js
+++ b/mgm-front/src/lib/mockup.js
@@ -111,7 +111,7 @@ export async function renderMockup1080(opts) {
 
     if (glassCtx) {
       const longestSide = Math.max(drawW, drawH);
-      const blurPx = Math.max(5, Math.round(Math.min(longestSide * 0.045, 30)));
+      const blurPx = Math.max(1, Math.round(Math.min(longestSide * 0.006, 4)));
 
       glassCtx.filter = `blur(${blurPx}px)`;
       glassCtx.drawImage(image, 0, 0, drawW, drawH);

--- a/mgm-front/src/lib/mockup.ts
+++ b/mgm-front/src/lib/mockup.ts
@@ -140,7 +140,7 @@ export async function renderMockup1080(opts: MockupOptions): Promise<Blob> {
 
     if (glassCtx) {
       const longestSide = Math.max(drawW, drawH);
-      const blurPx = Math.max(5, Math.round(Math.min(longestSide * 0.045, 30)));
+      const blurPx = Math.max(1, Math.round(Math.min(longestSide * 0.006, 4)));
 
       glassCtx.filter = `blur(${blurPx}px)`;
       glassCtx.drawImage(image, 0, 0, drawW, drawH);


### PR DESCRIPTION
## Summary
- decrease the glasspad mockup blur so artwork stays visible while still giving a subtle glass effect

## Testing
- npm run lint *(fails: existing eslint errors such as unused variables in ColorPopover.jsx, jobPayload.js, DevRenderPreview.jsx, Mockup.jsx, Result.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b93ff6948327a709e0eae48a4876