### PR TITLE
Fallback to legacy cart when Storefront token missing

### DIFF
--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -369,14 +369,6 @@ export default async function createCartLink(req, res) {
       });
     }
 
-    if (storefrontAttempt.reason === 'storefront_env_missing') {
-      return res.status(500).json({
-        ok: false,
-        error: 'shopify_storefront_env_missing',
-        missing: storefrontAttempt.missing,
-      });
-    }
-
     if (storefrontAttempt.reason === 'user_errors') {
       const detailMessages = (storefrontAttempt.userErrors || [])
         .map((err) => (typeof err?.message === 'string' ? err.message.trim() : ''))
@@ -389,7 +381,10 @@ export default async function createCartLink(req, res) {
       });
     }
 
-    if (storefrontAttempt.reason && storefrontAttempt.reason !== 'missing_variant_gid') {
+    if (
+      storefrontAttempt.reason &&
+      !['missing_variant_gid', 'storefront_env_missing'].includes(storefrontAttempt.reason)
+    ) {
       try {
         console.error('create_cart_link_storefront_failed', {
           reason: storefrontAttempt.reason,


### PR DESCRIPTION
## Summary
- allow the create-cart-link handler to fall back to the legacy cart flow when the Storefront token is not configured
- avoid logging an error for the expected storefront-env-missing fallback and cover it with a regression test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0cde453d083278ab08ef82ba3ad55