### PR TITLE
feat: refresh contain color picker styling

### DIFF
--- a/mgm-front/src/components/ColorPopover.jsx
+++ b/mgm-front/src/components/ColorPopover.jsx
@@ -2,6 +2,34 @@ import { useEffect, useRef, useState } from "react";
 import { HexColorPicker, HexColorInput } from "react-colorful";
 import styles from "./EditorCanvas.module.css";
 
+const iconModules = import.meta.glob("../icons/*.{svg,png}", {
+  eager: true,
+  import: "default",
+});
+
+const resolveIconAsset = (fileName) => {
+  const normalized = `../icons/${fileName}`;
+  const directMatch = iconModules[normalized];
+  if (directMatch) return directMatch;
+
+  const lower = fileName.toLowerCase();
+  if (lower.endsWith(".svg")) {
+    const pngKey = normalized.replace(/\.svg$/i, ".png");
+    if (iconModules[pngKey]) {
+      return iconModules[pngKey];
+    }
+  } else if (lower.endsWith(".png")) {
+    const svgKey = normalized.replace(/\.png$/i, ".svg");
+    if (iconModules[svgKey]) {
+      return iconModules[svgKey];
+    }
+  }
+
+  return `/icons/${fileName}`;
+};
+
+const EYEDROPPER_ICON = resolveIconAsset("tintero.svg");
+
 export default function ColorPopover({
   value,
   onChange,
@@ -10,8 +38,8 @@ export default function ColorPopover({
   onPickFromCanvas,
 }) {
   const boxRef = useRef(null);
-  const previewRef = useRef(null);
   const [hex, setHex] = useState(value || "#ffffff");
+  const [iconError, setIconError] = useState(false);
 
   useEffect(() => setHex(value || "#ffffff"), [value]);
 
@@ -31,10 +59,6 @@ export default function ColorPopover({
       document.removeEventListener("keydown", onKey);
     };
   }, [open, onClose]);
-
-  useEffect(() => {
-    if (previewRef.current) previewRef.current.style.background = hex;
-  }, [hex]);
 
   const swatches = [
     "#ffffff",
@@ -65,9 +89,10 @@ export default function ColorPopover({
         const ed = new window.EyeDropper();
         const { sRGBHex } = await ed.open();
         onChange?.(sRGBHex);
+        setHex(sRGBHex);
         return;
       }
-    } catch (err) {
+    } catch {
       // ignore
     }
     onPickFromCanvas?.();
@@ -78,58 +103,68 @@ export default function ColorPopover({
 
   return (
     <div ref={boxRef} className={styles.colorPopover}>
-      <HexColorPicker
-        color={hex}
-        onChange={(c) => {
-          setHex(c);
-          onChange?.(c);
-        }}
-        className={styles.colorPicker}
-      />
+      <div className={styles.colorPickerShell}>
+        <HexColorPicker
+          color={hex}
+          onChange={(c) => {
+            setHex(c);
+            onChange?.(c);
+          }}
+          className={styles.colorPicker}
+        />
+      </div>
+      <div className={styles.colorControls}>
+        <span
+          className={styles.previewDot}
+          style={{ background: hex }}
+          aria-hidden="true"
+        />
+        <div className={styles.hexField}>
+          <span className={styles.hexLabel}>Hex</span>
+          <HexColorInput
+            color={hex}
+            onChange={(c) => {
+              const v = c.startsWith("#") ? c : `#${c}`;
+              setHex(v);
+              onChange?.(v);
+            }}
+            prefixed
+            className={styles.hexInput}
+          />
+        </div>
+        <button
+          type="button"
+          title="Elegir del lienzo"
+          onClick={handlePick}
+          className={styles.eyedropperButton}
+        >
+          {iconError ? (
+            <span className={styles.eyedropperFallback} aria-hidden="true" />
+          ) : (
+            <img
+              src={EYEDROPPER_ICON}
+              alt="Tomar color del lienzo"
+              className={styles.eyedropperIcon}
+              onError={() => setIconError(true)}
+            />
+          )}
+        </button>
+      </div>
       <div className={styles.swatches}>
-        {swatches.map((c, i) => (
+        {swatches.map((c) => (
           <button
             key={c}
+            type="button"
             title={c}
             onClick={() => {
               setHex(c);
               onChange?.(c);
             }}
-            className={`${styles.swatch} ${styles["swatch" + i]}`}
+            className={styles.swatch}
+            style={{ background: c }}
+            data-selected={hex.toLowerCase() === c.toLowerCase()}
           />
         ))}
-      </div>
-      <div className={styles.colorControls}>
-        <div ref={previewRef} className={styles.colorPreview} />
-        <HexColorInput
-          color={hex}
-          onChange={(c) => {
-            const v = c.startsWith("#") ? c : `#${c}`;
-            setHex(v);
-            onChange?.(v);
-          }}
-          prefixed
-          className={styles.hexInput}
-        />
-        <button
-          title="Elegir del lienzo"
-          onClick={handlePick}
-          className={styles.eyedropperButton}
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M3 21l6.6-6.6" />
-            <path d="M8.5 2.5a3 3 0 0 1 4.2 4.2L7.5 12 4 8.5 8.5 2.5z" />
-          </svg>
-        </button>
       </div>
     </div>
   );

--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -1,86 +1,211 @@
 .colorPopover {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 12px;
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.12);
-  width: 260px;
+  gap: 16px;
+  padding: 18px;
+  width: 280px;
+  border-radius: 18px;
+  background: linear-gradient(155deg, #25252d 0%, #141418 100%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 55px rgba(0, 0, 0, 0.55);
+  color: #f9fafb;
+}
+
+.colorPickerShell {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .colorPicker {
   width: 100%;
-  border-radius: 12px;
 }
 
-.swatches {
-  display: grid;
-  grid-template-columns: repeat(10, 18px);
-  gap: 6px;
+.colorPicker :global(.react-colorful) {
+  width: 100%;
 }
 
-.swatch {
+.colorPicker :global(.react-colorful__saturation) {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 18px;
+  overflow: hidden;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 20px 40px rgba(0, 0, 0, 0.45);
+}
+
+.colorPicker :global(.react-colorful__saturation-pointer) {
   width: 18px;
   height: 18px;
-  border-radius: 6px;
-  cursor: pointer;
-  border: none;
+  border-radius: 999px;
+  border: 2px solid #ffffff;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
 }
 
-.swatch0 { background: #ffffff; border: 1px solid #e5e7eb; }
-.swatch1 { background: #000000; }
-.swatch2 { background: #f3f4f6; }
-.swatch3 { background: #e5e7eb; }
-.swatch4 { background: #d1d5db; }
-.swatch5 { background: #1f2937; }
-.swatch6 { background: #111827; }
-.swatch7 { background: #ff0000; }
-.swatch8 { background: #ff7f00; }
-.swatch9 { background: #ffb800; }
-.swatch10 { background: #ffe600; }
-.swatch11 { background: #00a859; }
-.swatch12 { background: #00c9a7; }
-.swatch13 { background: #00ccff; }
-.swatch14 { background: #0066ff; }
-.swatch15 { background: #6f42c1; }
-.swatch16 { background: #ff69b4; }
-.swatch17 { background: #8b4513; }
-.swatch18 { background: #808080; }
-.swatch19 { background: #333333; }
+.colorPicker :global(.react-colorful__hue) {
+  height: 14px;
+  border-radius: 999px;
+  margin-top: 16px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.colorPicker :global(.react-colorful__hue-pointer) {
+  width: 16px;
+  height: 16px;
+  border-radius: 6px;
+  border: 2px solid #ffffff;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.45);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(148, 163, 184, 0.9));
+}
 
 .colorControls {
   display: flex;
-  gap: 8px;
   align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 14px;
+  background: rgba(17, 17, 23, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
-.colorPreview {
-  width: 18px;
-  height: 18px;
-  border-radius: 6px;
-  border: 1px solid #e5e7eb;
+.previewDot {
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  border: 2px solid rgba(255, 255, 255, 0.95);
+  box-shadow:
+    0 0 0 4px rgba(255, 255, 255, 0.05),
+    0 10px 25px rgba(0, 0, 0, 0.45);
+  flex-shrink: 0;
 }
-.colorWrapper1 {
-  position: relative;           /* <- ancla local para posicionar el popover */
+
+.hexField {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  border-radius: 12px;
+  background: rgba(36, 36, 46, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    inset 0 -1px 0 rgba(15, 15, 20, 0.6);
+}
+
+.hexLabel {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(249, 250, 251, 0.65);
+  padding-right: 10px;
+  border-right: 1px solid rgba(249, 250, 251, 0.08);
 }
 
 .hexInput {
   flex: 1;
-  padding: 6px 8px;
-  border: 1px solid #e5e7eb;
-  border-radius: 10px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  padding: 0;
+  border: none;
+  background: none;
+  color: #f9fafb;
+  font-size: 15px;
+  font-family: "JetBrains Mono", "SFMono-Regular", Menlo, monospace;
+}
+
+.hexInput:focus {
+  outline: none;
+}
+
+.hexInput::placeholder {
+  color: rgba(249, 250, 251, 0.25);
 }
 
 .eyedropperButton {
-  border: 1px solid #e5e7eb;
-  background: #fff;
-  color: #111827;
-  padding: 6px 10px;
-  border-radius: 10px;
+  width: 42px;
+  height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: linear-gradient(160deg, rgba(148, 163, 184, 0.15), rgba(36, 36, 46, 0.6));
+  color: inherit;
   cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.eyedropperButton:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.5);
+}
+
+.eyedropperButton:active {
+  transform: translateY(0);
+}
+
+.eyedropperButton:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.85);
+  outline-offset: 3px;
+}
+
+.eyedropperIcon {
+  width: 22px;
+  height: 22px;
+  display: block;
+}
+
+.eyedropperFallback {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px dashed rgba(249, 250, 251, 0.5);
+}
+
+.swatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.swatch {
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0;
+  cursor: pointer;
+  position: relative;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.swatch:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(0, 0, 0, 0.45);
+}
+
+.swatch:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.85);
+  outline-offset: 3px;
+}
+
+.swatch[data-selected="true"] {
+  border-color: rgba(249, 250, 251, 0.9);
+  box-shadow: 0 18px 26px rgba(0, 0, 0, 0.5);
+}
+
+.swatch[data-selected="true"]::after {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: inherit;
+  border: 2px solid rgba(249, 250, 251, 0.95);
+}
+
+.colorWrapper1 {
+  position: relative;           /* <- ancla local para posicionar el popover */
 }
 
 .copyButton {

--- a/mgm-front/src/icons/tintero.svg
+++ b/mgm-front/src/icons/tintero.svg
@@ -1,0 +1,32 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="inkGradient" x1="6" y1="5" x2="19" y2="21" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FF6B6B" />
+      <stop offset="0.48" stop-color="#F43F5E" />
+      <stop offset="1" stop-color="#BE123C" />
+    </linearGradient>
+    <linearGradient id="inkHighlight" x1="9" y1="7" x2="15" y2="15" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFF5F5" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#FFF5F5" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <path
+    d="M12.028 2.5c-.224.333-5.528 7.178-5.528 11.238 0 3.802 3.044 6.762 6.8 6.762s6.8-2.96 6.8-6.762c0-4.06-5.304-10.905-5.528-11.238a.8.8 0 0 0-1.544 0Z"
+    fill="url(#inkGradient)"
+  />
+  <path
+    d="M9.35 13.35c0 1.945 1.73 3.525 3.95 3.525s3.95-1.58 3.95-3.525c0-1.666-1.582-3.635-3.091-5.63-.384-.518-1.334-.518-1.718 0-1.509 1.995-3.091 3.964-3.091 5.63Z"
+    fill="#0F172A"
+    fill-opacity="0.25"
+  />
+  <path
+    d="M14.05 7.392c.537.693 1.044 1.326 1.484 1.914a.6.6 0 0 1-.476.96H12.4c-.51 0-.798-.567-.502-.986.358-.511.733-1.045 1.115-1.593.322-.463.999-.468 1.337.006Z"
+    fill="url(#inkHighlight)"
+  />
+  <path
+    d="M9.1 19.45c.96.674 2.146 1.05 3.4 1.05 1.253 0 2.439-.376 3.4-1.05"
+    stroke="rgba(15, 23, 42, 0.35)"
+    stroke-width="1.2"
+    stroke-linecap="round"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- restyled the contain mode color popover to match the requested mock, including the new preview, hex field, and action layout
- refined react-colorful palette and swatch styling to deliver the dark in-app look and interactions
- added the missing inkwell icon asset for the eyedropper shortcut

## Testing
- npm run lint *(fails: repository already contains unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d179c91f448327b855ef1673ae7273