### PR TITLE
Make config dropdown overlay canvas

### DIFF
--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -120,7 +120,12 @@
   transform: rotate(180deg);
 }
 
-.configContent {
+.configPanel {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 0;
+  min-width: min(420px, calc(100vw - 96px));
+  max-width: min(520px, calc(100vw - 96px));
   display: flex;
   flex-direction: column;
   gap: 24px;
@@ -130,7 +135,7 @@
   border-top: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(14, 14, 20, 0.96);
   box-shadow: 0 32px 60px rgba(0, 0, 0, 0.5);
-  z-index: 20;
+  z-index: 30;
 }
 
 .configPanelDisabled {
@@ -411,7 +416,11 @@
 
   .configPanel {
     position: static;
+    top: auto;
+    left: auto;
     width: 100%;
+    min-width: 0;
+    max-width: none;
   }
 
   .canvasStage {


### PR DESCRIPTION
## Summary
- position the configuration dropdown panel absolutely so it floats over the editor canvas
- constrain the panel width and raise its z-index while keeping the mobile layout unchanged

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d194b330a08327a24d291dc1135966