### PR TITLE
feat: actualiza estilos del configurador

### DIFF
--- a/mgm-front/public/icons/down.svg
+++ b/mgm-front/public/icons/down.svg
@@ -1,0 +1,9 @@
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M5 9.5L12 16.5L19 9.5" stroke="url(#gradient)" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" />
+  <defs>
+    <linearGradient id="gradient" x1="6" y1="8" x2="18" y2="18" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#C7CBFF" />
+      <stop offset="1" stop-color="#7C83FF" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/mgm-front/public/icons/wheel.svg
+++ b/mgm-front/public/icons/wheel.svg
@@ -1,0 +1,19 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="url(#gradient)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="12" r="4.5" />
+    <path d="M12 2.25V5.4" />
+    <path d="M12 18.6V21.75" />
+    <path d="M2.25 12H5.4" />
+    <path d="M18.6 12H21.75" />
+    <path d="M5.45 5.45L7.6 7.6" />
+    <path d="M16.4 16.4L18.55 18.55" />
+    <path d="M5.45 18.55L7.6 16.4" />
+    <path d="M16.4 7.6L18.55 5.45" />
+  </g>
+  <defs>
+    <linearGradient id="gradient" x1="5" y1="4" x2="19" y2="20" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#C7CBFF" />
+      <stop offset="1" stop-color="#7C83FF" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/mgm-front/src/components/SizeControls.jsx
+++ b/mgm-front/src/components/SizeControls.jsx
@@ -63,56 +63,80 @@ export default function SizeControls({ material, size, onChange, locked = false 
 
   return (
     <div className={styles.container}>
-      <label>Material
-        <select
-          value={material}
-          onChange={(e) => onChange({ material: e.target.value })}
-        >
-          <option>Classic</option>
-          <option>PRO</option>
-          <option>Glasspad</option>
-        </select>
-      </label>
+      <div className={styles.section}>
+        <span className={styles.groupLabel}>Medidas (cm)</span>
+        <div className={styles.dimensionsRow}>
+          <label className={styles.inputLabel}>
+            Largo
+            <div className={styles.inputControl}>
+              <input
+                className={styles.input}
+                value={isGlasspad ? GLASSPAD_SIZE_CM.w : wText}
+                onChange={!isGlasspad ? handleWChange : undefined}
+                onBlur={!isGlasspad ? handleWBlur : undefined}
+                inputMode="decimal"
+                pattern="[0-9]*"
+                disabled={locked || isGlasspad}
+              />
+            </div>
+          </label>
+          <label className={styles.inputLabel}>
+            Ancho
+            <div className={styles.inputControl}>
+              <input
+                className={styles.input}
+                value={isGlasspad ? GLASSPAD_SIZE_CM.h : hText}
+                onChange={!isGlasspad ? handleHChange : undefined}
+                onBlur={!isGlasspad ? handleHBlur : undefined}
+                inputMode="decimal"
+                pattern="[0-9]*"
+                disabled={locked || isGlasspad}
+              />
+            </div>
+          </label>
+        </div>
 
-      <label>Ancho (cm)
-        <input
-          value={isGlasspad ? GLASSPAD_SIZE_CM.w : wText}
-          onChange={!isGlasspad ? handleWChange : undefined}
-          onBlur={!isGlasspad ? handleWBlur : undefined}
-          inputMode="decimal"
-          pattern="[0-9]*"
-          disabled={locked || isGlasspad}
-        />
-      </label>
+        {presets.length > 0 && (
+          <div className={styles.presets}>
+            {presets.map(p => (
+              <button
+                key={`${p.w}x${p.h}`}
+                type="button"
+                className={styles.presetButton}
+                onClick={() => applyPreset(p.w, p.h)}
+                disabled={locked}
+              >
+                {p.w}×{p.h}
+              </button>
+            ))}
+          </div>
+        )}
 
-      <label>Alto (cm)
-        <input
-          value={isGlasspad ? GLASSPAD_SIZE_CM.h : hText}
-          onChange={!isGlasspad ? handleHChange : undefined}
-          onBlur={!isGlasspad ? handleHBlur : undefined}
-          inputMode="decimal"
-          pattern="[0-9]*"
-          disabled={locked || isGlasspad}
-        />
-      </label>
+        {!locked && !isGlasspad && (
+          <p className={styles.helper}>
+            Máximo {limits.maxW}×{limits.maxH} cm para {material}
+          </p>
+        )}
 
-      <div className={styles.presets}>
-        {presets.map(p => (
-          <button key={`${p.w}x${p.h}`} onClick={() => applyPreset(p.w, p.h)} disabled={locked}>
-            {p.w}×{p.h}
-          </button>
-        ))}
+        {locked && (
+          <p className={styles.helper}>Medida fija {GLASSPAD_SIZE_CM.w}×{GLASSPAD_SIZE_CM.h} cm</p>
+        )}
       </div>
 
-      {!locked && !isGlasspad && (
-        <small className={styles.helper}>
-          Máximo {limits.maxW}×{limits.maxH} cm para {material}
-        </small>
-      )}
-
-      {locked && (
-        <small className={styles.helper}>Medida fija {GLASSPAD_SIZE_CM.w}×{GLASSPAD_SIZE_CM.h} cm</small>
-      )}
+      <label className={`${styles.section} ${styles.selectSection}`}>
+        <span className={styles.groupLabel}>Serie</span>
+        <div className={styles.selectControl}>
+          <select
+            className={styles.select}
+            value={material}
+            onChange={(e) => onChange({ material: e.target.value })}
+          >
+            <option>Classic</option>
+            <option>PRO</option>
+            <option>Glasspad</option>
+          </select>
+        </div>
+      </label>
     </div>
   );
 }

--- a/mgm-front/src/components/SizeControls.module.css
+++ b/mgm-front/src/components/SizeControls.module.css
@@ -1,18 +1,136 @@
 .container {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.groupLabel {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: #cbd5f5;
+}
+
+.dimensionsRow {
+  display: flex;
+  gap: 16px;
+}
+
+.inputLabel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
   gap: 8px;
-  margin-bottom: 10px;
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.inputControl {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid #2f2f35;
+  background: linear-gradient(180deg, rgba(26, 26, 30, 0.85), rgba(18, 18, 22, 0.95));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.input {
+  flex: 1;
+  font-size: 1rem;
+  font-weight: 500;
+  border: none;
+  background: transparent;
+  color: #f4f5f7;
+  outline: none;
+}
+
+.input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .presets {
-  grid-column: 1 / -1;
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 8px;
+}
+
+.presetButton {
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid #2d2d33;
+  background: rgba(20, 20, 24, 0.9);
+  color: #f4f4f5;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.presetButton:hover:not(:disabled) {
+  border-color: #4f46e5;
+  transform: translateY(-1px);
+}
+
+.presetButton:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .helper {
-  grid-column: 1 / -1;
+  margin: 0;
+  font-size: 0.75rem;
   color: #6b7280;
+}
+
+.selectSection {
+  gap: 12px;
+}
+
+.selectControl {
+  position: relative;
+  display: flex;
+  align-items: center;
+  border-radius: 12px;
+  border: 1px solid #2f2f35;
+  background: linear-gradient(180deg, rgba(26, 26, 30, 0.85), rgba(18, 18, 22, 0.95));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  padding: 8px 16px;
+}
+
+.selectControl::after {
+  content: '';
+  position: absolute;
+  right: 16px;
+  width: 12px;
+  height: 12px;
+  background: url('/icons/down.svg') center / contain no-repeat;
+  pointer-events: none;
+  transform: rotate(0deg);
+}
+
+.select {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: #f4f5f7;
+  font-size: 1rem;
+  font-weight: 600;
+  appearance: none;
+  outline: none;
+  padding: 8px 0;
+}
+
+.select option {
+  color: #111827;
 }

--- a/mgm-front/src/globals.css
+++ b/mgm-front/src/globals.css
@@ -1,5 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap');
+
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Poppins', sans-serif;
   line-height: 1.5;
   font-weight: 400;
   color: #f5f5f5;

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -6,7 +6,6 @@ import SeoJsonLd from '../components/SeoJsonLd';
 import UploadStep from '../components/UploadStep';
 import EditorCanvas from '../components/EditorCanvas';
 import SizeControls from '../components/SizeControls';
-import Calculadora from '../components/Calculadora';
 import LoadingOverlay from '../components/LoadingOverlay';
 
 import { LIMITS, STANDARD, GLASSPAD_SIZE_CM } from '../lib/material.js';
@@ -281,21 +280,31 @@ export default function Home() {
               className={styles.configHeader}
               onClick={() => setConfigOpen(open => !open)}
             >
-              <span className={styles.configIcon} aria-hidden="true">⚙️</span>
-              <span className={styles.configTitle}>Configura tu mousepad</span>
-              <span
-                className={`${styles.configArrow} ${configOpen ? styles.configArrowOpen : ''}`}
-                aria-hidden="true"
-              >
-                ▾
+              <span className={styles.configHeaderLeft}>
+                <img
+                  src="/icons/wheel.svg"
+                  alt=""
+                  className={styles.configIcon}
+                  aria-hidden="true"
+                />
+                <span className={styles.configTitle}>Configura tu mousepad</span>
               </span>
+              <img
+                src="/icons/down.svg"
+                alt=""
+                className={`${styles.configArrowIcon} ${configOpen ? styles.configArrowIconOpen : ''}`}
+                aria-hidden="true"
+              />
             </button>
             {configOpen && (
               <div className={styles.configContent}>
                 <div className={styles.field}>
+                  <label className={styles.fieldLabel} htmlFor="design-name">Nombre de tu diseño</label>
                   <input
                     type="text"
-                    placeholder="Nombre del modelo"
+                    id="design-name"
+                    className={styles.textInput}
+                    placeholder="Ej: Nubes y cielo rosa"
                     value={designName}
                     onChange={e => setDesignName(e.target.value)}
                   />
@@ -306,12 +315,6 @@ export default function Home() {
                   mode={mode}
                   onChange={handleSizeChange}
                   locked={material === 'Glasspad'}
-                />
-                <Calculadora
-                  width={activeWcm}
-                  height={activeHcm}
-                  material={material}
-                  setPrice={setPriceAmount}
                 />
               </div>
             )}
@@ -349,7 +352,7 @@ export default function Home() {
         {uploaded && (
           <button
             className={styles.continueButton}
-            disabled={busy || priceAmount <= 0 || trimmedDesignName.length < 2}
+            disabled={busy || trimmedDesignName.length < 2}
             onClick={handleContinue}
           >
             Continuar

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -1,80 +1,126 @@
+
 .container {
   display: flex;
-  gap: 16px;
+  gap: 32px;
+  align-items: flex-start;
 }
 
 .sidebar {
-  width: 260px;
-  padding: 16px;
-  background: #2b2b2b;
-  border-radius: 8px;
-}
-
-.field {
-  margin-bottom: 12px;
+  width: 360px;
+  padding: 8px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .configAccordion {
-  border: 1px solid #3b3b3b;
-  border-radius: 12px;
-  background: #1f1f1f;
+  border: 1px solid #252530;
+  border-radius: 20px;
+  background: linear-gradient(180deg, rgba(20, 20, 24, 0.92), rgba(14, 14, 18, 0.98));
   color: #f9fafb;
   overflow: hidden;
-  transition: border-color 0.2s ease;
+  box-shadow: 0 20px 40px rgba(8, 8, 12, 0.45);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .configAccordionOpen {
-  border-color: #5f5f5f;
+  border-color: #3f3f4d;
+  box-shadow: 0 24px 44px rgba(12, 12, 20, 0.55);
 }
 
 .configHeader {
   width: 100%;
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px 16px;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 20px 24px;
   border: none;
   background: transparent;
   color: inherit;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 1rem;
+  font-weight: 600;
 }
 
 .configHeader:focus-visible {
-  outline: 2px solid #9ca3af;
-  outline-offset: 2px;
+  outline: 2px solid #6366f1;
+  outline-offset: 4px;
+}
+
+.configHeaderLeft {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
 }
 
 .configIcon {
-  font-size: 16px;
+  width: 22px;
+  height: 22px;
+  filter: drop-shadow(0 0 6px rgba(99, 102, 241, 0.25));
 }
 
 .configTitle {
   flex: 1;
   text-align: left;
+  color: #f5f7ff;
   font-weight: 600;
 }
 
-.configArrow {
+.configArrowIcon {
+  width: 16px;
+  height: 16px;
   transition: transform 0.2s ease;
-  font-size: 14px;
 }
 
-.configArrowOpen {
+.configArrowIconOpen {
   transform: rotate(180deg);
 }
 
 .configContent {
-  padding: 16px;
-  background: #262626;
-  border-top: 1px solid #3b3b3b;
+  padding: 24px;
+  background: rgba(10, 10, 14, 0.92);
+  border-top: 1px solid rgba(63, 63, 77, 0.6);
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 24px;
 }
 
-.configContent .field {
-  margin-bottom: 0;
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.fieldLabel {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #cbd5f5;
+  font-weight: 600;
+}
+
+.textInput {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid #2f2f35;
+  background: linear-gradient(180deg, rgba(26, 26, 30, 0.85), rgba(18, 18, 22, 0.95));
+  color: #f4f5f7;
+  font-size: 1rem;
+  font-weight: 500;
+  outline: none;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.textInput::placeholder {
+  color: #9da3b0;
+}
+
+.textInput:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
 }
 
 .main {


### PR DESCRIPTION
## Summary
- establece Poppins como tipografía global y aplica el nuevo estilo al acordeón de configuración
- añade los íconos de rueda y flecha en el encabezado del panel y ajusta los campos del formulario al nuevo diseño
- reestructura y estiliza los controles de medidas para que coincidan con la maqueta solicitada

## Testing
- npm run lint *(falla: el proyecto ya contenía múltiples errores de lint no relacionados con estos cambios)*

------
https://chatgpt.com/codex/tasks/task_e_68d170c7210483278334c31a7117b451