### PR TITLE
Fix cart popup references in mockup page

### DIFF
--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -25,6 +25,9 @@ export default function Mockup() {
 
     if (mode !== 'checkout' && mode !== 'cart' && mode !== 'private') return;
 
+    let cartTarget;
+    let cartPopup;
+
     try {
       setBusy(true);
       if (mode === 'cart' && typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- declare the cart popup variables inside the mockup handler to avoid reference errors when adding items to the cart

## Testing
- npm run lint *(fails: existing lint warnings and unused variable errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c7aa0d548327b68634ec350dd482