### PR TITLE
Adjust toolbar icon sizing

### DIFF
--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -225,6 +225,8 @@
   justify-content: center;
   width: 44px;
   height: 44px;
+  padding: 0;
+  margin: 0;
   border-radius: 10px;
   border: 1px solid #34343b;
   background: #1f1f24;
@@ -270,16 +272,16 @@
 }
 
 .iconOnlyButtonImage {
-  width: 24px;
-  height: 24px;
+  width: 25px;
+  height: 25px;
   display: block;
   object-fit: contain;
   filter: brightness(0) invert(1);
 }
 
 .iconFallback {
-  width: 24px;
-  height: 24px;
+  width: 25px;
+  height: 25px;
   border-radius: 8px;
 
   border: 1px dashed rgba(249, 250, 251, 0.45);


### PR DESCRIPTION
## Summary
- remove inherited padding/margin from toolbar icon buttons to eliminate extra spacing
- increase toolbar icon and fallback placeholder size to 25px to match requested logo dimensions

## Testing
- npm run lint *(fails: existing unused variable errors in src/pages/Home.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d19801744c832791da2799a4927612