### PR TITLE
Add friendly 404 handling for unknown front-end routes

### DIFF
--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -15,6 +15,7 @@ import ComoFunciona from './pages/ComoFunciona.jsx';
 import PreguntasFrecuentes from './pages/PreguntasFrecuentes.jsx';
 import Contacto from './pages/Contacto.jsx';
 import Busqueda from './pages/Busqueda.jsx';
+import NotFound, { NotFoundBoundary } from './pages/NotFound.jsx';
 import { OrderFlowProvider } from './store/orderFlow';
 import { FlowProvider } from './state/flow.js';
 import './globals.css';
@@ -27,6 +28,7 @@ if (typeof globalThis !== 'undefined' && typeof globalThis.Buffer === 'undefined
 const routes = [
   {
     element: <App />,
+    errorElement: <NotFoundBoundary />,
     children: [
       { path: '/', element: <Home /> },
       { path: '/mousepads-personalizados', element: <MousepadsPersonalizados /> },
@@ -37,7 +39,8 @@ const routes = [
       { path: '/confirm', element: <Confirm /> },
       { path: '/mockup', element: <Mockup /> },
       { path: '/creating/:jobId', element: <Creating /> },
-      { path: '/result/:jobId', element: <Result /> }
+      { path: '/result/:jobId', element: <Result /> },
+      { path: '*', element: <NotFound /> }
     ]
   }
 ];

--- a/mgm-front/src/pages/NotFound.jsx
+++ b/mgm-front/src/pages/NotFound.jsx
@@ -1,0 +1,90 @@
+import { Link, isRouteErrorResponse, useRouteError } from 'react-router-dom';
+import SeoJsonLd from '../components/SeoJsonLd';
+import styles from './NotFound.module.css';
+
+const LOST_META = {
+  title: '¿Estás perdido? — MGMGAMERS',
+  description: 'No encontramos la página que buscabas. Volvé al inicio o contactá a nuestro equipo para obtener ayuda.',
+  canonical: 'https://www.mgmgamers.store/404'
+};
+
+const ERROR_META = {
+  title: 'Algo salió mal — MGMGAMERS',
+  description: 'Tuvimos un inconveniente inesperado al cargar la página. Probá nuevamente o escribinos si el problema persiste.',
+  canonical: 'https://www.mgmgamers.store/error'
+};
+
+function LostLayout({
+  eyebrow = 'Error 404',
+  title = '¿Estás perdido?',
+  description = 'No encontramos la página que buscabas. Volvé al inicio o contactá a nuestro equipo para obtener ayuda.',
+  details = null,
+  meta = LOST_META
+}) {
+  return (
+    <>
+      <SeoJsonLd
+        title={meta.title}
+        description={meta.description}
+        canonical={meta.canonical}
+        noIndex
+      />
+      <section className={styles.container}>
+        <span className={styles.illustration} role="img" aria-hidden="true">
+          🧭
+        </span>
+        <p className={styles.eyebrow}>{eyebrow}</p>
+        <h1 className={styles.title}>{title}</h1>
+        <p className={styles.description}>{description}</p>
+        {details && <p className={styles.details}>{details}</p>}
+        <div className={styles.actions}>
+          <Link className={styles.primary} to="/">
+            Ir al inicio
+          </Link>
+          <Link className={styles.secondary} to="/contacto">
+            Hablar con soporte
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+}
+
+export default function NotFound() {
+  return <LostLayout />;
+}
+
+export function NotFoundBoundary() {
+  const error = useRouteError();
+  const isResponse = isRouteErrorResponse(error);
+  if (isResponse && error.status === 404) {
+    const detailMessage = typeof error.data === 'string' ? error.data : null;
+    return <LostLayout details={detailMessage} />;
+  }
+
+  const fallbackDetails = (() => {
+    if (!error) return null;
+    if (isResponse) {
+      const parts = [error.statusText, typeof error.data === 'string' ? error.data : null].filter(Boolean);
+      return parts.length ? parts.join(' — ') : null;
+    }
+    if (error instanceof Error) {
+      return error.message;
+    }
+    if (typeof error === 'string') {
+      return error;
+    }
+    return null;
+  })();
+
+  const eyebrow = isResponse && error?.status ? `Error ${error.status}` : 'Error inesperado';
+  return (
+    <LostLayout
+      eyebrow={eyebrow}
+      title="Algo salió mal"
+      description="Tuvimos un inconveniente inesperado al cargar la página. Probá nuevamente o escribinos si el problema persiste."
+      details={fallbackDetails}
+      meta={ERROR_META}
+    />
+  );
+}

--- a/mgm-front/src/pages/NotFound.module.css
+++ b/mgm-front/src/pages/NotFound.module.css
@@ -1,0 +1,102 @@
+.container {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  font-weight: 700;
+  color: #f5f5f5;
+}
+
+.description {
+  margin: 0;
+  color: #d1d5db;
+  line-height: 1.6;
+}
+
+.details {
+  margin: 0;
+  max-width: 32rem;
+  color: #9ca3af;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  background: #f5f5f5;
+  color: #111827;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+}
+
+.secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.25rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  color: #f5f5f5;
+  font-weight: 500;
+  text-decoration: none;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.secondary:hover {
+  border-color: rgba(148, 163, 184, 0.7);
+  color: #e5e7eb;
+}
+
+.illustration {
+  font-size: 3rem;
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding: 2.5rem 1rem 3rem;
+  }
+
+  .actions {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .primary,
+  .secondary {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated not found page with SEO metadata, guidance links, and styling that matches the site
- register the new page as both the wildcard child route and the router error boundary so unknown paths or route errors show a friendly message

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0c5af7d448327918c796ef976f175