### PR TITLE
Fix missing closing brace in Home styles

### DIFF
--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -189,20 +189,21 @@
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.textInput::placeholder {
+  .textInput::placeholder {
 
-  color: rgba(156, 163, 175, 0.7);
+    color: rgba(156, 163, 175, 0.7);
 
-}
+  }
 
-.textInput:focus {
-  outline: none;
+  .textInput:focus {
+    outline: none;
 
-  border-color: rgba(170, 170, 190, 0.9);
-  box-shadow: 0 0 0 3px rgba(170, 170, 190, 0.2);
+    border-color: rgba(170, 170, 190, 0.9);
+    box-shadow: 0 0 0 3px rgba(170, 170, 190, 0.2);
 
+  }
 
-.headerActions {
+  .headerActions {
   display: flex;
   align-items: center;
   gap: 14px;


### PR DESCRIPTION
## Summary
- close the `.textInput:focus` rule in `Home.module.css` to resolve the PostCSS parse error triggered during Vite builds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d18e392e008327a8d40249f45b55a4