### PR TITLE
Adjust tooltip delay and hide behavior

### DIFF
--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -339,7 +339,7 @@
   pointer-events: none;
   opacity: 0;
   visibility: hidden;
-  transition: opacity 0.18s ease, transform 0.18s ease;
+  transition: none;
   transition-delay: 0s;
   z-index: 30;
 }
@@ -365,7 +365,8 @@
   opacity: 1;
   visibility: visible;
   transform: translate(-50%, 0);
-  transition-delay: 1s;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  transition-delay: 0.7s;
 }
 
 .iconButtonWithTooltip[data-tooltip-disabled="true"] .toolbarTooltip {


### PR DESCRIPTION
## Summary
- reduce the editor toolbar tooltip hover delay to 0.7 seconds
- ensure tooltips hide immediately by removing transitions from the default state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1bb72b7d883279973d7de2f42fd29