### PR TITLE
Move history controls over canvas

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -394,35 +394,6 @@ export default function Home() {
               )}
             </div>
           </div>
-          <div className={styles.headerActions}>
-            <button
-              type="button"
-              className={styles.topActionButton}
-              onClick={handleUndo}
-              disabled={!hasImage || !canUndo}
-              aria-label="Deshacer"
-            >
-              <UndoIcon className={styles.topActionIcon} />
-            </button>
-            <button
-              type="button"
-              className={styles.topActionButton}
-              onClick={handleRedo}
-              disabled={!hasImage || !canRedo}
-              aria-label="Rehacer"
-            >
-              <RedoIcon className={styles.topActionIcon} />
-            </button>
-            <button
-              type="button"
-              className={`${styles.topActionButton} ${styles.deleteActionButton}`}
-              onClick={handleClearImage}
-              disabled={!hasImage}
-              aria-label="Eliminar imagen"
-            >
-              <TrashIcon className={styles.topActionIcon} />
-            </button>
-          </div>
         </div>
 
         <div className={styles.canvasStage}>
@@ -439,6 +410,36 @@ export default function Home() {
               showHistoryControls={false}
               onHistoryChange={handleHistoryChange}
             />
+            {hasImage && (
+              <div className={styles.canvasHistoryActions}>
+                <button
+                  type="button"
+                  className={styles.topActionButton}
+                  onClick={handleUndo}
+                  disabled={!canUndo}
+                  aria-label="Deshacer"
+                >
+                  <UndoIcon className={styles.topActionIcon} />
+                </button>
+                <button
+                  type="button"
+                  className={styles.topActionButton}
+                  onClick={handleRedo}
+                  disabled={!canRedo}
+                  aria-label="Rehacer"
+                >
+                  <RedoIcon className={styles.topActionIcon} />
+                </button>
+                <button
+                  type="button"
+                  className={`${styles.topActionButton} ${styles.deleteActionButton}`}
+                  onClick={handleClearImage}
+                  aria-label="Eliminar imagen"
+                >
+                  <TrashIcon className={styles.topActionIcon} />
+                </button>
+              </div>
+            )}
             {!hasImage && (
               <div className={styles.uploadOverlay}>
                 <UploadStep

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -176,11 +176,14 @@
 }
 
 
-  .headerActions {
+.canvasHistoryActions {
+  position: absolute;
+  top: 24px;
+  right: 24px;
   display: flex;
   align-items: center;
   gap: 14px;
-  flex-wrap: wrap;
+  z-index: 10;
 }
 
 .topActionButton {
@@ -417,6 +420,12 @@
   .canvasStage {
     padding: 22px;
     border-radius: 24px;
+  }
+
+  .canvasHistoryActions {
+    top: 16px;
+    right: 16px;
+    gap: 10px;
   }
 
   .uploadControl {


### PR DESCRIPTION
## Summary
- relocate undo, redo and delete controls from the editor header into an overlay inside the canvas viewport
- add styles so the controls float in the top-right corner of the canvas with mobile spacing adjustments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d193d0b6608327ae4153634a71d0af