### PR TITLE
Ensure editor controls initialize disabled before image upload

### DIFF
--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -418,6 +418,11 @@
     0 32px 90px rgba(0, 0, 0, 0.55);
 }
 
+.canvasWrapperInactive {
+  background: rgba(8, 8, 12, 0.85);
+  border-color: rgba(70, 70, 98, 0.35);
+}
+
 .grabbing {
   cursor: grabbing;
 }

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -195,7 +195,7 @@ export default function Home() {
 
   async function handleContinue() {
     setErr('');
-    if (!layout || !canvasRef.current) {
+    if (!layout?.image || !canvasRef.current) {
       setErr('Falta imagen o layout');
       return;
     }
@@ -421,19 +421,17 @@ export default function Home() {
         <div className={canvasStageClasses}>
           <div className={styles.canvasViewport}>
 
-            {isCanvasReady && (
-              <EditorCanvas
-                ref={canvasRef}
-                imageUrl={imageUrl}
-                imageFile={uploaded?.file}
-                sizeCm={activeSizeCm}
-                bleedMm={3}
-                dpi={300}
-                onLayoutChange={setLayout}
-                onClearImage={handleClearImage}
-              />
-
-            )}
+            <EditorCanvas
+              ref={canvasRef}
+              imageUrl={imageUrl}
+              imageFile={uploaded?.file}
+              sizeCm={activeSizeCm}
+              bleedMm={3}
+              dpi={300}
+              onLayoutChange={setLayout}
+              onClearImage={handleClearImage}
+              showCanvas={isCanvasReady}
+            />
             {!hasImage && (
               <div className={styles.uploadOverlay}>
                 <UploadStep


### PR DESCRIPTION
## Summary
- always render the editor component so history and alignment controls are visible in a disabled state before an image is uploaded
- hide the Konva stage until artwork is available, reset layout callbacks when clearing the image, and style the inactive canvas wrapper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1c43a7c9c8327956f8c9b6827e23e