### PR TITLE
Define history icon specs for editor

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -65,6 +65,13 @@ const ACTION_ICON_MAP = {
 };
 
 
+const HISTORY_ICON_SPECS = {
+  undo: { src: resolveIconAsset("undo.svg"), fallbackLabel: "↶" },
+  redo: { src: resolveIconAsset("redo.svg"), fallbackLabel: "↷" },
+  delete: { src: resolveIconAsset("delete.svg"), fallbackLabel: "✕" },
+};
+
+
 const ToolbarTooltip = ({ label, children, disabled = false }) => (
   <div
     className={styles.iconButtonWithTooltip}


### PR DESCRIPTION
## Summary
- define el mapa HISTORY_ICON_SPECS con los recursos y fallback labels para los controles de historial del editor
- evita el ReferenceError cuando se renderizan los botones de deshacer, rehacer y eliminar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1bd5a464c832781e39027f210e644