### PR TITLE
Show history controls in editor canvas

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -431,7 +431,6 @@ export default function Home() {
                 dpi={300}
                 onLayoutChange={setLayout}
                 onClearImage={handleClearImage}
-                showHistoryControls={false}
               />
 
             )}


### PR DESCRIPTION
## Summary
- remove the prop that hid the history controls when rendering `EditorCanvas` on the home page so the undo, redo, and delete buttons appear over the canvas

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1bbd549c883279b17ef15fd4dab74