### PR TITLE
Implement backend SEO rendering and sitemap support

### DIFF
--- a/api/[...slug].js
+++ b/api/[...slug].js
@@ -87,12 +87,36 @@ export default withCors(async function handler(req, res) {
         const m = await import('../lib/handlers/renderDryrun.js');
         return m.default(req, res);
       }
+      case 'GET seo/home': {
+        const m = await import('../lib/handlers/seoPages.js');
+        return m.seoHome(req, res);
+      }
+      case 'GET seo/editor': {
+        const m = await import('../lib/handlers/seoPages.js');
+        return m.seoEditor(req, res);
+      }
+      case 'GET seo/checkout': {
+        const m = await import('../lib/handlers/seoPages.js');
+        return m.seoCheckout(req, res);
+      }
+      case 'GET seo/product': {
+        const m = await import('../lib/handlers/seoPages.js');
+        return m.seoProduct(req, res);
+      }
       case 'POST worker-process': {
         const m = await import('../lib/handlers/workerProcess.js');
         return m.default(req, res);
       }
       case 'POST shopify-webhook': {
         const m = await import('../lib/handlers/shopifyWebhook.js');
+        return m.default(req, res);
+      }
+      case 'GET sitemap.xml': {
+        const m = await import('../lib/handlers/sitemap.js');
+        return m.default(req, res);
+      }
+      case 'GET robots.txt': {
+        const m = await import('../lib/handlers/robots.js');
         return m.default(req, res);
       }
       default: {

--- a/lib/handlers/finalizeAssets.js
+++ b/lib/handlers/finalizeAssets.js
@@ -196,17 +196,26 @@ export default async function finalizeAssets(req, res) {
   if (!innerBuffer) innerBuffer = printBuffer;
 
   let previewBuffer;
+  let previewContentType = 'image/webp';
+  let previewExtension = '.webp';
   try {
     previewBuffer = await sharp(innerBuffer)
       .resize({ width: 1200, height: 1200, fit: 'inside', withoutEnlargement: true })
-      .png()
+      .webp({ quality: 85, alphaQuality: 80 })
       .toBuffer();
   } catch (err) {
     console.warn('finalize-assets preview', { diagId, error: err?.message || err });
     try {
-      previewBuffer = await sharp(innerBuffer).png().toBuffer();
+      previewBuffer = await sharp(innerBuffer)
+        .resize({ width: 1200, height: 1200, fit: 'inside', withoutEnlargement: true })
+        .png()
+        .toBuffer();
+      previewContentType = 'image/png';
+      previewExtension = '.png';
     } catch {
       previewBuffer = innerBuffer;
+      previewContentType = 'image/png';
+      previewExtension = '.png';
     }
   }
 
@@ -228,7 +237,13 @@ export default async function finalizeAssets(req, res) {
   }
 
   const baseName = buildBaseName(job, payload, renderDescriptor);
-  const { printKey, previewKey, pdfKey } = buildObjectKeys(job, baseName);
+  const { printKey, previewKey: rawPreviewKey, pdfKey } = buildObjectKeys(job, baseName);
+  let previewKey = rawPreviewKey;
+  if (previewExtension === '.webp') {
+    previewKey = rawPreviewKey.replace(/\.png$/i, '.webp');
+  } else if (!/\.(png|webp)$/i.test(previewKey)) {
+    previewKey = `${rawPreviewKey}${previewExtension}`;
+  }
 
   const storage = supabase.storage.from(OUTPUT_BUCKET);
   async function upload(key, buffer, contentType) {
@@ -243,7 +258,7 @@ export default async function finalizeAssets(req, res) {
   try {
     [printUrl, previewUrl, pdfUrl] = await Promise.all([
       upload(printKey, printJpgBuffer, 'image/jpeg'),
-      upload(previewKey, previewBuffer, 'image/png'),
+      upload(previewKey, previewBuffer, previewContentType),
       upload(pdfKey, pdfBuffer, 'application/pdf'),
     ]);
   } catch (err) {

--- a/lib/handlers/robots.js
+++ b/lib/handlers/robots.js
@@ -1,0 +1,26 @@
+import { SITE } from '../seo/constants.js';
+
+const CACHE_CONTROL = 'public, s-maxage=86400, stale-while-revalidate=604800';
+
+export default function robots(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.statusCode = 405;
+    res.end('Método no permitido');
+    return;
+  }
+
+  const lines = [
+    'User-agent: *',
+    'Allow: /',
+    'Disallow: /api/',
+    'Disallow: /api',
+    `Sitemap: ${SITE.baseUrl}/sitemap.xml`,
+    `Host: ${SITE.baseUrl.replace(/^https?:\/\//, '')}`,
+  ];
+
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.setHeader('Cache-Control', CACHE_CONTROL);
+  res.end(`${lines.join('\n')}\n`);
+}

--- a/lib/handlers/seoPages.js
+++ b/lib/handlers/seoPages.js
@@ -1,0 +1,68 @@
+import { ensureQuery } from '../_lib/http.js';
+import {
+  renderCheckoutPage,
+  renderEditorPage,
+  renderHomePage,
+  renderProductPage,
+} from '../seo/pages.js';
+
+const CACHE_LONG = 'public, s-maxage=3600, stale-while-revalidate=86400';
+const CACHE_MEDIUM = 'public, s-maxage=1800, stale-while-revalidate=43200';
+const CACHE_SHORT = 'public, s-maxage=600, stale-while-revalidate=3600';
+
+function sendHtml(res, html, { status = 200, cache = CACHE_LONG } = {}) {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  res.setHeader('Cache-Control', cache);
+  res.end(html);
+}
+
+export function seoHome(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.statusCode = 405;
+    res.end('Método no permitido');
+    return;
+  }
+  const html = renderHomePage();
+  sendHtml(res, html, { cache: CACHE_LONG });
+}
+
+export function seoEditor(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.statusCode = 405;
+    res.end('Método no permitido');
+    return;
+  }
+  const html = renderEditorPage();
+  sendHtml(res, html, { cache: CACHE_LONG });
+}
+
+export function seoCheckout(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.statusCode = 405;
+    res.end('Método no permitido');
+    return;
+  }
+  const html = renderCheckoutPage();
+  sendHtml(res, html, { cache: CACHE_MEDIUM });
+}
+
+export async function seoProduct(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.statusCode = 405;
+    res.end('Método no permitido');
+    return;
+  }
+  const query = ensureQuery(req);
+  const id = [query?.id, query?.jobId, query?.job_id]
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .find((value) => value);
+
+  const { status, html } = await renderProductPage(id);
+  const cache = status === 200 ? CACHE_MEDIUM : CACHE_SHORT;
+  sendHtml(res, html, { status, cache });
+}

--- a/lib/handlers/sitemap.js
+++ b/lib/handlers/sitemap.js
@@ -1,0 +1,86 @@
+import { supa } from '../supa.js';
+import { absoluteUrl } from '../seo/constants.js';
+
+const CACHE_CONTROL = 'public, s-maxage=3600, stale-while-revalidate=86400';
+
+const STATIC_ROUTES = [
+  { path: '/', changefreq: 'weekly', priority: '1.0' },
+  { path: '/mockup', changefreq: 'weekly', priority: '0.8' },
+  { path: '/confirm', changefreq: 'weekly', priority: '0.6' },
+  { path: '/mousepads-personalizados', changefreq: 'monthly', priority: '0.6' },
+  { path: '/como-funciona', changefreq: 'monthly', priority: '0.5' },
+  { path: '/preguntas-frecuentes', changefreq: 'monthly', priority: '0.5' },
+  { path: '/contacto', changefreq: 'monthly', priority: '0.4' },
+];
+
+function formatDate(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString().split('T')[0];
+}
+
+async function fetchProductRoutes(limit = 40) {
+  try {
+    const { data, error } = await supa
+      .from('jobs')
+      .select('job_id,created_at,is_public,shopify_product_url,preview_url')
+      .or('is_public.eq.true,shopify_product_url.not.is.null')
+      .not('preview_url', 'is', null)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (error || !Array.isArray(data)) {
+      return [];
+    }
+
+    return data
+      .filter((job) => job && typeof job.job_id === 'string' && job.job_id.trim())
+      .map((job) => ({
+        loc: absoluteUrl(`/result/${job.job_id}`),
+        changefreq: 'weekly',
+        priority: '0.5',
+        lastmod: formatDate(job.created_at),
+      }));
+  } catch {
+    return [];
+  }
+}
+
+function renderUrlNode({ loc, changefreq, priority, lastmod }) {
+  const parts = [`  <url>`, `    <loc>${loc}</loc>`];
+  if (lastmod) parts.push(`    <lastmod>${lastmod}</lastmod>`);
+  if (changefreq) parts.push(`    <changefreq>${changefreq}</changefreq>`);
+  if (priority) parts.push(`    <priority>${priority}</priority>`);
+  parts.push('  </url>');
+  return parts.join('\n');
+}
+
+export default async function sitemap(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.statusCode = 405;
+    res.end('Método no permitido');
+    return;
+  }
+
+  const productRoutes = await fetchProductRoutes();
+  const staticRoutes = STATIC_ROUTES.map(({ path, ...rest }) => ({
+    loc: absoluteUrl(path),
+    ...rest,
+  }));
+
+  const allRoutes = [...staticRoutes, ...productRoutes];
+
+  const xmlParts = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...allRoutes.map(renderUrlNode),
+    '</urlset>',
+  ];
+
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+  res.setHeader('Cache-Control', CACHE_CONTROL);
+  res.end(xmlParts.join('\n'));
+}

--- a/lib/seo/constants.js
+++ b/lib/seo/constants.js
@@ -1,0 +1,37 @@
+export const SITE = {
+  name: 'MGMGAMERS',
+  baseUrl: 'https://www.mgmgamers.store',
+  locale: 'es-AR',
+  ogLocale: 'es_AR',
+  defaultOgPath: '/og/og-default.png',
+  instagram: 'https://www.instagram.com/mgmgamers.store',
+  keywords: [
+    'mousepad gamer personalizado',
+    'glasspad gamer personalizado',
+    'mousepad de tela personalizado Argentina',
+    'alfombrilla gamer personalizada',
+    'pad gamer personalizado Argentina',
+  ],
+  organizationLogoPath: '/icons/icon-512.png',
+};
+
+export function absoluteUrl(path = '/') {
+  const trimmed = typeof path === 'string' ? path.trim() : '';
+  if (!trimmed) return SITE.baseUrl;
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  const normalized = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  return `${SITE.baseUrl}${normalized}`;
+}
+
+export function ensureAbsoluteUrl(candidate) {
+  const value = typeof candidate === 'string' ? candidate.trim() : '';
+  if (!value) return absoluteUrl(SITE.defaultOgPath);
+  if (/^https?:\/\//i.test(value)) return value;
+  return absoluteUrl(value);
+}
+
+export function buildDefaultImageUrl() {
+  return ensureAbsoluteUrl(SITE.defaultOgPath);
+}

--- a/lib/seo/jsonld.js
+++ b/lib/seo/jsonld.js
@@ -1,0 +1,81 @@
+import { SITE, ensureAbsoluteUrl } from './constants.js';
+import { normalizePrice } from './utils.js';
+
+export function buildOrganizationJsonLd() {
+  const logoUrl = ensureAbsoluteUrl(SITE.organizationLogoPath);
+  const sameAs = [SITE.instagram].filter(Boolean);
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: SITE.name,
+    url: SITE.baseUrl,
+    logo: logoUrl,
+    sameAs,
+  };
+}
+
+export function buildProductJsonLd({
+  name,
+  description,
+  image,
+  price,
+  currency = 'ARS',
+  material,
+  availability = 'InStock',
+  canonical,
+  sku,
+  width,
+  height,
+}) {
+  const normalizedPrice = normalizePrice(price);
+  const offers = normalizedPrice
+    ? {
+        '@type': 'Offer',
+        price: normalizedPrice,
+        priceCurrency: currency,
+        availability: availability.startsWith('http')
+          ? availability
+          : `https://schema.org/${availability}`,
+        url: canonical,
+        itemCondition: 'https://schema.org/NewCondition',
+        seller: {
+          '@type': 'Organization',
+          name: SITE.name,
+          url: SITE.baseUrl,
+        },
+      }
+    : undefined;
+
+  const additionalProperties = [];
+  if (width || height) {
+    additionalProperties.push({
+      '@type': 'PropertyValue',
+      name: 'Dimensiones',
+      value: [width, height].filter(Boolean).join(' x '),
+      unitCode: 'CMT',
+    });
+  }
+  if (material) {
+    additionalProperties.push({
+      '@type': 'PropertyValue',
+      name: 'Material',
+      value: material,
+    });
+  }
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name,
+    description,
+    image: [ensureAbsoluteUrl(image)],
+    sku,
+    brand: {
+      '@type': 'Brand',
+      name: SITE.name,
+    },
+    material,
+    offers,
+    additionalProperty: additionalProperties.length ? additionalProperties : undefined,
+  };
+}

--- a/lib/seo/pages.js
+++ b/lib/seo/pages.js
@@ -1,0 +1,335 @@
+import { buildDefaultImageUrl } from './constants.js';
+import {
+  buildKeywords,
+  canonicalUrl,
+  describeMaterial,
+  ensureImageUrl,
+  formatCurrency,
+  formatMeasurement,
+  formatNumber,
+  sanitizeText,
+} from './utils.js';
+import { renderPageLayout, renderSeoDocument } from './templates.js';
+import { buildOrganizationJsonLd, buildProductJsonLd } from './jsonld.js';
+import { fetchJobForSeo } from './productData.js';
+
+export function renderHomePage() {
+  const canonical = canonicalUrl('/');
+  const keywords = buildKeywords([
+    'mousepads gamers Argentina',
+    'personalización de Glasspad',
+    'diseñar mousepad online',
+  ]);
+  const hero = {
+    eyebrow: 'MGMGAMERS · Argentina',
+    heading: 'Mousepad gamer personalizado hecho a tu medida',
+    subheading:
+      'Diseñá mousepads de tela o Glasspads gamers con impresión HD, bordes reforzados y envío rápido a todo Argentina.',
+    stats: [
+      { label: 'Materiales', value: 'Tela premium y Glasspad de vidrio' },
+      { label: 'Producción', value: 'Hecho en Argentina' },
+      { label: 'Entrega', value: 'Envío a todo el país' },
+    ],
+  };
+  const sections = [
+    {
+      heading: '¿Por qué elegir un mousepad gamer personalizado en Argentina?',
+      paragraphs: [
+        'Un mousepad gamer personalizado eleva tu setup competitivo con una superficie optimizada para eSports y un diseño único. En MGMGAMERS imprimimos en alta definición sobre materiales profesionales para que cada movimiento sea preciso.',
+        'Trabajamos con tintas resistentes y un proceso de curado que conserva la saturación del color incluso después de sesiones intensas de juego o prácticas de aim.',
+      ],
+      list: {
+        items: [
+          'Opciones speed y control para distintos estilos de juego competitivo.',
+          'Impresión full color preparada para resoluciones de hasta 300 DPI.',
+          'Costuras reforzadas y base antideslizante para torneos en Argentina.',
+        ],
+      },
+    },
+    {
+      heading: 'Glasspad gamer personalizado o tela profesional',
+      paragraphs: [
+        'Elegí entre Glasspad gamer personalizado con fricción mínima o mousepad de tela personalizado Argentina para lograr control absoluto. Nuestro laboratorio calibra cada material para que la sensación sea consistente en torneos LAN o streams desde casa.',
+        'Todas las piezas se producen localmente, por lo que podés aprovechar soporte en español y reposiciones rápidas sin depender de envíos internacionales.',
+      ],
+    },
+    {
+      heading: 'Proceso 100% online con entrega nacional',
+      paragraphs: [
+        'Subí tu diseño, seleccioná medidas estándar o personalizadas y recibí una vista previa antes de imprimir. Nuestro equipo revisa cada archivo para garantizar nitidez y cumplimiento de márgenes de seguridad.',
+        'Coordinamos envíos a todo el país y brindamos seguimiento en español para que tu mousepad gamer personalizado llegue listo para competir.',
+      ],
+    },
+  ];
+  const bodyHtml = renderPageLayout({ hero, sections });
+
+  const html = renderSeoDocument({
+    title: 'Mousepad Gamer Personalizado - Diseñá el Tuyo | MGMGAMERS',
+    description:
+      'Creá mousepads gamers personalizados o Glasspads en MGMGAMERS. Alta calidad, ideales para esports, con envío rápido en Argentina.',
+    canonical,
+    keywords,
+    ogImage: buildDefaultImageUrl(),
+    ogImageAlt: 'Mousepad gamer personalizado argentino',
+    jsonLd: [buildOrganizationJsonLd()],
+    bodyHtml,
+  });
+  return html;
+}
+
+export function renderEditorPage() {
+  const canonical = canonicalUrl('/mockup');
+  const keywords = buildKeywords([
+    'editor de mousepad gamer',
+    'personalizar glasspad argentina',
+    'diseñar mousepad de tela',
+  ]);
+  const hero = {
+    eyebrow: 'Editor online',
+    heading: 'Diseñá tu mousepad gamer personalizado en minutos',
+    subheading:
+      'Subí tu arte, elegí medidas en centímetros y ajustá la vista previa en tiempo real. Compatible con mousepads de tela y Glasspads premium hechos en Argentina.',
+    stats: [
+      { label: 'Formatos', value: 'Medidas estándar y personalizadas' },
+      { label: 'Salida', value: 'Archivos listos para impresión 300 DPI' },
+      { label: 'Materiales', value: 'Tela PRO, Classic y Glasspad' },
+    ],
+  };
+
+  const sections = [
+    {
+      heading: 'Herramientas pensadas para esports',
+      paragraphs: [
+        'El editor valida resolución mínima para asegurar un mousepad gamer personalizado de alta fidelidad. Podés posicionar tu logo, agregar fondos y revisar el sangrado antes de enviar a producción.',
+      ],
+      list: {
+        items: [
+          'Control de DPI y alertas cuando la imagen no alcanza calidad competitiva.',
+          'Plantillas para Glasspad gamer personalizado con medidas oficiales.',
+          'Opciones de material para speed o control según tu estilo de juego.',
+        ],
+      },
+    },
+    {
+      heading: 'Flujo guiado para publicar o comprar',
+      paragraphs: [
+        'Una vez que confirmás el diseño, generamos mockups, archivos print-ready y enlaces de checkout para Argentina. Podés agregar el mousepad al carrito, comprar al instante o solicitar una publicación privada.',
+        'El backend asegura que los datos SEO y las vistas previas estén optimizadas para compartir tu diseño con tu comunidad gamer.',
+      ],
+    },
+    {
+      heading: 'Recomendaciones de diseño profesional',
+      paragraphs: [
+        'Trabajá en modo RGB, subí imágenes de al menos 300 DPI y mantené elementos críticos fuera del área de seguridad. Así garantizamos un mousepad de tela personalizado Argentina sin cortes ni pérdida de detalles.',
+      ],
+    },
+  ];
+
+  const bodyHtml = renderPageLayout({ hero, sections });
+
+  return renderSeoDocument({
+    title: 'Diseñá tu Mousepad Gamer Personalizado | MGMGAMERS',
+    description:
+      'Personalizá un mousepad de tela o Glasspad para gaming. Subí tu diseño y elegí el tamaño para un rendimiento profesional en Argentina.',
+    canonical,
+    keywords,
+    ogImage: buildDefaultImageUrl(),
+    ogImageAlt: 'Editor de mousepads personalizados MGMGAMERS',
+    jsonLd: [buildOrganizationJsonLd()],
+    bodyHtml,
+  });
+}
+
+export function renderCheckoutPage() {
+  const canonical = canonicalUrl('/confirm');
+  const keywords = buildKeywords([
+    'checkout mousepad personalizado',
+    'comprar glasspad gamer argentina',
+    'pago seguro mousepad gamer',
+  ]);
+  const hero = {
+    eyebrow: 'Checkout protegido',
+    heading: 'Finalizá tu compra de mousepads personalizados',
+    subheading:
+      'Revisá el resumen de tu diseño, confirmá medidas y coordiná envío dentro de Argentina con soporte en español.',
+    stats: [
+      { label: 'Soporte', value: 'Acompañamiento en español' },
+      { label: 'Control', value: 'Verificación manual del archivo' },
+      { label: 'Envío', value: 'Seguimiento puerta a puerta' },
+    ],
+  };
+
+  const sections = [
+    {
+      heading: 'Resumen del pedido optimizado para gamers',
+      paragraphs: [
+        'Antes de abonar confirmás material, tamaño y vista previa del mousepad gamer personalizado. Nuestro equipo valida nuevamente la calidad del archivo antes de imprimir.',
+      ],
+    },
+    {
+      heading: 'Envíos dentro de Argentina',
+      paragraphs: [
+        'Coordinamos envíos a CABA, GBA y provincias con transportes de confianza. Te compartimos el seguimiento para que sepas cuándo llega tu mousepad de tela personalizado o Glasspad.',
+      ],
+    },
+    {
+      heading: 'Pagos seguros y asistencia',
+      paragraphs: [
+        'Trabajamos con pasarelas de pago seguras y soporte humano para resolver dudas en el proceso. Si necesitás factura o cambios de último momento, nos contactás desde el mismo panel.',
+      ],
+    },
+  ];
+
+  const bodyHtml = renderPageLayout({ hero, sections });
+
+  return renderSeoDocument({
+    title: 'Finalizá tu Compra de Mousepads Personalizados | MGMGAMERS',
+    description:
+      'Confirmá tu pedido de mousepads gamers personalizados o Glasspads. Pagos seguros y envíos a todo Argentina con soporte local.',
+    canonical,
+    keywords,
+    ogImage: buildDefaultImageUrl(),
+    ogImageAlt: 'Checkout de mousepads personalizados MGMGAMERS',
+    jsonLd: [buildOrganizationJsonLd()],
+    bodyHtml,
+  });
+}
+
+export async function renderProductPage(jobId) {
+  const job = await fetchJobForSeo(jobId);
+  if (!job) {
+    return renderMissingProduct(jobId);
+  }
+
+  const canonical = canonicalUrl(`/result/${job.job_id}`);
+  const designName = sanitizeText(job.design_name) || 'Personalizado';
+  const measurement = formatMeasurement(job.w_cm, job.h_cm);
+  const materialInfo = describeMaterial(job.material);
+  const priceDisplay = formatCurrency(job.price_amount, job.price_currency || 'ARS');
+  const ogImage = ensureImageUrl(job.preview_url || job.print_jpg_url || buildDefaultImageUrl());
+
+  const keywords = buildKeywords([
+    `mousepad gamer personalizado ${designName}`,
+    materialInfo.label,
+    measurement ? `mousepad ${measurement} Argentina` : '',
+  ]);
+
+  const hero = {
+    eyebrow: 'Vista previa del producto',
+    heading: `Mousepad gamer ${designName}`,
+    subheading:
+      `${materialInfo.label} producido en Argentina con impresión de alta fidelidad. Compartí el diseño con tu equipo o comunidad.`,
+    stats: [
+      { label: 'Material', value: materialInfo.short },
+      measurement ? { label: 'Medidas', value: measurement } : null,
+      priceDisplay ? { label: 'Precio estimado', value: priceDisplay } : null,
+    ].filter(Boolean),
+  };
+
+  const sections = [
+    {
+      heading: 'Características del mousepad personalizado',
+      paragraphs: [
+        materialInfo.narrative,
+        'El proceso de impresión garantiza colores vivos y un sellado que evita el desgaste en los bordes. Ideal para entrenamientos diarios, competencias locales y setups profesionales en Argentina.',
+      ],
+      list: {
+        items: [
+          measurement ? `Dimensiones configuradas: ${measurement}.` : 'Dimensiones personalizadas adaptadas a tu estilo.',
+          'Base antideslizante y superficie balanceada para tracking con sensores ópticos modernos.',
+          'Glasspad gamer personalizado o tela premium según la fricción que busques.',
+        ],
+      },
+    },
+    {
+      heading: 'Beneficios para gamers en Argentina',
+      paragraphs: [
+        'Recibí un mousepad gamer personalizado listo para usar en torneos locales o streamings. Cada pedido se arma en Argentina para acelerar la entrega y ofrecer garantía local.',
+        'Podés compartir esta vista previa en redes o enviarla a tu equipo para validar el diseño final antes de imprimir.',
+      ],
+    },
+    {
+      heading: 'Cómo completar la compra',
+      paragraphs: [
+        'Desde esta vista previa podés generar enlaces de checkout inmediato o agregarlo al carrito para seguir personalizando más mousepads gamers. El backend crea URLs seguras para pagar en pesos argentinos.',
+      ],
+    },
+  ];
+
+  const bodyHtml = renderPageLayout({ hero, sections });
+  const productName = `Mousepad gamer personalizado ${designName}${measurement ? ` ${measurement}` : ''}`;
+  const description = `Mousepad gamer personalizado ${designName} ${measurement ? `(${measurement})` : ''} fabricado en Argentina con ${materialInfo.label}. Ideal para esports y streamers.`;
+
+  const jsonLd = [
+    buildOrganizationJsonLd(),
+    buildProductJsonLd({
+      name: productName,
+      description,
+      image: ogImage,
+      price: job.price_amount,
+      currency: job.price_currency || 'ARS',
+      material: materialInfo.schemaMaterial,
+      availability: 'InStock',
+      canonical,
+      sku: job.job_id,
+      width: formatNumber(job.w_cm),
+      height: formatNumber(job.h_cm),
+    }),
+  ];
+
+  const html = renderSeoDocument({
+    title: `${productName} | MGMGAMERS Argentina`,
+    description,
+    canonical,
+    keywords,
+    ogImage,
+    ogType: 'product',
+    ogImageAlt: productName,
+    jsonLd,
+    bodyHtml,
+  });
+
+  return { status: 200, html };
+}
+
+function renderMissingProduct(jobId) {
+  const canonical = canonicalUrl('/result');
+  const keywords = buildKeywords(['mousepad personalizado Argentina', 'diseño no disponible']);
+  const hero = {
+    eyebrow: 'Mousepad no disponible',
+    heading: 'El diseño solicitado ya no está publicado',
+    subheading:
+      'Es posible que el mousepad gamer personalizado haya sido retirado o sea privado. Podés crear uno nuevo en minutos.',
+    stats: [
+      { label: 'Referencia', value: jobId ? `ID: ${jobId}` : 'Sin ID proporcionado' },
+    ],
+  };
+  const sections = [
+    {
+      heading: 'Creá tu propio mousepad en Argentina',
+      paragraphs: [
+        'Ingresá al editor para diseñar un mousepad gamer personalizado desde cero. Podés elegir entre tela o Glasspad con envíos a todo el país.',
+      ],
+      list: {
+        items: [
+          'Subí tu arte o logos en alta resolución.',
+          'Configura medidas estándar o personalizadas en centímetros.',
+          'Generá enlaces de checkout inmediatos para tus compras.',
+        ],
+      },
+    },
+  ];
+  const bodyHtml = renderPageLayout({ hero, sections });
+  const html = renderSeoDocument({
+    title: 'Mousepad personalizado no disponible | MGMGAMERS',
+    description: 'El mousepad gamer personalizado que buscás no está disponible. Diseñá uno nuevo con MGMGAMERS en Argentina.',
+    canonical,
+    keywords,
+    ogImage: buildDefaultImageUrl(),
+    ogImageAlt: 'Mousepad personalizado no disponible',
+    jsonLd: [buildOrganizationJsonLd()],
+    bodyHtml,
+    noindex: true,
+  });
+  return { status: 404, html };
+}

--- a/lib/seo/productData.js
+++ b/lib/seo/productData.js
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { supa } from '../supa.js';
+
+const JobSchema = z.object({
+  job_id: z.string(),
+  design_name: z.string().nullable(),
+  material: z.string().nullable(),
+  w_cm: z.coerce.number().nullable(),
+  h_cm: z.coerce.number().nullable(),
+  price_amount: z.coerce.number().nullable(),
+  price_currency: z.string().nullable(),
+  preview_url: z.string().nullable(),
+  print_jpg_url: z.string().nullable(),
+  checkout_url: z.string().nullable(),
+  shopify_product_url: z.string().nullable(),
+  is_public: z.boolean().nullable(),
+  status: z.string().nullable(),
+  created_at: z.string().nullable(),
+  updated_at: z.string().nullable().optional(),
+});
+
+export async function fetchJobForSeo(jobId) {
+  if (!jobId) return null;
+  const { data, error } = await supa
+    .from('jobs')
+    .select('job_id,design_name,material,w_cm,h_cm,price_amount,price_currency,preview_url,print_jpg_url,checkout_url,shopify_product_url,is_public,status,created_at,updated_at')
+    .eq('job_id', jobId)
+    .maybeSingle();
+
+  if (error || !data) {
+    return null;
+  }
+
+  const parsed = JobSchema.safeParse(data);
+  if (!parsed.success) {
+    return null;
+  }
+
+  const job = parsed.data;
+  const isPublic = job.is_public === true || job.shopify_product_url != null;
+  const hasPreview = typeof job.preview_url === 'string' && job.preview_url.trim().length > 0;
+  if (!isPublic && !hasPreview) {
+    return null;
+  }
+  return job;
+}

--- a/lib/seo/templates.js
+++ b/lib/seo/templates.js
@@ -1,0 +1,138 @@
+import { SITE, buildDefaultImageUrl, ensureAbsoluteUrl } from './constants.js';
+import { buildKeywords, escapeHtml, serializeJsonLd } from './utils.js';
+
+const BASE_STYLE = `body{margin:0;font-family:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;background:#f8fafc;color:#0f172a;}main{max-width:960px;margin:0 auto;padding:48px 24px;}article{background:#ffffff;border-radius:16px;box-shadow:0 24px 48px rgba(15,23,42,0.08);padding:40px 32px;}header.hero{margin-bottom:32px;}header.hero p.eyebrow{font-size:0.9rem;font-weight:600;letter-spacing:0.08em;text-transform:uppercase;color:#0ea5e9;margin:0 0 12px;}header.hero h1{font-size:2.4rem;line-height:1.1;margin:0 0 16px;color:#0b1120;}header.hero p.subheading{font-size:1.15rem;line-height:1.6;margin:0;}section{margin-top:32px;}section h2{font-size:1.5rem;margin-bottom:12px;color:#0f172a;}section p{font-size:1.05rem;line-height:1.7;margin:0 0 12px;color:#1f2937;}ul.feature-list{margin:16px 0 0 20px;padding:0;color:#1f2937;}ul.feature-list li{margin-bottom:8px;}div.hero-grid{display:flex;flex-wrap:wrap;gap:18px;margin-top:18px;}div.hero-grid div.stat{flex:1 1 160px;background:#f1f5f9;border-radius:12px;padding:16px;}div.hero-grid div.stat span.label{display:block;font-size:0.8rem;text-transform:uppercase;letter-spacing:0.06em;color:#334155;margin-bottom:6px;}div.hero-grid div.stat span.value{font-size:1.1rem;font-weight:600;color:#0f172a;}footer.page-footer{margin-top:40px;font-size:0.9rem;color:#475569;text-align:center;}@media(max-width:720px){article{padding:28px 20px;}header.hero h1{font-size:2rem;}header.hero p.subheading{font-size:1rem;}section h2{font-size:1.3rem;}}`;
+
+function renderJsonLdScripts(jsonLdItems = []) {
+  return jsonLdItems
+    .filter(Boolean)
+    .map((item) => `<script type="application/ld+json">${serializeJsonLd(item)}</script>`)
+    .join('');
+}
+
+export function renderSeoDocument({
+  title,
+  description,
+  canonical,
+  keywords = [],
+  ogImage,
+  ogType = 'website',
+  ogImageAlt,
+  jsonLd = [],
+  bodyHtml = '',
+  noindex = false,
+}) {
+  const finalTitle = escapeHtml(title || `${SITE.name} — Mousepads Personalizados`);
+  const finalDescription = escapeHtml(description || 'Mousepads gamers personalizados y Glasspads premium en Argentina.');
+  const canonicalUrl = ensureAbsoluteUrl(canonical || '/');
+  const imageUrl = ensureAbsoluteUrl(ogImage || buildDefaultImageUrl());
+  const ogImageAltText = escapeHtml(ogImageAlt || 'Mousepad gamer personalizado MGMGAMERS');
+  const keywordsContent = escapeHtml(buildKeywords(keywords).join(', '));
+  const robots = noindex ? 'noindex,nofollow' : 'index,follow';
+
+  return `<!DOCTYPE html>
+<html lang="${escapeHtml(SITE.locale)}">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${finalTitle}</title>
+<meta name="description" content="${finalDescription}" />
+<meta name="keywords" content="${keywordsContent}" />
+<meta name="robots" content="${robots}" />
+<meta name="language" content="${escapeHtml(SITE.locale)}" />
+<meta name="geo.region" content="AR" />
+<meta name="geo.placename" content="Argentina" />
+<link rel="canonical" href="${escapeHtml(canonicalUrl)}" />
+<link rel="alternate" href="${escapeHtml(canonicalUrl)}" hreflang="${escapeHtml(SITE.locale)}" />
+<link rel="alternate" href="${escapeHtml(canonicalUrl)}" hreflang="x-default" />
+<meta property="og:type" content="${escapeHtml(ogType)}" />
+<meta property="og:site_name" content="${escapeHtml(SITE.name)}" />
+<meta property="og:locale" content="${escapeHtml(SITE.ogLocale)}" />
+<meta property="og:title" content="${finalTitle}" />
+<meta property="og:description" content="${finalDescription}" />
+<meta property="og:url" content="${escapeHtml(canonicalUrl)}" />
+<meta property="og:image" content="${escapeHtml(imageUrl)}" />
+<meta property="og:image:secure_url" content="${escapeHtml(imageUrl)}" />
+<meta property="og:image:alt" content="${ogImageAltText}" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="${finalTitle}" />
+<meta name="twitter:description" content="${finalDescription}" />
+<meta name="twitter:image" content="${escapeHtml(imageUrl)}" />
+<meta name="twitter:creator" content="@mgmgamers" />
+<style>${BASE_STYLE}</style>
+${renderJsonLdScripts(jsonLd)}
+</head>
+<body>
+${bodyHtml}
+<footer class="page-footer">${escapeHtml('© ' + new Date().getFullYear() + ' MGMGAMERS — Mousepads personalizados en Argentina.')}</footer>
+</body>
+</html>`;
+}
+
+export function renderPageLayout({ hero, sections = [] }) {
+  const parts = [];
+  parts.push('<main id="contenido"><article>');
+  if (hero) {
+    parts.push('<header class="hero">');
+    if (hero.eyebrow) {
+      parts.push(`<p class="eyebrow">${escapeHtml(hero.eyebrow)}</p>`);
+    }
+    if (hero.heading) {
+      parts.push(`<h1>${escapeHtml(hero.heading)}</h1>`);
+    }
+    if (hero.subheading) {
+      parts.push(`<p class="subheading">${escapeHtml(hero.subheading)}</p>`);
+    }
+    if (Array.isArray(hero.stats) && hero.stats.length) {
+      parts.push('<div class="hero-grid">');
+      hero.stats.forEach((stat) => {
+        if (!stat || (!stat.label && !stat.value)) return;
+        parts.push('<div class="stat">');
+        if (stat.label) {
+          parts.push(`<span class="label">${escapeHtml(stat.label)}</span>`);
+        }
+        if (stat.value) {
+          parts.push(`<span class="value">${escapeHtml(stat.value)}</span>`);
+        }
+        parts.push('</div>');
+      });
+      parts.push('</div>');
+    }
+    parts.push('</header>');
+  }
+
+  sections.forEach((section) => {
+    if (!section) return;
+    parts.push('<section>');
+    if (section.heading) {
+      parts.push(`<h2>${escapeHtml(section.heading)}</h2>`);
+    }
+    if (Array.isArray(section.paragraphs)) {
+      section.paragraphs.forEach((paragraph) => {
+        const content = sanitizeParagraph(paragraph);
+        if (content) {
+          parts.push(`<p>${content}</p>`);
+        }
+      });
+    }
+    if (section.list && Array.isArray(section.list.items) && section.list.items.length) {
+      parts.push('<ul class="feature-list">');
+      section.list.items.forEach((item) => {
+        const content = sanitizeParagraph(item);
+        if (content) {
+          parts.push(`<li>${content}</li>`);
+        }
+      });
+      parts.push('</ul>');
+    }
+    parts.push('</section>');
+  });
+
+  parts.push('</article></main>');
+  return parts.join('');
+}
+
+function sanitizeParagraph(text) {
+  if (!text) return '';
+  return escapeHtml(String(text));
+}

--- a/lib/seo/utils.js
+++ b/lib/seo/utils.js
@@ -1,0 +1,135 @@
+import { SITE, absoluteUrl, ensureAbsoluteUrl } from './constants.js';
+
+export function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function sanitizeText(value) {
+  if (value == null) return '';
+  return String(value)
+    .replace(/\s+/g, ' ')
+    .replace(/[\r\n\t]+/g, ' ')
+    .trim();
+}
+
+export function buildKeywords(extra = []) {
+  const set = new Set();
+  SITE.keywords.forEach((keyword) => {
+    if (keyword) set.add(sanitizeText(keyword));
+  });
+  extra.forEach((keyword) => {
+    const normalized = sanitizeText(keyword);
+    if (normalized) set.add(normalized);
+  });
+  return Array.from(set).filter(Boolean);
+}
+
+export function formatNumber(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return null;
+  if (Math.abs(num - Math.round(num)) < 1e-6) {
+    return String(Math.round(num));
+  }
+  return num.toFixed(1).replace(/\.0+$/, '');
+}
+
+export function formatMeasurement(width, height) {
+  const w = formatNumber(width);
+  const h = formatNumber(height);
+  if (!w || !h) return '';
+  return `${w} x ${h} cm`;
+}
+
+export function describeMaterial(raw) {
+  const value = sanitizeText(raw).toLowerCase();
+  if (!value) {
+    return {
+      label: 'Mousepad de tela',
+      keywords: ['mousepad de tela personalizado Argentina'],
+      narrative:
+        'Mousepad gamer de tela con base antideslizante y costuras reforzadas, ideal para sesiones de esports en Argentina.',
+      schemaMaterial: 'Tela',
+      short: 'Tela premium',
+    };
+  }
+
+  if (value.includes('glass')) {
+    return {
+      label: 'Glasspad gamer personalizado',
+      keywords: ['Glasspad gamer personalizado', 'glasspad de vidrio templado'],
+      narrative:
+        'Glasspad gamer personalizado fabricado en vidrio templado de baja fricción para movimientos ultra precisos.',
+      schemaMaterial: 'Glass',
+      short: 'Glasspad de vidrio templado',
+    };
+  }
+
+  if (value.includes('pro')) {
+    return {
+      label: 'Mousepad PRO personalizado',
+      keywords: ['mousepad pro personalizado', 'mousepad gamer profesional'],
+      narrative:
+        'Mousepad gamer PRO con superficie de alto rendimiento y base con agarre firme, confeccionado en Argentina.',
+      schemaMaterial: 'Tela PRO',
+      short: 'Tela PRO',
+    };
+  }
+
+  if (value.includes('classic')) {
+    return {
+      label: 'Mousepad Classic personalizado',
+      keywords: ['mousepad classic personalizado', 'mousepad de tela clásico'],
+      narrative:
+        'Mousepad gamer Classic con textura equilibrada entre velocidad y control, pensado para jugadores argentinos.',
+      schemaMaterial: 'Tela Classic',
+      short: 'Tela Classic',
+    };
+  }
+
+  return {
+    label: `Mousepad ${sanitizeText(raw)}`,
+    keywords: ['mousepad personalizado Argentina'],
+    narrative:
+      'Mousepad gamer personalizado con materiales seleccionados para brindar estabilidad y precisión en torneos locales.',
+    schemaMaterial: sanitizeText(raw),
+    short: sanitizeText(raw),
+  };
+}
+
+export function formatCurrency(value, currency = 'ARS') {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num <= 0) return null;
+  return new Intl.NumberFormat('es-AR', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(num);
+}
+
+export function normalizePrice(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num <= 0) return null;
+  return num.toFixed(2);
+}
+
+export function ensureImageUrl(url) {
+  return ensureAbsoluteUrl(url || SITE.defaultOgPath);
+}
+
+export function canonicalUrl(path) {
+  return absoluteUrl(path || '/');
+}
+
+export function serializeJsonLd(data) {
+  const json = JSON.stringify(data, null, 2);
+  return json
+    .replace(/<\//g, '\\u003C/')
+    .replace(/</g, '\\u003C')
+    .replace(/>/g, '\\u003E');
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,7 @@
 {
-  "version": 2
+  "version": 2,
+  "rewrites": [
+    { "source": "/sitemap.xml", "destination": "/api/sitemap.xml" },
+    { "source": "/robots.txt", "destination": "/api/robots.txt" }
+  ]
 }


### PR DESCRIPTION
## Summary
- add Spanish SSR metadata generators for home, editor, checkout, and product preview pages with dynamic JSON-LD content
- expose cached sitemap and robots endpoints and rewrite /sitemap.xml and /robots.txt to the API
- compress preview assets to WebP and register new SEO routes in the API router

## Testing
- npm test *(fails: Node.js 22 test runner cannot resolve installed `zod` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c899ac788327af9ca4bd86ce41d8