### PR TITLE
Prevent auto-opening mousepad config dropdown

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -66,14 +66,6 @@ export default function Home() {
     }
   }, [uploaded?.localUrl]);
 
-  useEffect(() => {
-
-    if (uploaded) {
-      setConfigOpen(true);
-    }
-
-  }, [uploaded]);
-
   // No se ejecutan filtros rápidos al subir imagen
 
   // medidas y material (source of truth)


### PR DESCRIPTION
## Summary
- remove the effect that forced the configuration dropdown open after each upload so it stays closed until the user interacts with it

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1cb8a12308327a3c31812b32ba047