### PR TITLE
feat: add collapsible series selector

### DIFF
--- a/mgm-front/src/components/SizeControls.module.css
+++ b/mgm-front/src/components/SizeControls.module.css
@@ -114,10 +114,47 @@
   gap: 12px;
 }
 
-.materialList {
+.seriesSelect {
+  position: relative;
+}
+
+.seriesSelectText {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.seriesSelectIcon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.seriesSelectIconOpen {
+  transform: rotate(180deg);
+}
+
+.seriesOptions {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(18, 18, 22, 0.95);
+  box-shadow: 0 18px 36px rgba(8, 8, 12, 0.45);
+  backdrop-filter: blur(8px);
+  z-index: 10;
+}
+
+.seriesOptionItem {
+  width: 100%;
 }
 
 .materialOption {
@@ -151,6 +188,12 @@
 .materialOptionDisabled {
   opacity: 0.45;
   cursor: not-allowed;
+}
+
+.seriesSelectTrigger {
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .materialOptionTitle {


### PR DESCRIPTION
## Summary
- replace the series radio group with a collapsible selector that uses the down icon and highlights the chosen option
- add outside-click handling and new styles so the dropdown opens and rotates the indicator when expanded

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b8bb47d88327886d0dbc64bb2ded