### PR TITLE
Align size inputs with inline labels and icons

### DIFF
--- a/mgm-front/src/components/SizeControls.jsx
+++ b/mgm-front/src/components/SizeControls.jsx
@@ -107,8 +107,11 @@ export default function SizeControls({ material, size, onChange, locked = false,
         <span className={styles.groupLabel}>Medidas (cm)</span>
         <div className={styles.dimensionsRow}>
           <label className={styles.inputLabel}>
-            Largo
+            <span className={styles.visuallyHidden}>Largo</span>
             <div className={inputControlClassName}>
+              <span className={styles.inputAffix} aria-hidden="true">
+                Largo
+              </span>
               <img
                 src={WIDTH_ICON_SRC}
                 alt=""
@@ -127,8 +130,11 @@ export default function SizeControls({ material, size, onChange, locked = false,
             </div>
           </label>
           <label className={styles.inputLabel}>
-            Ancho
+            <span className={styles.visuallyHidden}>Ancho</span>
             <div className={inputControlClassName}>
+              <span className={styles.inputAffix} aria-hidden="true">
+                Ancho
+              </span>
               <img
                 src={HEIGHT_ICON_SRC}
                 alt=""

--- a/mgm-front/src/components/SizeControls.module.css
+++ b/mgm-front/src/components/SizeControls.module.css
@@ -29,17 +29,13 @@
 
 .inputLabel {
   flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  font-size: 0.75rem;
-  color: #9ca3af;
+  display: block;
 }
 
 .inputControl {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
   padding: 12px 16px;
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -61,12 +57,31 @@
   background: transparent;
   color: #f4f5f7;
   outline: none;
+  text-align: right;
 }
 
 .inputIcon {
   width: 24px;
   height: 24px;
   flex-shrink: 0;
+}
+
+.inputAffix {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #9ca3af;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .input:disabled {


### PR DESCRIPTION
## Summary
- move the Largo and Ancho labels inside the measurement control to match the expected layout
- show the measurement icon between the inline label text and the numeric field while keeping accessibility labels
- tweak the measurement input styling to accommodate the inline text and right-align the numeric value

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b68cb5ac8327913d374f3fd07d1f