### PR TITLE
Ensure cart links open on mgmgamers store

### DIFF
--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -112,11 +112,11 @@ export default async function createCartLink(req, res) {
 
     const candidates = [
       normalizeAbsolute(process.env.SHOPIFY_CART_RETURN_TO, base),
+      mgmCart,
+      cartPlainString,
       normalizeAbsolute(process.env.SHOPIFY_HOME_URL, base),
       mgmHome,
       homeUrl ? homeUrl.toString() : '',
-      mgmCart,
-      cartPlainString,
       (() => {
         try {
           return new URL('/', base).toString();

--- a/lib/publicStorefront.js
+++ b/lib/publicStorefront.js
@@ -12,6 +12,33 @@ const shouldForceWww = (hostname) => {
   return parts.length === 2;
 };
 
+function normalizeCandidate(raw) {
+  const withProtocol = preferHttps(raw);
+  if (!withProtocol) return null;
+  try {
+    const url = new URL(withProtocol);
+    if (shouldForceWww(url.hostname)) {
+      url.hostname = `www.${url.hostname}`;
+    }
+    url.pathname = '';
+    url.search = '';
+    url.hash = '';
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function scoreHostname(hostname = '') {
+  const host = hostname.toLowerCase();
+  let score = 0;
+  if (!host) return score;
+  if (host.includes('mgmgamers')) score += 200;
+  if (!host.endsWith('.myshopify.com')) score += 50;
+  if (host.startsWith('www.')) score += 5;
+  return score;
+}
+
 export function getPublicStorefrontBase() {
   const candidates = [
     process.env.SHOPIFY_HOME_URL,
@@ -21,23 +48,20 @@ export function getPublicStorefrontBase() {
     'https://www.mgmgamers.store',
   ];
 
-  for (const candidate of candidates) {
-    const withProtocol = preferHttps(candidate);
-    if (!withProtocol) continue;
-    try {
-      const url = new URL(withProtocol);
-      if (shouldForceWww(url.hostname)) {
-        url.hostname = `www.${url.hostname}`;
-      }
-      url.pathname = '';
-      url.search = '';
-      url.hash = '';
-      return url.origin;
-    } catch {
-      // ignore and keep trying
-    }
-  }
-  return '';
+  const normalized = candidates
+    .map((candidate, index) => {
+      const url = normalizeCandidate(candidate);
+      if (!url) return null;
+      return { url, score: scoreHostname(url.hostname), index };
+    })
+    .filter(Boolean)
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      return a.index - b.index;
+    });
+
+  if (!normalized.length) return '';
+  return normalized[0].url.origin;
 }
 
 export function buildProductUrl(handle) {

--- a/tests/create-cart-link.test.js
+++ b/tests/create-cart-link.test.js
@@ -21,7 +21,7 @@ function createMockRes() {
   };
 }
 
-test('create-cart-link uses cart/add and returns mgm home when base is mgmgamers', async () => {
+test('create-cart-link uses cart/add and returns mgm cart when base is mgmgamers', async () => {
   const prev = {
     STORE_DOMAIN: process.env.SHOPIFY_STORE_DOMAIN,
     PUBLIC_BASE: process.env.SHOPIFY_PUBLIC_BASE,
@@ -51,7 +51,7 @@ test('create-cart-link uses cart/add and returns mgm home when base is mgmgamers
     assert.equal(parsed.pathname, '/cart/add');
     assert.equal(parsed.searchParams.get('id'), '123456789');
     assert.equal(parsed.searchParams.get('quantity'), '2');
-    assert.equal(parsed.searchParams.get('return_to'), 'https://www.mgmgamers.store/');
+    assert.equal(parsed.searchParams.get('return_to'), 'https://www.mgmgamers.store/cart');
   } finally {
     process.env.SHOPIFY_STORE_DOMAIN = prev.STORE_DOMAIN;
     if (prev.PUBLIC_BASE === undefined) delete process.env.SHOPIFY_PUBLIC_BASE; else process.env.SHOPIFY_PUBLIC_BASE = prev.PUBLIC_BASE;


### PR DESCRIPTION
## Summary
- prioritize www.mgmgamers.store when resolving the public storefront base so cart links run on the branded domain
- return users to the mgmgamers cart page after posting to /cart/add so the product is immediately visible
- update the create-cart-link unit test to reflect the new redirect target

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0c0c8a0e08327bb0a8bfcfffd5bc4