### PR TITLE
style: igualar botones del editor a nuevo diseño

### DIFF
--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -208,14 +208,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
+  gap: 6px;
   flex-wrap: wrap;
-  padding: 14px 18px;
-  border-radius: 18px;
-  border: 1px solid rgba(82, 82, 110, 0.45);
-  background: rgba(14, 14, 22, 0.82);
-  box-shadow: 0 24px 55px rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(12px);
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid #2b2b33;
+  background: #1a1a1f;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
   align-self: center;
   max-width: 100%;
 }
@@ -224,13 +223,19 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 46px;
-  height: 46px;
-  border-radius: 14px;
-  border: 1px solid rgba(104, 104, 142, 0.45);
-  background: radial-gradient(circle at top, rgba(46, 46, 74, 0.92), rgba(18, 18, 26, 0.88));
-  color: #f4f4ff;
-  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  border: 1px solid #34343b;
+  background: #1f1f24;
+  color: #f7f7fb;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease,
+    border-color 0.18s ease,
+    background 0.18s ease,
+    opacity 0.18s ease;
 }
 
 .iconOnlyButton:not(:disabled) {
@@ -238,33 +243,38 @@
 }
 
 .iconOnlyButton:not(:disabled):hover {
-  transform: translateY(-2px);
-  border-color: rgba(126, 126, 220, 0.8);
-  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.55);
+  transform: translateY(-1px);
+  border-color: #585861;
+  background: #26262c;
+  box-shadow: 0 14px 26px rgba(0, 0, 0, 0.42);
 }
 
 .iconOnlyButton:not(:disabled):active {
   transform: translateY(0);
+  border-color: #41414a;
+  background: #18181d;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
 .iconOnlyButton:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.85);
+  outline: 2px solid rgba(255, 255, 255, 0.75);
   outline-offset: 2px;
-
 }
 
 .iconOnlyButton:disabled {
-  opacity: 0.35;
+  opacity: 0.45;
   cursor: not-allowed;
-  background: rgba(20, 20, 28, 0.6);
-  border-color: rgba(82, 82, 108, 0.25);
+  background: #16161a;
+  border-color: #24242a;
+  box-shadow: none;
 }
 
 .iconOnlyButtonImage {
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   display: block;
   object-fit: contain;
+  filter: brightness(0) invert(1);
 }
 
 .iconFallback {
@@ -286,7 +296,6 @@
 .colorWrapper {
   position: relative;
   display: inline-flex;
-  gap: 8px;
   align-items: center;
 }
 


### PR DESCRIPTION
## Summary
- actualicé el contenedor del toolbar del editor con nuevo fondo, borde y espaciado para replicar el diseño de referencia
- reestilicé los botones de iconos (dimensiones, bordes, estados hover/active/disabled y filtros de icono) para que coincidan visualmente con la guía entregada

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d191f7730c8327971dd32bb7b05b6d