### PR TITLE
Resalta la selección en los controles del editor

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -339,6 +339,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
   const stickyFitRef = useRef(null);
   const skipStickyFitOnceRef = useRef(false);
   const [bgColor, setBgColor] = useState("#ffffff");
+  const [activeAlign, setActiveAlign] = useState({ horizontal: null, vertical: null });
   const isTransformingRef = useRef(false);
   const setKeepRatioImmediate = useCallback(
     (value) => {
@@ -395,6 +396,10 @@ const EditorCanvas = forwardRef(function EditorCanvas(
       y: (wrapSize.h - stageH) / 2,
     });
   }, [imageUrl, imageFile, updateHistoryCounts]);
+
+  useEffect(() => {
+    setActiveAlign({ horizontal: null, vertical: null });
+  }, [imageUrl, imageFile]);
 
   // Ajuste inicial: imagen contenida y centrada una sola vez por carga
   useEffect(() => {
@@ -1157,6 +1162,16 @@ const EditorCanvas = forwardRef(function EditorCanvas(
     setColorOpen(true);
   };
   const closeColor = () => setColorOpen(false);
+  const iconButtonClass = (isActive) =>
+    isActive
+      ? `${styles.iconOnlyButton} ${styles.iconOnlyButtonActive}`
+      : styles.iconOnlyButton;
+  const setActiveAlignAxis = (axis, value) => {
+    setActiveAlign((prev) => {
+      if (prev[axis] === value) return prev;
+      return { ...prev, [axis]: value };
+    });
+  };
   // track latest callback to avoid effect loops when parent re-renders
   const layoutChangeRef = useRef(onLayoutChange);
   useEffect(() => {
@@ -1566,11 +1581,14 @@ const EditorCanvas = forwardRef(function EditorCanvas(
       <div className={styles.toolbar}>
         <button
           type="button"
-          onClick={() => alignEdge("left")}
+          onClick={() => {
+            alignEdge("left");
+            setActiveAlignAxis("horizontal", "left");
+          }}
           disabled={!imgEl}
           aria-label="Alinear a la izquierda"
           title="Alinear a la izquierda"
-          className={styles.iconOnlyButton}
+          className={iconButtonClass(activeAlign.horizontal === "left")}
         >
           {missingIcons.izquierda ? (
             <span className={styles.iconFallback} aria-hidden="true" />
@@ -1587,11 +1605,14 @@ const EditorCanvas = forwardRef(function EditorCanvas(
         </button>
         <button
           type="button"
-          onClick={centerHoriz}
+          onClick={() => {
+            centerHoriz();
+            setActiveAlignAxis("horizontal", "center");
+          }}
           disabled={!imgEl}
           aria-label="Centrar horizontal"
           title="Centrar horizontal"
-          className={styles.iconOnlyButton}
+          className={iconButtonClass(activeAlign.horizontal === "center")}
         >
           {missingIcons.centrado_V ? (
             <span className={styles.iconFallback} aria-hidden="true" />
@@ -1608,11 +1629,14 @@ const EditorCanvas = forwardRef(function EditorCanvas(
         </button>
         <button
           type="button"
-          onClick={() => alignEdge("right")}
+          onClick={() => {
+            alignEdge("right");
+            setActiveAlignAxis("horizontal", "right");
+          }}
           disabled={!imgEl}
           aria-label="Alinear a la derecha"
           title="Alinear a la derecha"
-          className={styles.iconOnlyButton}
+          className={iconButtonClass(activeAlign.horizontal === "right")}
         >
           {missingIcons.derecha ? (
             <span className={styles.iconFallback} aria-hidden="true" />
@@ -1629,11 +1653,14 @@ const EditorCanvas = forwardRef(function EditorCanvas(
         </button>
         <button
           type="button"
-          onClick={() => alignEdge("top")}
+          onClick={() => {
+            alignEdge("top");
+            setActiveAlignAxis("vertical", "top");
+          }}
           disabled={!imgEl}
           aria-label="Alinear arriba"
           title="Alinear arriba"
-          className={styles.iconOnlyButton}
+          className={iconButtonClass(activeAlign.vertical === "top")}
         >
           {missingIcons.arriba ? (
             <span className={styles.iconFallback} aria-hidden="true" />
@@ -1650,11 +1677,14 @@ const EditorCanvas = forwardRef(function EditorCanvas(
         </button>
         <button
           type="button"
-          onClick={centerVert}
+          onClick={() => {
+            centerVert();
+            setActiveAlignAxis("vertical", "center");
+          }}
           disabled={!imgEl}
           aria-label="Centrar vertical"
           title="Centrar vertical"
-          className={styles.iconOnlyButton}
+          className={iconButtonClass(activeAlign.vertical === "center")}
         >
           {missingIcons.centrado_h ? (
             <span className={styles.iconFallback} aria-hidden="true" />
@@ -1671,11 +1701,14 @@ const EditorCanvas = forwardRef(function EditorCanvas(
         </button>
         <button
           type="button"
-          onClick={() => alignEdge("bottom")}
+          onClick={() => {
+            alignEdge("bottom");
+            setActiveAlignAxis("vertical", "bottom");
+          }}
           disabled={!imgEl}
           aria-label="Alinear abajo"
           title="Alinear abajo"
-          className={styles.iconOnlyButton}
+          className={iconButtonClass(activeAlign.vertical === "bottom")}
         >
           {missingIcons.abajo ? (
             <span className={styles.iconFallback} aria-hidden="true" />
@@ -1696,7 +1729,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
           disabled={!imgEl}
           aria-label="Rotar 90°"
           title="Rotar 90°"
-          className={styles.iconOnlyButton}
+          className={iconButtonClass(false)}
         >
           {missingIcons.rotar ? (
             <span className={styles.iconFallback} aria-hidden="true" />
@@ -1717,7 +1750,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
           disabled={!imgEl}
           aria-label="Espejo vertical"
           title="Espejo vertical"
-          className={styles.iconOnlyButton}
+          className={iconButtonClass(Boolean(imgTx.flipY))}
         >
           {missingIcons.espejo_v ? (
             <span className={styles.iconFallback} aria-hidden="true" />
@@ -1738,7 +1771,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
           disabled={!imgEl}
           aria-label="Espejo horizontal"
           title="Espejo horizontal"
-          className={styles.iconOnlyButton}
+          className={iconButtonClass(Boolean(imgTx.flipX))}
         >
           {missingIcons.espejo_h ? (
             <span className={styles.iconFallback} aria-hidden="true" />
@@ -1759,7 +1792,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
           disabled={!imgEl}
           aria-label="Cubrir"
           title="Cubrir"
-          className={styles.iconOnlyButton}
+          className={iconButtonClass(mode === "cover")}
         >
           {missingIcons.cubrir ? (
             <span className={styles.iconFallback} aria-hidden="true" />
@@ -1782,7 +1815,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
             disabled={!imgEl}
             aria-label="Contener"
             title="Contener"
-            className={styles.iconOnlyButton}
+            className={iconButtonClass(mode === "contain")}
           >
             {missingIcons.contener ? (
               <span className={styles.iconFallback} aria-hidden="true" />
@@ -1816,7 +1849,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
           disabled={!imgEl}
           aria-label="Estirar"
           title="Estirar"
-          className={styles.iconOnlyButton}
+          className={iconButtonClass(mode === "stretch")}
         >
           {missingIcons.estirar ? (
             <span className={styles.iconFallback} aria-hidden="true" />

--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -240,6 +240,11 @@
     opacity 0.18s ease;
 }
 
+.iconOnlyButtonActive {
+  background: rgba(132, 132, 132, 0.6);
+  border-color: rgba(132, 132, 132, 0.6);
+}
+
 .iconOnlyButton:not(:disabled) {
   cursor: pointer;
 }
@@ -251,11 +256,21 @@
   box-shadow: 0 14px 26px rgba(0, 0, 0, 0.42);
 }
 
+.iconOnlyButtonActive:not(:disabled):hover {
+  background: rgba(132, 132, 132, 0.6);
+  border-color: rgba(132, 132, 132, 0.6);
+}
+
 .iconOnlyButton:not(:disabled):active {
   transform: translateY(0);
   border-color: #41414a;
   background: #18181d;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.iconOnlyButtonActive:not(:disabled):active {
+  background: rgba(132, 132, 132, 0.6);
+  border-color: rgba(132, 132, 132, 0.6);
 }
 
 .iconOnlyButton:focus-visible {


### PR DESCRIPTION
## Summary
- agrega estado para recordar la alineación activa y reutiliza el estado existente (`mode`, `flipX`, `flipY`) para decidir qué botones deben resaltarse
- aplica la nueva clase `iconOnlyButtonActive` a los botones relevantes para mostrar el fondo #848484 con 60 % de opacidad
- define el estilo del estado activo y asegura que se mantenga incluso al hacer hover o presionar los botones

## Testing
- `npm run lint` *(falla: Home.jsx contiene variables sin uso desde antes de este cambio)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a1b49e70832789ae75587d43f915