### PR TITLE
Fix cart return flow for mgmgamers storefront

### DIFF
--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -90,11 +90,11 @@ export default async function createCartLink(req, res) {
 
     const candidates = [
       normalizeAbsolute(process.env.SHOPIFY_CART_RETURN_TO, base),
-      mgmCart,
-      cartPlainString,
       normalizeAbsolute(process.env.SHOPIFY_HOME_URL, base),
       mgmHome,
       homeUrl ? homeUrl.toString() : '',
+      mgmCart,
+      cartPlainString,
       (() => {
         try {
           return new URL('/', base).toString();
@@ -104,9 +104,9 @@ export default async function createCartLink(req, res) {
       })(),
       '/',
     ];
-    const returnToCart = candidates.find((value) => sanitizeReturnTarget(value)) || '/';
-    if (returnToCart) {
-      cartAddUrl.searchParams.set('return_to', returnToCart);
+    const returnTarget = candidates.find((value) => sanitizeReturnTarget(value)) || '/';
+    if (returnTarget) {
+      cartAddUrl.searchParams.set('return_to', returnTarget);
     }
 
     const checkoutNowUrl = buildUrl(`/cart/${normalizedVariantId}:${qty}`);

--- a/mgm-front/src/lib/cart.ts
+++ b/mgm-front/src/lib/cart.ts
@@ -30,9 +30,9 @@ function submitCartForm(url: URL, target: string) {
     form.appendChild(buildHiddenInput(key, value));
   });
 
-  // Ensure return_to defaults to cart when missing
+  // Ensure return_to defaults to home when missing
   if (!params.has('return_to')) {
-    form.appendChild(buildHiddenInput('return_to', '/cart'));
+    form.appendChild(buildHiddenInput('return_to', '/'));
   }
 
   let targetName = target;

--- a/tests/create-cart-link.test.js
+++ b/tests/create-cart-link.test.js
@@ -51,7 +51,7 @@ test('create-cart-link uses cart/add and returns mgm home when base is mgmgamers
     assert.equal(parsed.pathname, '/cart/add');
     assert.equal(parsed.searchParams.get('id'), '123456789');
     assert.equal(parsed.searchParams.get('quantity'), '2');
-    assert.equal(parsed.searchParams.get('return_to'), 'https://www.mgmgamers.store/cart');
+    assert.equal(parsed.searchParams.get('return_to'), 'https://www.mgmgamers.store/');
   } finally {
     process.env.SHOPIFY_STORE_DOMAIN = prev.STORE_DOMAIN;
     if (prev.PUBLIC_BASE === undefined) delete process.env.SHOPIFY_PUBLIC_BASE; else process.env.SHOPIFY_PUBLIC_BASE = prev.PUBLIC_BASE;


### PR DESCRIPTION
## Summary
- prioritize the mgmgamers storefront home URL when generating Shopify cart links so add-to-cart redirects land on the homepage
- keep the front-end cart helper aligned by defaulting missing return_to values to the home path
- update the create-cart-link unit test to reflect the new homepage redirect expectation

## Testing
- node --test tests/create-cart-link.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d0ba114bb4832785f137296b84e9e0