### PR TITLE
Fix color picker gradient and eyedropper icon

### DIFF
--- a/mgm-front/src/components/ColorPopover.jsx
+++ b/mgm-front/src/components/ColorPopover.jsx
@@ -1,8 +1,7 @@
 import { useEffect, useId, useRef, useState } from "react";
 import { HexColorPicker, HexColorInput } from "react-colorful";
+import eyedropperIcon from "../icons/tintero.svg";
 import styles from "./EditorCanvas.module.css";
-
-const EYEDROPPER_ICON = "/icons/tintero.svg";
 
 export default function ColorPopover({
   value,
@@ -77,7 +76,7 @@ export default function ColorPopover({
             <span className={styles.eyedropperFallback} aria-hidden="true" />
           ) : (
             <img
-              src={EYEDROPPER_ICON}
+              src={eyedropperIcon}
               alt=""
               className={styles.eyedropperIcon}
               onError={() => setIconError(true)}

--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -15,6 +15,7 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  width: 100%;
 }
 
 .colorPicker {
@@ -26,6 +27,7 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  height: auto;
 }
 
 .colorPicker :global(.react-colorful__saturation) {
@@ -34,7 +36,9 @@
   border-radius: 14px;
   overflow: hidden;
   border: 1px solid rgba(15, 15, 20, 0.7);
-  background: #1f1f23;
+  background-color: #1f1f23;
+  background-image: linear-gradient(0deg, #000, transparent),
+    linear-gradient(90deg, #fff, rgba(255, 255, 255, 0));
   box-shadow: none;
 }
 


### PR DESCRIPTION
## Summary
- restore the saturation gradient and full-width sizing for the color picker preview
- load the eyedropper button icon from the bundled SVG asset so it renders correctly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b5bc858083278ee9972284f31530