### PR TITLE
Update editor header font and home navigation

### DIFF
--- a/mgm-front/src/App.jsx
+++ b/mgm-front/src/App.jsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Link, Outlet } from 'react-router-dom';
 import styles from './App.module.css';
 import SeoJsonLd from './components/SeoJsonLd';
 
@@ -7,7 +7,9 @@ export default function App() {
     <div className={styles.container}>
       <SeoJsonLd />
       <header className={styles.header}>
-        <strong>MGM GAMERS®</strong>
+        <Link to="/" className={styles.brand}>
+          MGM GAMERS®
+        </Link>
         <span>EDITOR</span>
       </header>
       <main className={styles.main}>

--- a/mgm-front/src/App.module.css
+++ b/mgm-front/src/App.module.css
@@ -13,18 +13,25 @@
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  font-family: 'Poppins', sans-serif;
   font-weight: 600;
   letter-spacing: 0.08em;
   font-size: 1rem;
 }
 
-.header strong {
+.brand {
   font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: inherit;
+  text-decoration: none;
+  font-family: 'Poppins', sans-serif;
 }
 
 .header span {
   font-size: 0.9rem;
   opacity: 0.75;
+  font-family: 'Poppins', sans-serif;
 }
 
 .main {


### PR DESCRIPTION
## Summary
- update the editor header so the MGM GAMERS® label links back to the home route
- ensure the header brand and status text explicitly use the Poppins font family

## Testing
- npm run lint *(fails: existing unused variable warnings in src/pages/Home.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d198c3c32c83279091ca2ac391ca5d