### PR TITLE
feat: redesign home editor layout

### DIFF
--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -96,47 +96,13 @@
   cursor: crosshair;
 }
 
-.toolbar {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  margin-bottom: 8px;
-  flex-wrap: wrap;
-}
-
-.colorWrapper {
-  position: relative;
-  display: inline-flex;
-  gap: 8px;
-  align-items: center;
-}
-
-.colorPopoverWrap {
-  position: absolute;
-  z-index: 20;
-  top: 100%;
-  left: 0;
-  margin-top: 8px;
-}
-
-.qualityBadge {
-  padding: 6px 10px;
-  border-radius: 999px;
-  margin-left: auto;
-}
-
-.qualityUnknown { background: #9ca3af22; color: #9ca3af; border: 1px solid #9ca3af; }
-.qualityBad { background: #ef444422; color: #ef4444; border: 1px solid #ef4444; }
-.qualityWarn { background: #f59e0b22; color: #f59e0b; border: 1px solid #f59e0b; }
-.qualityOk { background: #10b98122; color: #10b981; border: 1px solid #10b981; }
-
 .canvasWrapper {
   width: 100%;
-  height: 70vh;
-  border: 1px solid #ddd;
-  border-radius: 8px;
+  min-height: 460px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 18px;
   overflow: hidden;
-  background: #f3f4f6;
+  background: radial-gradient(circle at 50% 20%, rgba(148, 163, 184, 0.15), rgba(15, 23, 42, 0.85));
   position: relative;
   cursor: default;
 }
@@ -147,13 +113,14 @@
 
 .undoButton {
   position: absolute;
-  top: 8px;
-  left: 8px;
+  top: 12px;
+  left: 12px;
   z-index: 20;
-  padding: 4px 8px;
-  border-radius: 6px;
-  border: 1px solid #d1d5db;
-  background: #fff;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
 }
 
 .undoButton:disabled {
@@ -218,5 +185,3 @@ pre, code {
   word-break: break-word;
 }
 
-/* Opcional (parche temporal mientras depurás): recorta overflow global horizontal
-   ÚSALO SOLO si aún tenés otros desbordes externos al toolbar */

--- a/mgm-front/src/components/SizeControls.module.css
+++ b/mgm-front/src/components/SizeControls.module.css
@@ -1,18 +1,66 @@
 .container {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 8px;
-  margin-bottom: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.container label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: #e2e8f0;
+}
+
+.container select,
+.container input {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 12px;
+  padding: 10px 12px;
+  color: #f8fafc;
+  font-size: 0.95rem;
+}
+
+.container select:focus,
+.container input:focus {
+  outline: 2px solid #38bdf8;
+  border-color: transparent;
 }
 
 .presets {
   grid-column: 1 / -1;
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.presets button {
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  color: #e2e8f0;
+  padding: 8px 12px;
+  border-radius: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.presets button:not(:disabled):hover,
+.presets button:not(:disabled):focus-visible {
+  background: rgba(99, 102, 241, 0.2);
+  border-color: rgba(99, 102, 241, 0.6);
+  transform: translateY(-1px);
+}
+
+.presets button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .helper {
   grid-column: 1 / -1;
-  color: #6b7280;
+  font-size: 0.78rem;
+  color: #94a3b8;
 }

--- a/mgm-front/src/components/UploadStep.module.css
+++ b/mgm-front/src/components/UploadStep.module.css
@@ -1,11 +1,40 @@
 .container {
-  margin-bottom: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  position: relative;
 }
 
 .hiddenInput {
   display: none;
 }
 
+.container button {
+  border-radius: 14px;
+  border: none;
+  padding: 12px 20px;
+  background: linear-gradient(135deg, #38bdf8 0%, #6366f1 50%, #9333ea 100%);
+  color: #0f172a;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.container button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.container button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(99, 102, 241, 0.35);
+}
+
 .error {
   margin-top: 6px;
+  font-size: 0.85rem;
 }

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -1,33 +1,340 @@
 .container {
-  display: flex;
-  gap: 16px;
+  min-height: 100vh;
+  padding: 32px;
+  background: radial-gradient(circle at 0% 0%, #1e293b 0%, #0b1120 55%, #020617 100%);
+  color: #f8fafc;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 32px;
+  max-width: 1400px;
+  margin: 0 auto;
 }
 
 .sidebar {
-  width: 260px;
-  padding: 16px;
-  background: #2b2b2b;
-  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
 }
 
-.field {
-  margin-bottom: 12px;
+.accordion {
+  background: rgba(15, 23, 42, 0.85);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  padding: 0;
+  overflow: hidden;
+  backdrop-filter: blur(12px);
 }
 
-.main {
-  flex: 1;
-  padding: 16px;
+.accordionTitle {
+  margin: 0;
+  padding: 18px 24px;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #94a3b8;
+  list-style: none;
+  cursor: pointer;
 }
 
-.ackLabel {
-  display: block;
-  margin-top: 12px;
+.accordionTitle::-webkit-details-marker,
+.accordionTitle::marker {
+  display: none;
 }
 
-.continueButton {
-  margin-top: 12px;
+.accordion[open] > .accordionTitle {
+  color: #f8fafc;
+}
+
+.accordionContent {
+  padding: 22px 24px 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.fieldLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.95rem;
+  color: #e2e8f0;
+}
+
+.fieldLabel input {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 12px;
+  padding: 12px 14px;
+  color: #f8fafc;
+  font-size: 1rem;
+}
+
+.fieldLabel input:focus {
+  outline: 2px solid #38bdf8;
+  border-color: transparent;
+}
+
+.priceBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(148, 163, 184, 0.1);
+}
+
+.priceLabel {
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #94a3b8;
+}
+
+.priceBlock :global(.p-calcu) {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.priceBlock :global(.minitext) {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #cbd5f5;
+}
+
+.qualityBadge {
+  align-self: flex-start;
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.qualityNeutral {
+  background: rgba(148, 163, 184, 0.2);
+  color: #e2e8f0;
+}
+
+.qualityExcellent {
+  background: rgba(34, 197, 94, 0.18);
+  color: #4ade80;
+}
+
+.qualityGood {
+  background: rgba(234, 179, 8, 0.18);
+  color: #facc15;
+}
+
+.qualityLow {
+  background: rgba(248, 113, 113, 0.18);
+  color: #f87171;
+}
+
+.ackField {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 0.9rem;
+  color: #e2e8f0;
+}
+
+.ackField input {
+  margin-top: 4px;
+}
+
+.primaryButton {
+  padding: 14px 18px;
+  border-radius: 16px;
+  border: none;
+  background: linear-gradient(135deg, #38bdf8 0%, #6366f1 50%, #9333ea 100%);
+  color: #0f172a;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primaryButton:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(99, 102, 241, 0.35);
+}
+
+.primaryButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 .error {
-  margin-top: 6px;
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.main {
+  display: flex;
+}
+
+.canvasCard {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding: 28px;
+  border-radius: 28px;
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  box-shadow: 0 28px 60px rgba(7, 11, 25, 0.55);
+  backdrop-filter: blur(14px);
+}
+
+.uploadSection {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.uploadCopy {
+  max-width: 420px;
+}
+
+.headline {
+  margin: 0;
+  font-size: 1.9rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.subhead {
+  margin: 6px 0 0;
+  font-size: 0.95rem;
+  color: #94a3b8;
+}
+
+.actionsSection {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.actionGroups {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.actionRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.actionButton {
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(148, 163, 184, 0.14);
+  color: #e2e8f0;
+  padding: 10px 16px;
+  border-radius: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.actionButton:not(:disabled):hover,
+.actionButton:not(:disabled):focus-visible {
+  background: rgba(99, 102, 241, 0.2);
+  border-color: rgba(99, 102, 241, 0.6);
+  transform: translateY(-1px);
+}
+
+.actionButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.containWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.popoverAnchor {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 0;
+  z-index: 40;
+}
+
+.canvasStage {
+  padding: 16px;
+  border-radius: 20px;
+  background: rgba(10, 15, 28, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+@media (max-width: 1024px) {
+  .layout {
+    grid-template-columns: 280px 1fr;
+    gap: 26px;
+  }
+
+  .canvasCard {
+    padding: 24px;
+  }
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 24px 16px;
+  }
+
+  .layout {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  .sidebar {
+    order: 2;
+  }
+
+  .main {
+    order: 1;
+  }
+
+  .canvasCard {
+    border-radius: 24px;
+    gap: 24px;
+  }
+
+  .accordionTitle {
+    font-size: 1rem;
+  }
+}
+
+@media (max-width: 560px) {
+  .uploadSection {
+    align-items: flex-start;
+  }
+
+  .actionRow {
+    gap: 8px;
+  }
 }


### PR DESCRIPTION
## Summary
- Implemented `BUTTON_MAP` with the action groups, color picker workflow, and responsive layout that mirror the Figma design in `Home.jsx`. 
- Exposed canvas actions (including `rotate`, `mirrorX`, `mirrorY`), background color helpers, and flip-aware rendering via `EditorCanvas.jsx`, plus refreshed canvas styling.
- Restyled supporting components (`SizeControls` and `UploadStep`) to fit the dark home layout.

## Outstanding TODOs
- None.

## Testing Notes
- `npm run lint` *(fails: script not defined in package.json)*

## Follow-up Work / Potential Issues
- The new action buttons rely on the exposed editor methods; verify the canvas transformations visually to confirm they behave as expected.
- Consider wiring up a lint/test workflow so automated checks can run in CI.
- No new automated tests were added—consider coverage for layout responsiveness and action dispatch logic in future iterations.

------
https://chatgpt.com/codex/tasks/task_e_68d0d313e9ac83278d1747e870f28134