### PR TITLE
Refine color popover layout

### DIFF
--- a/mgm-front/public/icons/tintero.svg
+++ b/mgm-front/public/icons/tintero.svg
@@ -1,0 +1,32 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="inkGradient" x1="6" y1="5" x2="19" y2="21" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FF6B6B" />
+      <stop offset="0.48" stop-color="#F43F5E" />
+      <stop offset="1" stop-color="#BE123C" />
+    </linearGradient>
+    <linearGradient id="inkHighlight" x1="9" y1="7" x2="15" y2="15" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFF5F5" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#FFF5F5" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <path
+    d="M12.028 2.5c-.224.333-5.528 7.178-5.528 11.238 0 3.802 3.044 6.762 6.8 6.762s6.8-2.96 6.8-6.762c0-4.06-5.304-10.905-5.528-11.238a.8.8 0 0 0-1.544 0Z"
+    fill="url(#inkGradient)"
+  />
+  <path
+    d="M9.35 13.35c0 1.945 1.73 3.525 3.95 3.525s3.95-1.58 3.95-3.525c0-1.666-1.582-3.635-3.091-5.63-.384-.518-1.334-.518-1.718 0-1.509 1.995-3.091 3.964-3.091 5.63Z"
+    fill="#0F172A"
+    fill-opacity="0.25"
+  />
+  <path
+    d="M14.05 7.392c.537.693 1.044 1.326 1.484 1.914a.6.6 0 0 1-.476.96H12.4c-.51 0-.798-.567-.502-.986.358-.511.733-1.045 1.115-1.593.322-.463.999-.468 1.337.006Z"
+    fill="url(#inkHighlight)"
+  />
+  <path
+    d="M9.1 19.45c.96.674 2.146 1.05 3.4 1.05 1.253 0 2.439-.376 3.4-1.05"
+    stroke="rgba(15, 23, 42, 0.35)"
+    stroke-width="1.2"
+    stroke-linecap="round"
+  />
+</svg>

--- a/mgm-front/src/components/ColorPopover.jsx
+++ b/mgm-front/src/components/ColorPopover.jsx
@@ -1,34 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { HexColorPicker, HexColorInput } from "react-colorful";
 import styles from "./EditorCanvas.module.css";
 
-const iconModules = import.meta.glob("../icons/*.{svg,png}", {
-  eager: true,
-  import: "default",
-});
-
-const resolveIconAsset = (fileName) => {
-  const normalized = `../icons/${fileName}`;
-  const directMatch = iconModules[normalized];
-  if (directMatch) return directMatch;
-
-  const lower = fileName.toLowerCase();
-  if (lower.endsWith(".svg")) {
-    const pngKey = normalized.replace(/\.svg$/i, ".png");
-    if (iconModules[pngKey]) {
-      return iconModules[pngKey];
-    }
-  } else if (lower.endsWith(".png")) {
-    const svgKey = normalized.replace(/\.png$/i, ".svg");
-    if (iconModules[svgKey]) {
-      return iconModules[svgKey];
-    }
-  }
-
-  return `/icons/${fileName}`;
-};
-
-const EYEDROPPER_ICON = resolveIconAsset("tintero.svg");
+const EYEDROPPER_ICON = "/icons/tintero.svg";
 
 export default function ColorPopover({
   value,
@@ -38,6 +12,7 @@ export default function ColorPopover({
   onPickFromCanvas,
 }) {
   const boxRef = useRef(null);
+  const inputId = useId();
   const [hex, setHex] = useState(value || "#ffffff");
   const [iconError, setIconError] = useState(false);
 
@@ -59,29 +34,6 @@ export default function ColorPopover({
       document.removeEventListener("keydown", onKey);
     };
   }, [open, onClose]);
-
-  const swatches = [
-    "#ffffff",
-    "#000000",
-    "#f3f4f6",
-    "#e5e7eb",
-    "#d1d5db",
-    "#1f2937",
-    "#111827",
-    "#ff0000",
-    "#ff7f00",
-    "#ffb800",
-    "#ffe600",
-    "#00a859",
-    "#00c9a7",
-    "#00ccff",
-    "#0066ff",
-    "#6f42c1",
-    "#ff69b4",
-    "#8b4513",
-    "#808080",
-    "#333333",
-  ];
 
   const handlePick = async () => {
     try {
@@ -112,29 +64,10 @@ export default function ColorPopover({
           }}
           className={styles.colorPicker}
         />
-      </div>
-      <div className={styles.colorControls}>
-        <span
-          className={styles.previewDot}
-          style={{ background: hex }}
-          aria-hidden="true"
-        />
-        <div className={styles.hexField}>
-          <span className={styles.hexLabel}>Hex</span>
-          <HexColorInput
-            color={hex}
-            onChange={(c) => {
-              const v = c.startsWith("#") ? c : `#${c}`;
-              setHex(v);
-              onChange?.(v);
-            }}
-            prefixed
-            className={styles.hexInput}
-          />
-        </div>
         <button
           type="button"
           title="Elegir del lienzo"
+          aria-label="Elegir color del lienzo"
           onClick={handlePick}
           className={styles.eyedropperButton}
         >
@@ -143,28 +76,33 @@ export default function ColorPopover({
           ) : (
             <img
               src={EYEDROPPER_ICON}
-              alt="Tomar color del lienzo"
+              alt=""
               className={styles.eyedropperIcon}
               onError={() => setIconError(true)}
+              draggable="false"
             />
           )}
         </button>
       </div>
-      <div className={styles.swatches}>
-        {swatches.map((c) => (
-          <button
-            key={c}
-            type="button"
-            title={c}
-            onClick={() => {
-              setHex(c);
-              onChange?.(c);
-            }}
-            className={styles.swatch}
-            style={{ background: c }}
-            data-selected={hex.toLowerCase() === c.toLowerCase()}
-          />
-        ))}
+      <div className={styles.hexField}>
+        <label className={styles.hexLabel} htmlFor={inputId}>
+          Hex
+        </label>
+        <HexColorInput
+          id={inputId}
+          color={hex}
+          onChange={(c) => {
+            const normalized = c.startsWith("#") ? c : `#${c}`;
+            setHex(normalized);
+            onChange?.(normalized);
+          }}
+          prefixed
+          className={styles.hexInput}
+          spellCheck={false}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+        />
       </div>
     </div>
   );

--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -1,20 +1,19 @@
 .colorPopover {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 18px;
-  width: 280px;
-  border-radius: 18px;
-  background: linear-gradient(155deg, #25252d 0%, #141418 100%);
+  gap: 18px;
+  padding: 20px 18px 18px;
+  width: 268px;
+  border-radius: 20px;
+  background: linear-gradient(180deg, #1c1c23 0%, #111118 100%);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 24px 55px rgba(0, 0, 0, 0.55);
+  box-shadow: 0 28px 55px rgba(0, 0, 0, 0.6);
   color: #f9fafb;
 }
 
 .colorPickerShell {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+  position: relative;
+  padding-bottom: 12px;
 }
 
 .colorPicker {
@@ -23,6 +22,9 @@
 
 .colorPicker :global(.react-colorful) {
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .colorPicker :global(.react-colorful__saturation) {
@@ -30,116 +32,70 @@
   aspect-ratio: 1 / 1;
   border-radius: 18px;
   overflow: hidden;
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
-    0 20px 40px rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.55);
 }
 
 .colorPicker :global(.react-colorful__saturation-pointer) {
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
   border-radius: 999px;
   border: 2px solid #ffffff;
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.45);
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.95),
+    rgba(148, 163, 184, 0.85)
+  );
 }
 
 .colorPicker :global(.react-colorful__hue) {
-  height: 14px;
+  height: 16px;
   border-radius: 999px;
-  margin-top: 16px;
+  margin: 22px 0 0 58px;
+  width: calc(100% - 58px);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
 }
 
 .colorPicker :global(.react-colorful__hue-pointer) {
-  width: 16px;
-  height: 16px;
-  border-radius: 6px;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
   border: 2px solid #ffffff;
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.45);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(148, 163, 184, 0.9));
-}
-
-.colorControls {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px;
-  border-radius: 14px;
-  background: rgba(17, 17, 23, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
-}
-
-.previewDot {
-  width: 32px;
-  height: 32px;
-  border-radius: 999px;
-  border: 2px solid rgba(255, 255, 255, 0.95);
-  box-shadow:
-    0 0 0 4px rgba(255, 255, 255, 0.05),
-    0 10px 25px rgba(0, 0, 0, 0.45);
-  flex-shrink: 0;
-}
-
-.hexField {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 6px 12px;
-  border-radius: 12px;
-  background: rgba(36, 36, 46, 0.88);
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    inset 0 -1px 0 rgba(15, 15, 20, 0.6);
-}
-
-.hexLabel {
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(249, 250, 251, 0.65);
-  padding-right: 10px;
-  border-right: 1px solid rgba(249, 250, 251, 0.08);
-}
-
-.hexInput {
-  flex: 1;
-  padding: 0;
-  border: none;
-  background: none;
-  color: #f9fafb;
-  font-size: 15px;
-  font-family: "JetBrains Mono", "SFMono-Regular", Menlo, monospace;
-}
-
-.hexInput:focus {
-  outline: none;
-}
-
-.hexInput::placeholder {
-  color: rgba(249, 250, 251, 0.25);
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.95),
+    rgba(148, 163, 184, 0.9)
+  );
 }
 
 .eyedropperButton {
-  width: 42px;
-  height: 42px;
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 46px;
+  height: 46px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: linear-gradient(160deg, rgba(148, 163, 184, 0.15), rgba(36, 36, 46, 0.6));
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(
+    160deg,
+    rgba(148, 163, 184, 0.22),
+    rgba(36, 36, 46, 0.7)
+  );
   color: inherit;
   cursor: pointer;
   transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+  box-shadow: 0 22px 40px rgba(0, 0, 0, 0.55);
 }
 
 .eyedropperButton:hover {
   transform: translateY(-1px);
-  border-color: rgba(255, 255, 255, 0.2);
-  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.5);
+  border-color: rgba(255, 255, 255, 0.24);
+  box-shadow: 0 26px 44px rgba(0, 0, 0, 0.58);
 }
 
 .eyedropperButton:active {
@@ -152,57 +108,76 @@
 }
 
 .eyedropperIcon {
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   display: block;
 }
 
 .eyedropperFallback {
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  border: 2px dashed rgba(249, 250, 251, 0.5);
-}
-
-.swatches {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.swatch {
-  width: 26px;
-  height: 26px;
+  width: 20px;
+  height: 20px;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  padding: 0;
-  cursor: pointer;
-  position: relative;
-  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+  border: 2px dashed rgba(249, 250, 251, 0.55);
 }
 
-.swatch:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 22px rgba(0, 0, 0, 0.45);
+.hexField {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(18, 18, 26, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    inset 0 -1px 0 rgba(10, 10, 18, 0.7);
 }
 
-.swatch:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.85);
-  outline-offset: 3px;
+.hexLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 10px;
+  background: rgba(32, 32, 42, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(249, 250, 251, 0.78);
+  white-space: nowrap;
 }
 
-.swatch[data-selected="true"] {
-  border-color: rgba(249, 250, 251, 0.9);
-  box-shadow: 0 18px 26px rgba(0, 0, 0, 0.5);
-}
-
-.swatch[data-selected="true"]::after {
+.hexLabel::after {
   content: "";
-  position: absolute;
-  inset: -4px;
-  border-radius: inherit;
-  border: 2px solid rgba(249, 250, 251, 0.95);
+  width: 10px;
+  height: 6px;
+  margin-left: 4px;
+  background: url('/icons/down.svg') center / contain no-repeat;
+  opacity: 0.7;
 }
+
+.hexInput {
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: #f9fafb;
+  font-size: 16px;
+  font-family: "JetBrains Mono", "SFMono-Regular", Menlo, monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.hexInput:focus {
+  outline: none;
+}
+
+.hexInput::placeholder {
+  color: rgba(249, 250, 251, 0.35);
+}
+
 
 .colorWrapper1 {
   position: relative;           /* <- ancla local para posicionar el popover */


### PR DESCRIPTION
## Summary
- restyle the color popover to remove swatches, simplify controls, and align the eyedropper button with the hue slider
- source the eyedropper icon from /icons/tintero.svg and expose it via the public assets folder
- refresh the associated CSS to match the new layout and typography

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1825e13a08327891443541dd9cf1c