### PR TITLE
Enable private checkout via draft order invoices

### DIFF
--- a/lib/handlers/createCheckout.js
+++ b/lib/handlers/createCheckout.js
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { getPublicStorefrontBase } from '../publicStorefront.js';
-import { getShopifySalesChannel } from '../shopify.js';
+import { getShopifySalesChannel, shopifyAdmin } from '../shopify.js';
 import { parseJsonBody } from '../_lib/http.js';
 
 function normalizeVariantId(value) {
@@ -18,8 +18,70 @@ const BodySchema = z
     variantGid: z.union([z.string(), z.number()]).optional(),
     quantity: z.union([z.string(), z.number()]).optional(),
     email: z.string().email().optional(),
+    mode: z.enum(['checkout', 'cart', 'private']).optional(),
   })
   .passthrough();
+
+function parseVariantNumericId(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) return null;
+  return Math.floor(numeric);
+}
+
+async function createDraftOrderCheckout({ variantId, quantity, email }) {
+  const numericVariantId = parseVariantNumericId(variantId);
+  if (!numericVariantId) {
+    return { ok: false, reason: 'invalid_variant' };
+  }
+
+  const payload = {
+    draft_order: {
+      line_items: [
+        {
+          variant_id: numericVariantId,
+          quantity,
+        },
+      ],
+      use_customer_default_address: true,
+      tags: 'mgm_private_checkout',
+      note_attributes: [
+        { name: 'mgm_source', value: 'editor' },
+      ],
+    },
+  };
+
+  if (email) {
+    payload.draft_order.email = email;
+  }
+
+  const resp = await shopifyAdmin('draft_orders.json', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  const json = await resp.json().catch(() => null);
+  if (!resp.ok) {
+    return {
+      ok: false,
+      reason: 'draft_order_http_error',
+      status: resp.status,
+      detail: typeof json === 'object' ? json : undefined,
+    };
+  }
+
+  const invoiceUrl = json?.draft_order?.invoice_url;
+  if (!invoiceUrl) {
+    return { ok: false, reason: 'missing_invoice_url', detail: json };
+  }
+
+  return {
+    ok: true,
+    url: invoiceUrl,
+    draftOrderId: json?.draft_order?.id,
+    draftOrderName: json?.draft_order?.name,
+  };
+}
 
 export default async function createCheckout(req, res) {
   if (req.method !== 'POST') {
@@ -44,13 +106,48 @@ export default async function createCheckout(req, res) {
     if (!parsed.success) {
       return res.status(400).json({ ok: false, error: 'invalid_body', issues: parsed.error.flatten().fieldErrors });
     }
-    const { variantId, variantGid, quantity, email } = parsed.data;
+    const { variantId, variantGid, quantity, email, mode } = parsed.data;
     const normalizedVariantId = normalizeVariantId(variantId ?? variantGid);
     if (!normalizedVariantId) return res.status(400).json({ ok: false, error: 'missing_variant' });
     const qtyRaw = Number(quantity);
     const qty = Number.isFinite(qtyRaw) && qtyRaw > 0 ? Math.min(Math.floor(qtyRaw), 99) : 1;
     const base = getPublicStorefrontBase();
     if (!base) return res.status(500).json({ ok: false, error: 'missing_store_domain' });
+
+    const normalizedEmail = typeof email === 'string' ? email.trim() : '';
+
+    if (mode === 'private') {
+      if (!normalizedEmail) {
+        return res.status(400).json({ ok: false, error: 'missing_email' });
+      }
+      try {
+        const draftCheckout = await createDraftOrderCheckout({
+          variantId: normalizedVariantId,
+          quantity: qty,
+          email: normalizedEmail,
+        });
+        if (!draftCheckout?.ok || !draftCheckout?.url) {
+          return res.status(502).json({
+            ok: false,
+            error: draftCheckout?.reason || 'draft_order_failed',
+            detail: draftCheckout?.detail,
+            status: draftCheckout?.status,
+          });
+        }
+        return res.status(200).json({
+          ok: true,
+          url: draftCheckout.url,
+          draft_order_id: draftCheckout.draftOrderId,
+          draft_order_name: draftCheckout.draftOrderName,
+        });
+      } catch (err) {
+        if (err?.message === 'SHOPIFY_ENV_MISSING') {
+          return res.status(400).json({ ok: false, error: 'shopify_env_missing', missing: err?.missing });
+        }
+        console.error('create_checkout_draft_order_error', err);
+        return res.status(500).json({ ok: false, error: 'draft_order_failed' });
+      }
+    }
 
     let checkoutUrl;
     try {
@@ -62,7 +159,6 @@ export default async function createCheckout(req, res) {
 
     const checkoutChannel = getShopifySalesChannel('checkout');
     if (checkoutChannel) checkoutUrl.searchParams.set('channel', checkoutChannel);
-    const normalizedEmail = typeof email === 'string' ? email.trim() : '';
     if (normalizedEmail) {
       checkoutUrl.searchParams.set('checkout[email]', normalizedEmail);
     }

--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -180,6 +180,8 @@ export async function createJobAndProduct(mode: 'checkout' | 'cart' | 'private',
     variantId?: string;
     productUrl?: string;
     visibility: 'public' | 'private';
+    draftOrderId?: string;
+    draftOrderName?: string;
   } = {
     productId,
     variantId,
@@ -197,6 +199,7 @@ export async function createJobAndProduct(mode: 'checkout' | 'cart' | 'private',
           variantId,
           quantity: 1,
           ...(customerEmail ? { email: customerEmail } : {}),
+          ...(isPrivate ? { mode: 'private' as const } : { mode: mode }),
         }),
       });
       const ck = await ckResp.json().catch(() => null);
@@ -204,6 +207,12 @@ export async function createJobAndProduct(mode: 'checkout' | 'cart' | 'private',
         throw new Error('checkout_link_failed');
       }
       result.checkoutUrl = ck.url;
+      if (ck.draft_order_id) {
+        result.draftOrderId = String(ck.draft_order_id);
+      }
+      if (ck.draft_order_name) {
+        result.draftOrderName = String(ck.draft_order_name);
+      }
     } else {
       const clResp = await apiFetch('/api/create-cart-link', {
         method: 'POST',
@@ -255,6 +264,8 @@ export async function createJobAndProduct(mode: 'checkout' | 'cart' | 'private',
         productUrl: publish.productUrl,
         productHandle: publish.productHandle,
         visibility: result.visibility,
+        draftOrderId: result.draftOrderId,
+        draftOrderName: result.draftOrderName,
       },
     });
   }

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -108,7 +108,7 @@ export default function Mockup() {
       else if (reasonRaw === 'missing_variant') friendly = 'No se pudo obtener la variante del producto creado en Shopify.';
       else if (reasonRaw === 'cart_link_failed') friendly = 'No se pudo generar el enlace del carrito. Revisá la configuración de Shopify.';
       else if (reasonRaw === 'checkout_link_failed') friendly = 'No se pudo generar el enlace de compra.';
-      else if (reasonRaw === 'missing_customer_email') friendly = 'Completá un correo electrónico válido para comprar en privado.';
+      else if (reasonRaw === 'missing_customer_email' || reasonRaw === 'missing_email') friendly = 'Completá un correo electrónico válido para comprar en privado.';
       else if (reasonRaw.startsWith('publish_failed')) friendly = 'Shopify rechazó la creación del producto. Revisá los datos enviados.';
       else if (reasonRaw === 'shopify_error') friendly = 'Shopify devolvió un error al crear el producto.';
       else if (reasonRaw === 'shopify_env_missing') {

--- a/mgm-front/src/state/flow.tsx
+++ b/mgm-front/src/state/flow.tsx
@@ -22,6 +22,8 @@ export type FlowState = {
     productUrl?: string;
     productHandle?: string;
     visibility?: 'public' | 'private';
+    draftOrderId?: string;
+    draftOrderName?: string;
   };
   set: (p: Partial<FlowState>) => void;
   reset: () => void;


### PR DESCRIPTION
## Summary
- add a Shopify draft order flow to `POST /api/create-checkout` when the caller requests a private checkout
- update the editor frontend to request the private draft order checkout and persist returned draft order metadata
- improve the private purchase error message when the customer email is missing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0ce6f56b883278ef6ed509ee273b6