### PR TITLE
Simplify server moderation heuristics

### DIFF
--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -531,39 +531,11 @@ function computeNudityConfidence({
   return clamp(combined);
 }
 
-const SEVERITY_RANK = { ALLOW: 0, REVIEW: 1, BLOCK: 2 };
 
 export async function evaluateImage(buffer, filename, designName = '', options = {}) {
-  const lowQualityAck = Boolean(options?.lowQualityAck);
-  const approxDpiRaw = Number(options?.approxDpi);
-  const approxDpi = Number.isFinite(approxDpiRaw) ? approxDpiRaw : null;
-  const debug = { metadata: null, skin: null, illustration: null, nazi: null, textHints: 0, scores: {}, flags: { lowQualityAck, approxDpi } };
-  let label = 'ALLOW';
-  let reasons = [];
-  let blockConfidence = 0;
-  let reviewConfidence = 0;
-
-  const applyOutcome = (newLabel, newReasons = [], newConfidence = 0) => {
-    const currentRank = SEVERITY_RANK[label];
-    const newRank = SEVERITY_RANK[newLabel];
-    if (newRank === undefined) return;
-
-    if (newRank === SEVERITY_RANK.BLOCK) blockConfidence = Math.max(blockConfidence, newConfidence);
-    if (newRank === SEVERITY_RANK.REVIEW) reviewConfidence = Math.max(reviewConfidence, newConfidence);
-
-    const filteredReasons = newReasons.filter(Boolean);
-    if (newRank > currentRank) {
-      label = newLabel;
-      reasons = filteredReasons.length ? [...filteredReasons] : [];
-    } else if (newRank === currentRank && filteredReasons.length) {
-      for (const reason of filteredReasons) {
-        if (!reasons.includes(reason)) reasons.push(reason);
-      }
-    }
-  };
-
-  // Preload metadata for downstream heuristics and normalize buffer
+  const debug = { metadata: null, skin: null, illustration: null, nazi: null, textHints: 0, scores: {} };
   let workingBuffer = buffer;
+
   try {
     const prepared = await prepareModerationImage(buffer);
     workingBuffer = prepared.buffer;
@@ -578,292 +550,122 @@ export async function evaluateImage(buffer, filename, designName = '', options =
     debug.metadata = { error: err?.message };
   }
 
+  const blockReasons = new Set();
+  let blockConfidence = 0;
+
+  const markBlocked = (reason, confidence = 0.6) => {
+    if (!reason) return;
+    blockReasons.add(reason);
+    blockConfidence = Math.max(blockConfidence, clamp(confidence));
+  };
+
   const metaGate = hateTextCheck({ filename, designName, textHints: '' });
-  debug.scores.metaText = metaGate.blocked ? 0.85 : 0;
   if (metaGate.blocked) {
-    applyOutcome('BLOCK', ['extremism_nazi_text'], 0.85);
+    markBlocked('extremism_nazi_text', 0.85);
   }
 
-  // Pre-compute illustration confidence before applying nudity heuristics so we can relax
-  // false positives on stylized or padded images (e.g. Valorant renders or solid color fills).
   const illustration = await detectIllustration(workingBuffer);
   debug.illustration = illustration;
-  const cartoonConfidence = illustration?.cartoonConfidence || 0;
-  debug.scores.illustration = cartoonConfidence;
 
-  // A) skin-based real nudity heuristic with illustration-based relaxations
   const skin = await detectSkin(workingBuffer);
   debug.skin = skin;
-  let nudityConfidence = computeNudityConfidence(skin);
 
-  const CARTOON_STRONG_THRESHOLD = 0.78;
-  const CARTOON_RELAX_THRESHOLD = 0.58;
-  const CARTOON_RELAX_MAX_PALETTE_RATIO = 0.05;
-  const CARTOON_RELAX_MIN_EDGE_RATIO = 0.014;
-  const CARTOON_RELAX_MAX_TONE_VARIANCE = 0.18;
-  const CARTOON_RELAX_MAX_CENTER_SKIN = 0.48;
-  const CARTOON_RELAX_MAX_SKIN_PERCENT = 0.44;
-  const CARTOON_RELAX_MAX_BLOB = 0.38;
-  const CARTOON_RELAX_MAX_BLOB_CENTER_RATIO = 0.74;
-  const CARTOON_REVIEW_RELAX_MAX_PALETTE_RATIO = 0.065;
-  const CARTOON_REVIEW_RELAX_MIN_EDGE_RATIO = 0.012;
-  const CARTOON_REVIEW_RELAX_MAX_TONE_VARIANCE = 0.22;
-  const CARTOON_REVIEW_RELAX_MAX_CENTER_SKIN = 0.52;
-  const CARTOON_REVIEW_RELAX_MAX_SKIN_PERCENT = 0.48;
-  const CARTOON_REVIEW_RELAX_MAX_BLOB = 0.45;
-  const CARTOON_REVIEW_RELAX_MAX_BLOB_CENTER_RATIO = 0.8;
-  const REAL_NUDITY_BLOCK_THRESHOLD = 0.55;
-  const REAL_NUDITY_REVIEW_THRESHOLD = 0.45;
-  const REAL_NUDITY_MIN_COVERAGE_FOR_REVIEW = 0.28;
-  const REAL_NUDITY_MIN_BLOB_FOR_REVIEW = 0.16;
-  const REAL_NUDITY_MIN_CENTER_FOR_REVIEW = 0.22;
-  const REAL_NUDITY_MIN_COVERAGE_FOR_BLOCK = 0.38;
-  const REAL_NUDITY_MIN_BLOB_FOR_BLOCK = 0.26;
-  const REAL_NUDITY_MIN_CENTER_FOR_BLOCK = 0.34;
+  const nudityConfidence = computeNudityConfidence(skin);
+  debug.scores.realNudity = nudityConfidence;
 
   const skinPercent = skin?.skinPercent ?? 0;
+  const centerSkinPercent = skin?.centerSkinPercent ?? 0;
   const largestBlob = skin?.largestBlob ?? 0;
   const secondLargestBlob = skin?.secondLargestBlob ?? 0;
-  const centerSkinPercent = skin?.centerSkinPercent ?? 0;
   const largestBlobBoxCoverage = skin?.largestBlobBoxCoverage ?? 0;
   const largestBlobCenterRatio = skin?.largestBlobCenterRatio ?? 0;
   const toneVariance = skin?.toneVariance ?? 0;
   const paletteRatio = illustration?.paletteRatio ?? 0;
   const edgeRatio = illustration?.edgeRatio ?? 0;
+  const cartoonConfidence = illustration?.cartoonConfidence ?? 0;
 
-  // Penalize extremely uniform, low-texture scenes that mimic skin tones (e.g. wallpapers)
-  // so they do not trigger the "real nudity" gate.
-  const TONE_FLAT_MAX = 0.01;
-  const EDGE_SOFT_MAX = 0.022;
-  const PALETTE_SOFT_MAX = 0.0035;
-  let flatSceneReduction = 0;
-  if (
-    toneVariance <= TONE_FLAT_MAX &&
-    edgeRatio <= EDGE_SOFT_MAX &&
-    paletteRatio <= PALETTE_SOFT_MAX &&
-    skinPercent >= 0.32 &&
-    largestBlob >= 0.32 &&
-    centerSkinPercent >= 0.55
-  ) {
-    // `largestBlobCenterRatio` closer to ~0.65 is typical for real people framed in the center.
-    // Extreme deviations combined with flat tones usually correspond to solid backgrounds.
-    const centerBias = clamp((Math.abs(largestBlobCenterRatio - 0.65) - 0.08) / 0.22);
-    if (centerBias > 0) {
-      const coverageIntensity = clamp((skinPercent - 0.32) / 0.68);
-      const edgeLack = clamp((EDGE_SOFT_MAX - edgeRatio) / EDGE_SOFT_MAX);
-      const toneFlatness = clamp((TONE_FLAT_MAX - toneVariance) / TONE_FLAT_MAX);
-      const uniformity =
-        Math.max(edgeLack, toneFlatness) * 0.65 +
-        coverageIntensity * 0.2 +
-        centerBias * 0.15;
-      flatSceneReduction = clamp(0.3 + uniformity * 0.6, 0.3, 0.9);
-    }
-  }
-  const meetsReviewCoverage =
-    skinPercent >= REAL_NUDITY_MIN_COVERAGE_FOR_REVIEW ||
-    largestBlob >= REAL_NUDITY_MIN_BLOB_FOR_REVIEW ||
-    centerSkinPercent >= REAL_NUDITY_MIN_CENTER_FOR_REVIEW;
-  const meetsBlockCoverage =
-    skinPercent >= REAL_NUDITY_MIN_COVERAGE_FOR_BLOCK ||
-    largestBlob >= REAL_NUDITY_MIN_BLOB_FOR_BLOCK ||
-    centerSkinPercent >= REAL_NUDITY_MIN_CENTER_FOR_BLOCK ||
-    largestBlobBoxCoverage >= 0.32;
+  debug.scores.skinPercent = skinPercent;
+  debug.scores.centerSkinPercent = centerSkinPercent;
+  debug.scores.largestBlob = largestBlob;
+  debug.scores.paletteRatio = paletteRatio;
+  debug.scores.edgeRatio = edgeRatio;
+  debug.scores.cartoonConfidence = cartoonConfidence;
 
-  const centerBoost = clamp((centerSkinPercent - 0.26) / 0.28);
-  const blobBoost = clamp((largestBlob - 0.24) / 0.22);
-  const boxBoost = clamp((largestBlobBoxCoverage - 0.3) / 0.26);
-  const secondaryBoost = clamp(((largestBlob + secondLargestBlob) - 0.45) / 0.4);
-  const combinedBoost = Math.max(centerBoost * 0.5 + blobBoost * 0.5, boxBoost, secondaryBoost);
-  nudityConfidence = Math.max(nudityConfidence, combinedBoost);
-  if (flatSceneReduction > 0) {
-    nudityConfidence *= 1 - flatSceneReduction;
-    debug.scores.realNudityPenalty = flatSceneReduction;
+  const meetsCoverage = (
+    skinPercent >= 0.35 &&
+    centerSkinPercent >= 0.28 &&
+    largestBlob >= 0.24
+  );
+
+  const strongCenter = centerSkinPercent >= 0.55;
+  const strongBlob = largestBlob >= 0.42 || largestBlobBoxCoverage >= 0.38;
+  const highSkinCoverage = skinPercent >= 0.5;
+  const notCartoon =
+    cartoonConfidence < 0.65 ||
+    paletteRatio >= 0.015 ||
+    edgeRatio <= 0.03 ||
+    toneVariance <= 0.18;
+
+  debug.scores.notCartoon = notCartoon ? 1 : 0;
+
+  const shouldBlockStrong = strongCenter && strongBlob && highSkinCoverage && notCartoon;
+  const shouldBlockByConfidence =
+    !shouldBlockStrong &&
+    nudityConfidence >= 0.72 &&
+    meetsCoverage &&
+    notCartoon &&
+    centerSkinPercent >= 0.4 &&
+    largestBlob >= 0.35;
+
+  if (shouldBlockStrong || shouldBlockByConfidence) {
+    const baseConfidence = shouldBlockStrong ? 0.78 : 0.7;
+    const confidence = clamp(baseConfidence + (nudityConfidence - 0.7) * 0.5);
+    markBlocked('real_nudity', confidence);
   }
 
-  const stylizedSofteningEligible =
-    cartoonConfidence >= 0.56 &&
-    paletteRatio <= 0.07 &&
-    edgeRatio >= 0.01 &&
-    skinPercent <= 0.46 &&
-    largestBlob <= 0.4 &&
-    centerSkinPercent <= 0.52 &&
-    largestBlobCenterRatio <= 0.78;
-  if (stylizedSofteningEligible) {
-    const stylizedBoost =
-      clamp((cartoonConfidence - 0.56) / 0.24) * 0.4 +
-      clamp((0.46 - skinPercent) / 0.32) * 0.35 +
-      clamp((0.52 - centerSkinPercent) / 0.26) * 0.25;
-    if (stylizedBoost > 0) {
-      const reduction = clamp(0.1 + stylizedBoost * 0.32, 0.1, 0.36);
-      nudityConfidence = clamp(nudityConfidence - reduction);
-      debug.scores.realNudityStylizedRelax = reduction;
-    }
-  }
-
-  debug.scores.realNudity = nudityConfidence;
-
-  const canRelaxForCartoonBlock =
-    cartoonConfidence >= CARTOON_RELAX_THRESHOLD &&
-    paletteRatio <= CARTOON_RELAX_MAX_PALETTE_RATIO &&
-    edgeRatio >= CARTOON_RELAX_MIN_EDGE_RATIO &&
-    toneVariance <= CARTOON_RELAX_MAX_TONE_VARIANCE &&
-    centerSkinPercent <= CARTOON_RELAX_MAX_CENTER_SKIN &&
-    skinPercent <= CARTOON_RELAX_MAX_SKIN_PERCENT &&
-    largestBlob <= CARTOON_RELAX_MAX_BLOB &&
-    largestBlobCenterRatio <= CARTOON_RELAX_MAX_BLOB_CENTER_RATIO;
-
-  const canRelaxForCartoonReview =
-    cartoonConfidence >= CARTOON_RELAX_THRESHOLD &&
-    paletteRatio <= CARTOON_REVIEW_RELAX_MAX_PALETTE_RATIO &&
-    edgeRatio >= CARTOON_REVIEW_RELAX_MIN_EDGE_RATIO &&
-    toneVariance <= CARTOON_REVIEW_RELAX_MAX_TONE_VARIANCE &&
-    centerSkinPercent <= CARTOON_REVIEW_RELAX_MAX_CENTER_SKIN &&
-    skinPercent <= CARTOON_REVIEW_RELAX_MAX_SKIN_PERCENT &&
-    largestBlob <= CARTOON_REVIEW_RELAX_MAX_BLOB &&
-    largestBlobCenterRatio <= CARTOON_REVIEW_RELAX_MAX_BLOB_CENTER_RATIO;
-
-  if (nudityConfidence >= REAL_NUDITY_BLOCK_THRESHOLD) {
-    if (canRelaxForCartoonBlock) {
-      const allowConfidence = clamp(0.6 + (cartoonConfidence - CARTOON_RELAX_THRESHOLD) * 0.25);
-      applyOutcome('ALLOW', ['anime_explicit_allowed'], allowConfidence);
-    } else if (meetsBlockCoverage) {
-      const nudityReasons = ['real_nudity'];
-      if (largestBlob >= 0.38 || largestBlobBoxCoverage >= 0.38) nudityReasons.push('genitals_visible');
-      if (skinPercent >= 0.7 || centerSkinPercent >= 0.4) nudityReasons.push('sex_act');
-      if (centerSkinPercent >= 0.32) nudityReasons.push('high_center_skin');
-      applyOutcome('BLOCK', nudityReasons, Math.max(nudityConfidence, centerBoost));
-    } else if (meetsReviewCoverage) {
-      applyOutcome('REVIEW', ['real_nudity_suspected'], nudityConfidence);
-    }
-  } else if (nudityConfidence >= REAL_NUDITY_REVIEW_THRESHOLD && meetsReviewCoverage) {
-    if (canRelaxForCartoonReview && cartoonConfidence >= CARTOON_RELAX_THRESHOLD + 0.03) {
-      const allowConfidence = clamp(0.58 + (cartoonConfidence - CARTOON_RELAX_THRESHOLD) * 0.22);
-      applyOutcome('ALLOW', ['anime_skin_visible'], allowConfidence);
-    } else {
-      const reasons = centerSkinPercent >= 0.28 ? ['real_nudity_suspected', 'high_center_skin'] : ['real_nudity_suspected'];
-      applyOutcome('REVIEW', reasons, nudityConfidence);
-    }
-  }
-
-  // B) nazi detection via pHash + color heuristic
   const nazi = await detectNazi(workingBuffer);
   debug.nazi = nazi;
-  let naziConfidence = 0;
-  if (nazi.nazi) {
+  if (nazi?.nazi) {
     if (nazi.reason === 'phash') {
-      const dist = typeof nazi.score === 'number' ? nazi.score : 0;
-      naziConfidence = clamp(0.95 - dist * 0.025, 0.6, 0.95);
+      const score = typeof nazi.score === 'number' ? nazi.score : 0;
+      const conf = clamp(0.95 - score * 0.03, 0.6, 0.95);
+      markBlocked('extremism_nazi', conf);
     } else {
-      naziConfidence = 0.85;
+      markBlocked('extremism_nazi', 0.85);
     }
-    applyOutcome('BLOCK', ['extremism_nazi'], naziConfidence);
   }
-  debug.scores.nazi = naziConfidence;
 
-  // C) OCR-based hate speech detection (only if not already blocked for text)
-  if (SEVERITY_RANK[label] < SEVERITY_RANK.BLOCK) {
+  if (!blockReasons.size && !metaGate.blocked) {
     const textHints = await extractTextHints(workingBuffer);
     debug.textHints = textHints.length;
     if (textHints) {
-      const textGate = hateTextCheck({ filename, designName, textHints });
-      if (textGate.blocked) {
-        applyOutcome('BLOCK', ['extremism_nazi_text'], 0.8);
+      const ocrGate = hateTextCheck({ filename, designName, textHints });
+      if (ocrGate.blocked) {
+        markBlocked('extremism_nazi_text', 0.82);
       }
     }
   }
 
-  // D) illustration vs real estimation based on skin detection context
-  if (SEVERITY_RANK[label] < SEVERITY_RANK.BLOCK) {
-    if (cartoonConfidence >= CARTOON_STRONG_THRESHOLD) {
-      applyOutcome('ALLOW', ['anime_explicit_allowed'], cartoonConfidence);
-    } else {
-      const ANIMATED_REVIEW_MIN_CARTOON = 0.5;
-      const ANIMATED_REVIEW_MIN_EDGE = 0.02;
-      const ANIMATED_REVIEW_MIN_PALETTE = 24;
-      const ANIMATED_REVIEW_MIN_SKIN = 0.2;
-      const ANIMATED_REVIEW_MAX_SKIN = 0.9;
-      const ANIMATED_REVIEW_MIN_BLOB = 0.12;
-      const ANIMATED_REVIEW_MIN_PALETTE_RATIO = 0.003;
-      const paletteRatio = illustration?.paletteRatio ?? 0;
-      const qualifiesAnimatedReview =
-        cartoonConfidence >= ANIMATED_REVIEW_MIN_CARTOON &&
-        nudityConfidence >= 0.32 &&
-        illustration?.edgeRatio >= ANIMATED_REVIEW_MIN_EDGE &&
-        illustration?.paletteSize >= ANIMATED_REVIEW_MIN_PALETTE &&
-        paletteRatio >= ANIMATED_REVIEW_MIN_PALETTE_RATIO &&
-        skinPercent >= ANIMATED_REVIEW_MIN_SKIN &&
-        skinPercent <= ANIMATED_REVIEW_MAX_SKIN &&
-        largestBlob >= ANIMATED_REVIEW_MIN_BLOB;
-      if (qualifiesAnimatedReview) {
-        const allowConfidence = clamp(Math.max(cartoonConfidence, nudityConfidence));
-        applyOutcome('ALLOW', ['anime_skin_visible'], allowConfidence);
-      }
-    }
+  if (blockReasons.size) {
+    return {
+      label: 'BLOCK',
+      reasons: Array.from(blockReasons),
+      confidence: blockConfidence || 0.65,
+      details: debug,
+    };
   }
 
-  // E) quality heuristics for review
-  const originalMeta = debug.metadata?.original || null;
-  const normalizedMeta = debug.metadata?.normalized || null;
-  const meta = originalMeta || normalizedMeta || debug.metadata || {};
-  const approxDpiValid = Number.isFinite(approxDpi);
-  const approxDpiSufficient = approxDpiValid && approxDpi >= LOW_RES_MIN_APPROX_DPI;
-  let lowResolutionOverrideRequested = false;
-  if (SEVERITY_RANK[label] < SEVERITY_RANK.BLOCK) {
-    const lowResolutionDimensions = Boolean(
-      (meta.width && meta.width < LOW_RES_MIN_DIMENSION) ||
-      (meta.height && meta.height < LOW_RES_MIN_DIMENSION)
-    );
-    const lowResolutionConcern = lowResolutionDimensions && !approxDpiSufficient;
-    if (lowResolutionConcern) {
-      debug.scores.lowResolution = 0.45;
-      if (lowQualityAck) {
-        debug.flags = { ...debug.flags, lowResolutionOverride: true };
-        lowResolutionOverrideRequested = true;
-        applyOutcome('ALLOW', ['low_resolution_acknowledged'], 0.55);
-      } else {
-        applyOutcome('REVIEW', ['low_resolution_uncertain'], 0.45);
-      }
-    } else if (lowResolutionDimensions) {
-      debug.flags = {
-        ...debug.flags,
-        lowResolutionBypassed: {
-          approxDpi: approxDpiValid ? approxDpi : null,
-          width: meta.width || null,
-          height: meta.height || null,
-        },
-      };
-    }
-  }
-
-  if (lowResolutionOverrideRequested && label === 'REVIEW') {
-    const seriousReviewReasons = new Set(['real_nudity_suspected']);
-    const hasSeriousReview = reasons.some((reason) => seriousReviewReasons.has(reason));
-    if (!hasSeriousReview) {
-      label = 'ALLOW';
-      reasons = ['low_resolution_acknowledged'];
-      debug.flags = { ...debug.flags, lowResolutionOverrideApplied: true };
-    }
-  }
-
-  let confidence = 0;
-  if (label === 'BLOCK') {
-    confidence = clamp(blockConfidence || 0.6);
-  } else if (label === 'REVIEW') {
-    confidence = clamp(reviewConfidence || 0.4);
-  } else {
-    if (!reasons.length) reasons.push('no_violation_detected');
-    const base = 0.7;
-    const boost = illustration.cartoonConfidence >= 0.7 ? (illustration.cartoonConfidence - 0.7) * 0.3 : 0;
-    confidence = clamp(base + boost);
-  }
-
-  return { label, reasons, confidence, details: debug };
+  return {
+    label: 'ALLOW',
+    reasons: ['no_violation_detected'],
+    confidence: clamp(0.78 + Math.max(0, 0.5 - cartoonConfidence) * 0.08),
+    details: debug,
+  };
 }
 
 export default async function moderateImage(req, res) {
   try {
     if (req.method === 'OPTIONS') {
-      // CORS handled globally by router; just acknowledge
       return res.status(204).end();
     }
     if (req.method !== 'POST') return res.status(405).end();
@@ -879,17 +681,11 @@ export default async function moderateImage(req, res) {
     let buffer = null;
     const filename = data?.filename || '';
     const designName = data?.designName || '';
-    const lowQualityAck = Boolean(data?.lowQualityAck);
-    const approxDpiNum = Number(data?.approxDpi);
-    const approxDpi = Number.isFinite(approxDpiNum) ? approxDpiNum : null;
     if (data?.dataUrl) buffer = toBufferFromDataUrl(data.dataUrl);
     if (!buffer && data?.imageBase64) buffer = Buffer.from(data.imageBase64, 'base64');
     if (!buffer) return res.status(400).json({ ok: false, reason: 'invalid_body' });
 
-    const result = await evaluateImage(buffer, filename, designName, {
-      lowQualityAck,
-      approxDpi,
-    });
+    const result = await evaluateImage(buffer, filename, designName);
     if (result.label === 'BLOCK') {
       return res.status(400).json({
         ok: false,
@@ -897,17 +693,10 @@ export default async function moderateImage(req, res) {
         ...result,
       });
     }
-    if (result.label === 'REVIEW') {
-      return res.status(400).json({
-        ok: false,
-        reason: 'review_required',
-        ...result,
-      });
-    }
+
     return res.status(200).json({ ok: true, ...result });
   } catch (e) {
     try { console.error('moderate-image error', e); } catch {}
     return res.status(500).json({ ok: false });
   }
 }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@supabase/supabase-js": "^2.54.0",
         "sharp": "^0.33.5",
         "tesseract.js": "^5.1.1",
-        "zod": "^3.23.8"
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "concurrently": "^8.2.2"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "engines": { "node": "20.x" },
+  "engines": {
+    "node": "20.x"
+  },
   "scripts": {
     "vercel-build": "node -e \"const fs=require('fs');fs.mkdirSync('public',{recursive:true});fs.writeFileSync('public/index.html','OK');console.log('no-build');\"",
     "vercel:link": "node scripts/vercel-link.mjs",
@@ -20,7 +22,7 @@
     "@supabase/supabase-js": "^2.54.0",
     "sharp": "^0.33.5",
     "tesseract.js": "^5.1.1",
-    "zod": "^3.23.8"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "concurrently": "^8.2.2"

--- a/tests/moderation.test.js
+++ b/tests/moderation.test.js
@@ -164,8 +164,8 @@ test('evaluateImage blocks obvious skin exposure', async () => {
   const buf = await createSyntheticNudityBuffer();
   const result = await evaluateImage(buf, 'design.png');
   assert.equal(result.label, 'BLOCK');
-  assert(result.reasons.some((r) => r.startsWith('real_nudity')));
-  assert(result.confidence >= 0.55);
+  assert(result.reasons.includes('real_nudity'));
+  assert(result.confidence >= 0.62);
 });
 
 test('evaluateImage allows neutral graphics', async () => {
@@ -179,7 +179,7 @@ test('evaluateImage allows stylized explicit art', async () => {
   const buf = await createCartoonBuffer();
   const result = await evaluateImage(buf, 'stylized.png', '', { approxDpi: 320 });
   assert.equal(result.label, 'ALLOW');
-  assert.equal(result.reasons.includes('anime_explicit_allowed'), true);
+  assert.equal(result.reasons.includes('no_violation_detected'), true);
   assert(result.confidence >= 0.7);
 });
 
@@ -187,8 +187,8 @@ test('evaluateImage allows stylized character renders', async () => {
   const buf = await createStylizedCharacterBuffer();
   const result = await evaluateImage(buf, 'character.png', '', { approxDpi: 320 });
   assert.equal(result.label, 'ALLOW');
-  assert.equal(result.reasons.some((reason) => reason.includes('anime')), true);
-  assert(result.confidence >= 0.65);
+  assert.equal(result.reasons.includes('no_violation_detected'), true);
+  assert(result.confidence >= 0.7);
 });
 
 test('evaluateImage blocks nazi symbols', async () => {


### PR DESCRIPTION
## Summary
- refactor server-side image moderation to focus on blocking explicit real human nudity and nazi imagery while simplifying the API handler
- tune the nudity detection heuristics to rely on strong skin coverage cues and retain nazi symbol/text detection without the previous review flow
- update moderation tests to reflect the new verdicts and bump the zod dependency required by the test suite

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0bfe35bc483278869a8479ce8003a