### PR TITLE
Show validation error when design name missing

### DIFF
--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -180,6 +180,19 @@
   box-shadow: 0 0 0 3px rgba(170, 170, 190, 0.2);
 }
 
+.textInputError,
+.textInputError:focus {
+  border-color: rgba(239, 68, 68, 0.7);
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.25);
+}
+
+.fieldError {
+  margin: 0;
+  color: #fca5a5;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
 
 .canvasHistoryActions {
   position: absolute;


### PR DESCRIPTION
## Summary
- surface an inline validation message when the design name is missing
- automatically open and focus the configuration panel, highlighting the name field
- keep the continue button enabled so the validation feedback can appear

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b972cae883278e24af3502804226