### PR TITLE
Restyle contain color popover

### DIFF
--- a/mgm-front/src/components/ColorPopover.jsx
+++ b/mgm-front/src/components/ColorPopover.jsx
@@ -64,6 +64,8 @@ export default function ColorPopover({
           }}
           className={styles.colorPicker}
         />
+      </div>
+      <div className={styles.pickerActions}>
         <button
           type="button"
           title="Elegir del lienzo"

--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -1,19 +1,20 @@
 .colorPopover {
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  padding: 20px 18px 18px;
+  gap: 16px;
+  padding: 16px;
   width: 268px;
-  border-radius: 20px;
-  background: linear-gradient(180deg, #1c1c23 0%, #111118 100%);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 28px 55px rgba(0, 0, 0, 0.6);
-  color: #f9fafb;
+  border-radius: 16px;
+  background: #2f2f35;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.55);
+  color: #f3f4f6;
 }
 
 .colorPickerShell {
-  position: relative;
-  padding-bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .colorPicker {
@@ -24,93 +25,107 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
 }
 
 .colorPicker :global(.react-colorful__saturation) {
   width: 100%;
   aspect-ratio: 1 / 1;
-  border-radius: 18px;
+  border-radius: 14px;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(15, 15, 20, 0.7);
+  background: #1f1f23;
+  box-shadow: none;
 }
 
 .colorPicker :global(.react-colorful__saturation-pointer) {
-  width: 20px;
-  height: 20px;
+  width: 16px;
+  height: 16px;
   border-radius: 999px;
   border: 2px solid #ffffff;
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.45);
-  background: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 0.95),
-    rgba(148, 163, 184, 0.85)
-  );
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.4);
+  background: #ffffff;
 }
 
 .colorPicker :global(.react-colorful__hue) {
-  height: 16px;
-  border-radius: 999px;
-  margin: 22px 0 0 58px;
-  width: calc(100% - 58px);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+  height: 12px;
+  border-radius: 8px;
+  margin: 0;
+  width: 100%;
+  border: 1px solid rgba(15, 15, 20, 0.7);
+  box-shadow: none;
 }
 
 .colorPicker :global(.react-colorful__hue-pointer) {
-  width: 18px;
-  height: 18px;
+  width: 14px;
+  height: 14px;
   border-radius: 999px;
   border: 2px solid #ffffff;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.45);
-  background: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 0.95),
-    rgba(148, 163, 184, 0.9)
-  );
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.4);
+  background: #ffffff;
+}
+
+.colorPicker :global(.react-colorful__alpha) {
+  height: 12px;
+  border-radius: 8px;
+  margin: 0;
+  width: 100%;
+  border: 1px solid rgba(15, 15, 20, 0.7);
+  box-shadow: none;
+}
+
+.colorPicker :global(.react-colorful__alpha-pointer) {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  border: 2px solid #ffffff;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.4);
+  background: #ffffff;
+}
+
+.pickerActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .eyedropperButton {
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  width: 46px;
-  height: 46px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: linear-gradient(
-    160deg,
-    rgba(148, 163, 184, 0.22),
-    rgba(36, 36, 46, 0.7)
-  );
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: #2a2a31;
   color: inherit;
   cursor: pointer;
-  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
-  box-shadow: 0 22px 40px rgba(0, 0, 0, 0.55);
+  transition: background-color 0.18s ease, border-color 0.18s ease,
+    transform 0.18s ease;
 }
 
 .eyedropperButton:hover {
   transform: translateY(-1px);
-  border-color: rgba(255, 255, 255, 0.24);
-  box-shadow: 0 26px 44px rgba(0, 0, 0, 0.58);
+  background: #32323a;
+  border-color: rgba(255, 255, 255, 0.14);
 }
 
 .eyedropperButton:active {
   transform: translateY(0);
+  background: #212128;
 }
 
 .eyedropperButton:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.85);
-  outline-offset: 3px;
+  outline: 2px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 2px;
 }
 
 .eyedropperIcon {
-  width: 24px;
-  height: 24px;
+  width: 25px;
+  height: 25px;
   display: block;
+  object-fit: contain;
 }
 
 .eyedropperFallback {
@@ -124,47 +139,30 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 12px 14px;
-  border-radius: 14px;
-  background: rgba(18, 18, 26, 0.92);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    inset 0 -1px 0 rgba(10, 10, 18, 0.7);
+  padding: 12px;
+  border-radius: 12px;
+  background: #25252c;
+  border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .hexLabel {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  border-radius: 10px;
-  background: rgba(32, 32, 42, 0.9);
-  border: 1px solid rgba(255, 255, 255, 0.08);
   font-size: 12px;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: rgba(249, 250, 251, 0.78);
+  color: rgba(249, 250, 251, 0.72);
   white-space: nowrap;
-}
-
-.hexLabel::after {
-  content: "";
-  width: 10px;
-  height: 6px;
-  margin-left: 4px;
-  background: url('/icons/down.svg') center / contain no-repeat;
-  opacity: 0.7;
 }
 
 .hexInput {
   flex: 1;
   min-width: 0;
-  padding: 0;
-  border: none;
-  background: none;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: #1b1b22;
   color: #f9fafb;
-  font-size: 16px;
+  font-size: 15px;
   font-family: "JetBrains Mono", "SFMono-Regular", Menlo, monospace;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -172,6 +170,7 @@
 
 .hexInput:focus {
   outline: none;
+  border-color: rgba(255, 255, 255, 0.24);
 }
 
 .hexInput::placeholder {
@@ -319,9 +318,9 @@
 .colorPopoverWrap {
   position: absolute;
   z-index: 20;
-  top: 100%;
+  bottom: 100%;
   left: 0;
-  margin-top: 8px;
+  margin-bottom: 8px;
 }
 
 .qualityBadge {
@@ -476,8 +475,8 @@
 /* Sacamos el popover del flujo para que NO empuje el ancho del toolbar */
 .colorPopoverWrap {
   position: absolute;
-  inset-block-start: calc(100% + 4px);   /* top */
-  inset-inline-start: 0;                 /* left */
+  inset-block-end: calc(100% + 4px);   /* bottom */
+  inset-inline-start: 0;               /* left */
   z-index: 1000;
 }
 

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -103,7 +103,6 @@ export default function Home() {
 
   const [priceAmount, setPriceAmount] = useState(0);
   const PRICE_CURRENCY = 'ARS';
-  const [historyCounts, setHistoryCounts] = useState({ undo: 0, redo: 0 });
 
   // layout del canvas
   const [layout, setLayout] = useState(null);
@@ -115,18 +114,6 @@ export default function Home() {
   const canvasRef = useRef(null);
   const flow = useFlow();
 
-  const handleHistoryChange = useCallback((counts) => {
-    setHistoryCounts(counts);
-  }, []);
-
-  const handleUndo = useCallback(() => {
-    canvasRef.current?.undo?.();
-  }, []);
-
-  const handleRedo = useCallback(() => {
-    canvasRef.current?.redo?.();
-  }, []);
-
   const handleClearImage = useCallback(() => {
     setUploaded(null);
     setLayout(null);
@@ -134,7 +121,6 @@ export default function Home() {
     setAckLow(false);
     setErr('');
     setPriceAmount(0);
-    setHistoryCounts({ undo: 0, redo: 0 });
   }, []);
 
   const effDpi = useMemo(() => {
@@ -306,9 +292,6 @@ export default function Home() {
   const url = 'https://www.mgmgamers.store/';
   const hasImage = Boolean(uploaded);
   const isCanvasReady = Boolean(hasImage && imageUrl);
-  const canUndo = historyCounts.undo > 0;
-  const canRedo = historyCounts.redo > 0;
-
   const configTriggerClasses = [
     styles.configTrigger,
     configOpen ? styles.configTriggerActive : '',
@@ -420,7 +403,6 @@ export default function Home() {
                 onLayoutChange={setLayout}
                 onClearImage={handleClearImage}
                 showHistoryControls={false}
-                onHistoryChange={handleHistoryChange}
               />
 
             )}


### PR DESCRIPTION
## Summary
- restyle the contain color picker popover to match the new reference styling and relocate it above the trigger
- update the eyedropper control and hex field so the icon renders at 25px without padding and the pickers span the container padding
- remove unused history callbacks from the home page that were triggering lint errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a695fae883279117bbd196e92c93