### PR TITLE
Apply private purchase markup to product price

### DIFF
--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -93,8 +93,8 @@ export async function createJobAndProduct(mode: 'checkout' | 'cart' | 'private',
   const widthCm = safeNumber((flow.editorState as any)?.size_cm?.w);
   const heightCm = safeNumber((flow.editorState as any)?.size_cm?.h);
   const approxDpi = safeNumber(flow.approxDpi);
-  const priceTransfer = safeNumber(flow.priceTransfer);
-  const priceNormal = safeNumber(flow.priceNormal);
+  const priceTransferRaw = safeNumber(flow.priceTransfer);
+  const priceNormalRaw = safeNumber(flow.priceNormal);
   const priceCurrencyRaw = typeof flow.priceCurrency === 'string' ? flow.priceCurrency : 'ARS';
   const priceCurrency = priceCurrencyRaw.trim() || 'ARS';
   const measurementLabel = formatMeasurement(widthCm, heightCm);
@@ -115,6 +115,19 @@ export async function createJobAndProduct(mode: 'checkout' | 'cart' | 'private',
   const customerEmail = typeof flow.customerEmail === 'string' ? flow.customerEmail.trim() : '';
   const isPrivate = mode === 'private';
   const requestedVisibility: 'public' | 'private' = isPrivate ? 'private' : 'public';
+
+  let priceTransfer = priceTransferRaw;
+  let priceNormal = priceNormalRaw;
+
+  if (isPrivate) {
+    const markupFactor = 1.25;
+    const applyMarkup = (value?: number) => {
+      if (typeof value !== 'number') return value;
+      return Math.round(value * markupFactor * 100) / 100;
+    };
+    priceTransfer = applyMarkup(priceTransferRaw);
+    priceNormal = applyMarkup(priceNormalRaw);
+  }
 
   if (isPrivate) {
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;


### PR DESCRIPTION
## Summary
- apply a 25% markup when publishing Shopify products for private purchases so the draft uses the higher price

## Testing
- npm --prefix mgm-front run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d42cb5588327844209af0d195a67