### PR TITLE
Use shared icon resolver for config controls

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -24,6 +24,7 @@ import ColorPopover from "./ColorPopover";
 import { buildSubmitJobBody, prevalidateSubmitBody } from "../lib/jobPayload";
 import { submitJob } from "../lib/submitJob";
 import { renderGlasspadPNG } from "../lib/renderGlasspadPNG";
+import { resolveIconAsset } from "@/lib/iconRegistry.js";
 
 const CM_PER_INCH = 2.54;
 const mmToCm = (mm) => mm / 10;
@@ -46,32 +47,6 @@ const CORNER_ANCHORS = new Set([
   "bottom-right",
 ]);
 
-
-const toolbarIconModules = import.meta.glob("../icons/*.{svg,png}", {
-  eager: true,
-  import: "default",
-});
-
-const resolveIconAsset = (fileName) => {
-  const normalized = `../icons/${fileName}`;
-  const directMatch = toolbarIconModules[normalized];
-  if (directMatch) return directMatch;
-
-  const lower = fileName.toLowerCase();
-  if (lower.endsWith(".svg")) {
-    const pngKey = normalized.replace(/\.svg$/i, ".png");
-    if (toolbarIconModules[pngKey]) {
-      return toolbarIconModules[pngKey];
-    }
-  } else if (lower.endsWith(".png")) {
-    const svgKey = normalized.replace(/\.png$/i, ".svg");
-    if (toolbarIconModules[svgKey]) {
-      return toolbarIconModules[svgKey];
-    }
-  }
-
-  return `/icons/${fileName}`;
-};
 
 const ACTION_ICON_MAP = {
   izquierda: resolveIconAsset("izquierda.svg"),

--- a/mgm-front/src/lib/iconRegistry.js
+++ b/mgm-front/src/lib/iconRegistry.js
@@ -1,0 +1,29 @@
+const iconModules = import.meta.glob('../icons/*.{svg,png}', {
+  eager: true,
+  import: 'default',
+});
+
+export function resolveIconAsset(fileName) {
+  const normalized = `../icons/${fileName}`;
+  const directMatch = iconModules[normalized];
+  if (directMatch) return directMatch;
+
+  const lower = fileName.toLowerCase();
+  if (lower.endsWith('.svg')) {
+    const pngKey = normalized.replace(/\.svg$/i, '.png');
+    if (iconModules[pngKey]) {
+      return iconModules[pngKey];
+    }
+  } else if (lower.endsWith('.png')) {
+    const svgKey = normalized.replace(/\.png$/i, '.svg');
+    if (iconModules[svgKey]) {
+      return iconModules[svgKey];
+    }
+  }
+
+  return `/icons/${fileName}`;
+}
+
+export function getIconAsset(fileName) {
+  return resolveIconAsset(fileName);
+}

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -17,6 +17,10 @@ import { quickHateSymbolCheck } from '@/lib/moderation.ts';
 import { scanNudityClient } from '@/lib/moderation/nsfw.client.js';
 import { useFlow } from '@/state/flow.js';
 import { apiFetch } from '@/lib/api.js';
+import { resolveIconAsset } from '@/lib/iconRegistry.js';
+
+const CONFIG_ICON_SRC = resolveIconAsset('wheel.svg');
+const CONFIG_ARROW_ICON_SRC = resolveIconAsset('down.svg');
 
 export default function Home() {
 
@@ -295,7 +299,7 @@ export default function Home() {
           >
             <span className={styles.configHeaderLeft}>
               <img
-                src="/icons/wheel.svg"
+                src={CONFIG_ICON_SRC}
                 alt=""
                 className={styles.configIcon}
                 aria-hidden="true"
@@ -303,7 +307,7 @@ export default function Home() {
               <span className={styles.configTitle}>Configura tu mousepad</span>
             </span>
             <img
-              src="/icons/down.svg"
+              src={CONFIG_ARROW_ICON_SRC}
               alt=""
               className={`${styles.configArrowIcon} ${configOpen ? styles.configArrowIconOpen : ''}`}
               aria-hidden="true"


### PR DESCRIPTION
## Summary
- add a shared icon registry helper that maps icon filenames to bundled assets or `/icons` fallbacks
- reuse the resolver from the editor canvas and home page so the configuration header pulls the correct wheel and down icons

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d17ce9618c8327aeb6ab0010068049