### PR TITLE
Ocultar lienzo hasta subir imagen

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -323,6 +323,13 @@ export default function Home() {
     .filter(Boolean)
     .join(' ');
 
+  const canvasStageClasses = [
+    styles.canvasStage,
+    !hasImage ? styles.canvasStageEmpty : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
     <div className={styles.page}>
       <SeoJsonLd
@@ -425,20 +432,22 @@ export default function Home() {
           </div>
         </div>
 
-        <div className={styles.canvasStage}>
+        <div className={canvasStageClasses}>
           <div className={styles.canvasViewport}>
-            <EditorCanvas
-              ref={canvasRef}
-              imageUrl={imageUrl}
-              imageFile={uploaded?.file}
-              sizeCm={activeSizeCm}
-              bleedMm={3}
-              dpi={300}
-              onLayoutChange={setLayout}
-              onClearImage={handleClearImage}
-              showHistoryControls={false}
-              onHistoryChange={handleHistoryChange}
-            />
+            {hasImage && (
+              <EditorCanvas
+                ref={canvasRef}
+                imageUrl={imageUrl}
+                imageFile={uploaded?.file}
+                sizeCm={activeSizeCm}
+                bleedMm={3}
+                dpi={300}
+                onLayoutChange={setLayout}
+                onClearImage={handleClearImage}
+                showHistoryControls={false}
+                onHistoryChange={handleHistoryChange}
+              />
+            )}
             {!hasImage && (
               <div className={styles.uploadOverlay}>
                 <UploadStep

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -246,6 +246,11 @@
   min-height: 520px;
 }
 
+.canvasStageEmpty {
+  border-color: transparent;
+  background: rgba(5, 5, 8, 0.98);
+}
+
 .canvasViewport {
   position: relative;
   flex: 1;


### PR DESCRIPTION
## Summary
- evita renderizar el editor de canvas cuando todavía no hay una imagen subida
- aplica un estilo alternativo al contenedor del lienzo vacío para mantener el fondo oscuro

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d1945502cc8327927615b3b61f6d1a