### PR TITLE
Refine editor controls and add configuration accordion

### DIFF
--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -145,23 +145,51 @@
   cursor: grabbing;
 }
 
-.undoButton {
+.historyControls {
   position: absolute;
-  top: 8px;
-  left: 8px;
+  top: 12px;
+  left: 12px;
   z-index: 20;
-  padding: 4px 8px;
+  display: flex;
+  gap: 8px;
+}
+
+.historyButton {
+  padding: 6px 12px;
   border-radius: 6px;
   border: 1px solid #d1d5db;
-  background: #fff;
-}
-
-.undoButton:disabled {
-  cursor: not-allowed;
-}
-
-.undoButton:not(:disabled) {
+  background: #ffffff;
+  color: #1f2937;
+  font-size: 13px;
   cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.historyButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.historyButton:not(:disabled):hover {
+  background: #111827;
+  color: #ffffff;
+  border-color: #111827;
+}
+
+.historyButton:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.historyButtonDanger {
+  border-color: #ef4444;
+  color: #ef4444;
+  background: #fff5f5;
+}
+
+.historyButtonDanger:not(:disabled):hover {
+  background: #ef4444;
+  color: #ffffff;
 }
 
 .spinnerOverlay {

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -14,6 +14,69 @@
   margin-bottom: 12px;
 }
 
+.configAccordion {
+  border: 1px solid #3b3b3b;
+  border-radius: 12px;
+  background: #1f1f1f;
+  color: #f9fafb;
+  overflow: hidden;
+  transition: border-color 0.2s ease;
+}
+
+.configAccordionOpen {
+  border-color: #5f5f5f;
+}
+
+.configHeader {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.configHeader:focus-visible {
+  outline: 2px solid #9ca3af;
+  outline-offset: 2px;
+}
+
+.configIcon {
+  font-size: 16px;
+}
+
+.configTitle {
+  flex: 1;
+  text-align: left;
+  font-weight: 600;
+}
+
+.configArrow {
+  transition: transform 0.2s ease;
+  font-size: 14px;
+}
+
+.configArrowOpen {
+  transform: rotate(180deg);
+}
+
+.configContent {
+  padding: 16px;
+  background: #262626;
+  border-top: 1px solid #3b3b3b;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.configContent .field {
+  margin-bottom: 0;
+}
+
 .main {
   flex: 1;
   padding: 16px;


### PR DESCRIPTION
## Summary
- hide the editor canvas until an image is uploaded and wrap the design inputs in a collapsible configuration panel
- extend the editor with undo/redo/reset controls, mirror and rotate actions, and include flip metadata in exported layouts
- adjust component styles for the accordion and the new history control buttons

## Testing
- npx eslint src/pages/Home.jsx src/components/EditorCanvas.jsx
- npm run lint *(fails: repository contains pre-existing lint issues outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1647a4eb08327b8a09eafc01e167a