### PR TITLE
Add private checkout button for draft Shopify products

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -130,6 +130,11 @@ export async function publishProduct(req, res) {
     });
     const metaDescription = (metaDescriptionRaw || generatedMeta || '').trim().slice(0, 320);
 
+    const visibilityRaw = typeof body.visibility === 'string' ? body.visibility.trim().toLowerCase() : '';
+    const visibility = visibilityRaw === 'private' || visibilityRaw === 'draft' ? 'private' : 'public';
+    const publishStatus = visibility === 'private' ? 'draft' : 'active';
+    const publishedScope = visibility === 'private' ? 'global' : 'web';
+
     const priceValue = Number.isFinite(priceTransfer) && priceTransfer > 0 ? formatPrice(priceTransfer) : '0.00';
     const compareAt = Number.isFinite(priceNormal) && priceNormal > (priceTransfer || 0)
       ? formatPrice(priceNormal)
@@ -163,8 +168,8 @@ export async function publishProduct(req, res) {
         title,
         body_html: description,
         product_type: productTypeLabel,
-        status: 'active',
-        published_scope: 'web',
+        status: publishStatus,
+        published_scope: publishedScope,
         tags: '',
         vendor: DEFAULT_VENDOR,
         template_suffix: templateSuffix,
@@ -223,6 +228,7 @@ export async function publishProduct(req, res) {
       variantAdminId: variantResp?.admin_graphql_api_id,
       productUrl: product?.handle ? buildProductUrl(product.handle) : undefined,
       status: product?.status,
+      visibility,
     });
   } catch (e) {
     if (e?.message === 'SHOPIFY_ENV_MISSING') {

--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -83,7 +83,7 @@ export async function blobToBase64(b: Blob): Promise<string> {
   });
 }
 
-export async function createJobAndProduct(mode: 'checkout' | 'cart', flow: FlowState) {
+export async function createJobAndProduct(mode: 'checkout' | 'cart' | 'private', flow: FlowState) {
   if (!flow.mockupBlob) throw new Error('missing_mockup');
   const mockupDataUrl = await blobToBase64(flow.mockupBlob);
   const productType = flow.productType === 'glasspad' ? 'glasspad' : 'mousepad';
@@ -112,6 +112,9 @@ export async function createJobAndProduct(mode: 'checkout' | 'cart', flow: FlowS
   const filename = `${slugify(designName || productTitle)}.png`;
   const imageAlt = `Mockup ${productTitle}`;
 
+  const isPrivate = mode === 'private';
+  const requestedVisibility: 'public' | 'private' = isPrivate ? 'private' : 'public';
+
   const publishResp = await apiFetch('/api/publish-product', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -133,6 +136,7 @@ export async function createJobAndProduct(mode: 'checkout' | 'cart', flow: FlowS
       tags: extraTags,
       description: '',
       seoDescription: metaDescription,
+      visibility: requestedVisibility,
     }),
   });
   const publish = await publishResp.json().catch(() => null);
@@ -162,14 +166,16 @@ export async function createJobAndProduct(mode: 'checkout' | 'cart', flow: FlowS
     productId?: string;
     variantId?: string;
     productUrl?: string;
+    visibility: 'public' | 'private';
   } = {
     productId,
     variantId,
     productUrl: publish.productUrl,
+    visibility: publish?.visibility === 'private' ? 'private' : requestedVisibility,
   };
 
   try {
-    if (mode === 'checkout') {
+    if (mode === 'checkout' || isPrivate) {
       const ckResp = await apiFetch('/api/create-checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -210,6 +216,7 @@ export async function createJobAndProduct(mode: 'checkout' | 'cart', flow: FlowS
         checkoutUrl: result.checkoutUrl,
         productUrl: publish.productUrl,
         productHandle: publish.productHandle,
+        visibility: result.visibility,
       },
     });
   }

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -22,11 +22,15 @@ export default function Mockup() {
   }
 
   async function handle(mode) {
-    if (mode !== 'checkout' && mode !== 'cart') return;
+    if (mode !== 'checkout' && mode !== 'cart' && mode !== 'private') return;
     try {
       setBusy(true);
       const result = await createJobAndProduct(mode, flow);
       if (mode === 'checkout' && result.checkoutUrl) {
+        window.location.assign(result.checkoutUrl);
+        return;
+      }
+      if (mode === 'private' && result.checkoutUrl) {
         window.location.assign(result.checkoutUrl);
         return;
       }
@@ -36,7 +40,7 @@ export default function Mockup() {
         navigate('/');
         return;
       }
-      if (result.productUrl) {
+      if (mode !== 'private' && result.productUrl) {
         window.open(result.productUrl, '_blank', 'noopener');
         return;
       }
@@ -125,6 +129,7 @@ export default function Mockup() {
         <button disabled={busy} onClick={() => { flow.reset(); navigate('/'); }}>Cancelar y volver</button>
         <button disabled={busy} onClick={() => handle('cart')}>Agregar al carrito y seguir creando</button>
         <button disabled={busy} onClick={() => handle('checkout')}>Comprar ahora</button>
+        <button disabled={busy} onClick={() => handle('private')}>Comprar en privado</button>
       </div>
     </div>
   );

--- a/mgm-front/src/state/flow.tsx
+++ b/mgm-front/src/state/flow.tsx
@@ -20,6 +20,7 @@ export type FlowState = {
     checkoutUrl?: string;
     productUrl?: string;
     productHandle?: string;
+    visibility?: 'public' | 'private';
   };
   set: (p: Partial<FlowState>) => void;
   reset: () => void;


### PR DESCRIPTION
## Summary
- add a “Comprar en privado” action in the mockup flow that requests draft Shopify products and redirects to checkout
- expose a visibility flag in the publish-product handler so private creations stay in draft/global scope
- store the resulting visibility on the client flow state for later use

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0c3e2323c8327b75c054c31c470bb