### PR TITLE
Adjust color popover width to remove blank area

### DIFF
--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -3,7 +3,8 @@
   flex-direction: column;
   gap: 16px;
   padding: 16px;
-  width: 268px;
+  width: max-content;
+  width: fit-content;
   border-radius: 16px;
   background: #2f2f35;
   border: 1px solid rgba(255, 255, 255, 0.06);


### PR DESCRIPTION
## Summary
- change the color picker popover to size itself to its contents, removing the empty column beside the gradient

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1c16fedcc8327812b68bd3d953a51