### PR TITLE
Reduce glasspad blur intensity

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -386,7 +386,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
     const pixelRatio = Math.max(1, 2 * baseScale * viewScale);
     node.cache({ pixelRatio });
     node.filters([Konva.Filters.Blur]);
-    node.blurRadius(4);
+    node.blurRadius(1);
     node.getLayer()?.batchDraw();
   }, [
     hasGlassOverlay,

--- a/mgm-front/src/lib/mockup.js
+++ b/mgm-front/src/lib/mockup.js
@@ -110,8 +110,7 @@ export async function renderMockup1080(opts) {
     const glassCtx = glassCanvas.getContext('2d');
 
     if (glassCtx) {
-      const longestSide = Math.max(drawW, drawH);
-      const blurPx = Math.max(1, Math.round(Math.min(longestSide * 0.006, 4)));
+      const blurPx = 1;
 
       glassCtx.filter = `blur(${blurPx}px)`;
       glassCtx.drawImage(image, 0, 0, drawW, drawH);

--- a/mgm-front/src/lib/mockup.ts
+++ b/mgm-front/src/lib/mockup.ts
@@ -139,8 +139,7 @@ export async function renderMockup1080(opts: MockupOptions): Promise<Blob> {
     const glassCtx = glassCanvas.getContext('2d');
 
     if (glassCtx) {
-      const longestSide = Math.max(drawW, drawH);
-      const blurPx = Math.max(1, Math.round(Math.min(longestSide * 0.006, 4)));
+      const blurPx = 1;
 
       glassCtx.filter = `blur(${blurPx}px)`;
       glassCtx.drawImage(image, 0, 0, drawW, drawH);

--- a/mgm-front/src/lib/renderGlasspadPNG.ts
+++ b/mgm-front/src/lib/renderGlasspadPNG.ts
@@ -13,7 +13,7 @@ export function renderGlasspadPNG(
 ): HTMLCanvasElement {
   const baseSize = Math.max(baseCanvas.width, baseCanvas.height);
   const {
-    blurPx = Math.max(1, Math.round(Math.min(baseSize * 0.0015, 12))),
+    blurPx = 1,
     shadowOffsetPx,
     shadowBlurPx,
     shadowAlpha = 0.18,


### PR DESCRIPTION
## Summary
- reduce the Konva blur radius on the glass overlay preview to keep the effect subtle
- lower the default blur amount applied when rendering glasspad PNGs and mockups so the filter is minimal

## Testing
- npm run lint *(fails: existing unused variable errors in unrelated files and missing react/no-danger rule)*

------
https://chatgpt.com/codex/tasks/task_e_68d0be5622f8832799c98c23cbf3967b