### PR TITLE
Use icon assets for editor history buttons

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -1240,7 +1240,12 @@ const EditorCanvas = forwardRef(function EditorCanvas(
               className={styles.historyButton}
               aria-label="Deshacer"
             >
-              Deshacer
+              <img
+                src="/icons/undo.svg"
+                alt=""
+                className={styles.historyIcon}
+                draggable="false"
+              />
             </button>
             <button
               type="button"
@@ -1249,15 +1254,26 @@ const EditorCanvas = forwardRef(function EditorCanvas(
               className={styles.historyButton}
               aria-label="Rehacer"
             >
-              Rehacer
+              <img
+                src="/icons/redo.svg"
+                alt=""
+                className={styles.historyIcon}
+                draggable="false"
+              />
             </button>
             <button
               type="button"
               onClick={() => onClearImage?.()}
               disabled={!onClearImage || !imageUrl}
               className={`${styles.historyButton} ${styles.historyButtonDanger}`}
+              aria-label="Eliminar"
             >
-              Eliminar
+              <img
+                src="/icons/delete.svg"
+                alt=""
+                className={styles.historyIcon}
+                draggable="false"
+              />
             </button>
           </div>
         )}

--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -356,6 +356,8 @@
 .historyButton {
   width: 44px;
   height: 44px;
+  margin: 0;
+  padding: 0;
   border-radius: 14px;
   border: 1px solid rgba(104, 104, 142, 0.45);
   background: rgba(16, 16, 24, 0.85);
@@ -369,6 +371,13 @@
   justify-content: center;
   cursor: pointer;
   transition: transform 0.18s ease, border-color 0.18s ease, background-color 0.18s ease;
+}
+
+.historyIcon {
+  width: 25px;
+  height: 25px;
+  display: block;
+  pointer-events: none;
 }
 
 .historyButton:disabled {
@@ -388,14 +397,12 @@
 }
 
 .historyButtonDanger {
-  border-color: rgba(239, 68, 68, 0.75);
-  color: #fca5a5;
-  background: rgba(52, 18, 24, 0.85);
+  border-color: rgba(239, 68, 68, 0.65);
 }
 
 .historyButtonDanger:not(:disabled):hover {
   background: rgba(239, 68, 68, 0.9);
-  color: #ffffff;
+  border-color: rgba(239, 68, 68, 0.9);
 }
 
 .spinnerOverlay {


### PR DESCRIPTION
## Summary
- replace the text labels in the editor history controls with undo, redo, and delete icons
- size the history buttons as icon-only controls and update styles for the delete hover state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d19d3194a0832790a8fdf2a32ddfe2