### PR TITLE
Ensure history history buttons remain visible

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -64,6 +64,12 @@ const ACTION_ICON_MAP = {
 
 };
 
+const HISTORY_ICON_SPECS = {
+  undo: { src: "/icons/undo.svg", fallbackLabel: "Deshacer" },
+  redo: { src: "/icons/redo.svg", fallbackLabel: "Rehacer" },
+  delete: { src: "/icons/delete.svg", fallbackLabel: "Eliminar" },
+};
+
 // ---------- Editor ----------
 const EditorCanvas = forwardRef(function EditorCanvas(
   {
@@ -128,10 +134,17 @@ const EditorCanvas = forwardRef(function EditorCanvas(
   const pickCallbackRef = useRef(null);
   const [isPickingColor, setIsPickingColor] = useState(false);
   const [missingIcons, setMissingIcons] = useState({});
+  const [missingHistoryIcons, setMissingHistoryIcons] = useState({});
 
 
   const handleIconError = (action) => () => {
     setMissingIcons((prev) => (prev[action] ? prev : { ...prev, [action]: true }));
+  };
+
+  const handleHistoryIconError = (action) => () => {
+    setMissingHistoryIcons((prev) =>
+      prev[action] ? prev : { ...prev, [action]: true },
+    );
   };
 
 
@@ -1240,7 +1253,19 @@ const EditorCanvas = forwardRef(function EditorCanvas(
               className={styles.historyButton}
               aria-label="Deshacer"
             >
-              Deshacer
+              {missingHistoryIcons.undo ? (
+                <span className={styles.historyFallback} aria-hidden="true">
+                  {HISTORY_ICON_SPECS.undo.fallbackLabel}
+                </span>
+              ) : (
+                <img
+                  src={HISTORY_ICON_SPECS.undo.src}
+                  alt=""
+                  className={styles.historyIcon}
+                  draggable="false"
+                  onError={handleHistoryIconError("undo")}
+                />
+              )}
             </button>
             <button
               type="button"
@@ -1249,15 +1274,40 @@ const EditorCanvas = forwardRef(function EditorCanvas(
               className={styles.historyButton}
               aria-label="Rehacer"
             >
-              Rehacer
+              {missingHistoryIcons.redo ? (
+                <span className={styles.historyFallback} aria-hidden="true">
+                  {HISTORY_ICON_SPECS.redo.fallbackLabel}
+                </span>
+              ) : (
+                <img
+                  src={HISTORY_ICON_SPECS.redo.src}
+                  alt=""
+                  className={styles.historyIcon}
+                  draggable="false"
+                  onError={handleHistoryIconError("redo")}
+                />
+              )}
             </button>
             <button
               type="button"
               onClick={() => onClearImage?.()}
               disabled={!onClearImage || !imageUrl}
               className={`${styles.historyButton} ${styles.historyButtonDanger}`}
+              aria-label="Eliminar"
             >
-              Eliminar
+              {missingHistoryIcons.delete ? (
+                <span className={styles.historyFallback} aria-hidden="true">
+                  {HISTORY_ICON_SPECS.delete.fallbackLabel}
+                </span>
+              ) : (
+                <img
+                  src={HISTORY_ICON_SPECS.delete.src}
+                  alt=""
+                  className={styles.historyIcon}
+                  draggable="false"
+                  onError={handleHistoryIconError("delete")}
+                />
+              )}
             </button>
           </div>
         )}

--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -348,7 +348,7 @@
   position: absolute;
   top: 24px;
   right: 24px;
-  z-index: 30;
+  z-index: 60;
   display: flex;
   gap: 10px;
 }
@@ -356,6 +356,8 @@
 .historyButton {
   width: 44px;
   height: 44px;
+  margin: 0;
+  padding: 0;
   border-radius: 14px;
   border: 1px solid rgba(104, 104, 142, 0.45);
   background: rgba(16, 16, 24, 0.85);
@@ -369,6 +371,31 @@
   justify-content: center;
   cursor: pointer;
   transition: transform 0.18s ease, border-color 0.18s ease, background-color 0.18s ease;
+}
+
+.historyIcon {
+  width: 25px;
+  height: 25px;
+  display: block;
+  pointer-events: none;
+}
+
+.historyFallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 0.55rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  line-height: 1.1;
+  text-align: center;
+  color: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .historyButton:disabled {
@@ -388,14 +415,12 @@
 }
 
 .historyButtonDanger {
-  border-color: rgba(239, 68, 68, 0.75);
-  color: #fca5a5;
-  background: rgba(52, 18, 24, 0.85);
+  border-color: rgba(239, 68, 68, 0.65);
 }
 
 .historyButtonDanger:not(:disabled):hover {
   background: rgba(239, 68, 68, 0.9);
-  color: #ffffff;
+  border-color: rgba(239, 68, 68, 0.9);
 }
 
 .spinnerOverlay {


### PR DESCRIPTION
## Summary
- keep the editor history controls above the canvas and reuse the icon sizing
- add dedicated fallback handling when undo, redo, or delete icons are missing so the buttons stay visible
- wire the history buttons to call the new fallback logic while still using the /icons assets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d19d3194a0832790a8fdf2a32ddfe2