### PR TITLE
Reorganize editor canvas overlays and config dropdown

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -98,6 +98,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
     showCanvas = true,
     showHistoryControls = true,
     onHistoryChange,
+    topLeftOverlay,
   },
   ref,
 ) {
@@ -1281,81 +1282,9 @@ const EditorCanvas = forwardRef(function EditorCanvas(
 
   return (
     <div className={styles.editorRoot}>
-      {/* Canvas */}
-      <div ref={wrapRef} className={wrapperClassName}>
-        {showHistoryControls && (
-          <div className={styles.historyControls}>
-            <button
-              type="button"
-              onClick={undo}
-              disabled={!canUndo}
-              className={styles.historyButton}
-              aria-label="Deshacer"
-            >
-
-              {missingHistoryIcons.undo ? (
-                <span className={styles.historyFallback} aria-hidden="true">
-                  {HISTORY_ICON_SPECS.undo.fallbackLabel}
-                </span>
-              ) : (
-                <img
-                  src={HISTORY_ICON_SPECS.undo.src}
-                  alt=""
-                  className={styles.historyIcon}
-                  draggable="false"
-                  onError={handleHistoryIconError("undo")}
-                />
-              )}
-
-            </button>
-            <button
-              type="button"
-              onClick={redo}
-              disabled={!canRedo}
-              className={styles.historyButton}
-              aria-label="Rehacer"
-            >
-
-              {missingHistoryIcons.redo ? (
-                <span className={styles.historyFallback} aria-hidden="true">
-                  {HISTORY_ICON_SPECS.redo.fallbackLabel}
-                </span>
-              ) : (
-                <img
-                  src={HISTORY_ICON_SPECS.redo.src}
-                  alt=""
-                  className={styles.historyIcon}
-                  draggable="false"
-                  onError={handleHistoryIconError("redo")}
-                />
-              )}
-
-            </button>
-            <button
-              type="button"
-              onClick={() => onClearImage?.()}
-              disabled={!onClearImage || !imageUrl}
-              className={`${styles.historyButton} ${styles.historyButtonDanger}`}
-              aria-label="Eliminar"
-            >
-
-              {missingHistoryIcons.delete ? (
-                <span className={styles.historyFallback} aria-hidden="true">
-                  {HISTORY_ICON_SPECS.delete.fallbackLabel}
-                </span>
-              ) : (
-                <img
-                  src={HISTORY_ICON_SPECS.delete.src}
-                  alt=""
-                  className={styles.historyIcon}
-                  draggable="false"
-                  onError={handleHistoryIconError("delete")}
-                />
-              )}
-
-            </button>
-          </div>
-        )}
+      <div className={styles.lienzo}>
+        {/* Canvas */}
+        <div ref={wrapRef} className={wrapperClassName}>
         <Stage
           ref={stageRef}
           width={wrapSize.w}
@@ -1640,10 +1569,81 @@ const EditorCanvas = forwardRef(function EditorCanvas(
         )}
       </div>
 
-      {lastDiag && <p className={styles.errorBox}>{lastDiag}</p>}
+      {topLeftOverlay ? (
+        <div className={styles.overlayTopLeft}>{topLeftOverlay}</div>
+      ) : null}
 
-      {/* Toolbar */}
-      <div className={styles.toolbar}>
+      {showHistoryControls && (
+        <div className={`${styles.overlayTopRight} ${styles.historyControls}`}>
+          <button
+            type="button"
+            onClick={undo}
+            disabled={!canUndo}
+            className={styles.historyButton}
+            aria-label="Deshacer"
+          >
+            {missingHistoryIcons.undo ? (
+              <span className={styles.historyFallback} aria-hidden="true">
+                {HISTORY_ICON_SPECS.undo.fallbackLabel}
+              </span>
+            ) : (
+              <img
+                src={HISTORY_ICON_SPECS.undo.src}
+                alt=""
+                className={styles.historyIcon}
+                draggable="false"
+                onError={handleHistoryIconError("undo")}
+              />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={redo}
+            disabled={!canRedo}
+            className={styles.historyButton}
+            aria-label="Rehacer"
+          >
+            {missingHistoryIcons.redo ? (
+              <span className={styles.historyFallback} aria-hidden="true">
+                {HISTORY_ICON_SPECS.redo.fallbackLabel}
+              </span>
+            ) : (
+              <img
+                src={HISTORY_ICON_SPECS.redo.src}
+                alt=""
+                className={styles.historyIcon}
+                draggable="false"
+                onError={handleHistoryIconError("redo")}
+              />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={() => onClearImage?.()}
+            disabled={!onClearImage || !imageUrl}
+            className={`${styles.historyButton} ${styles.historyButtonDanger}`}
+            aria-label="Eliminar"
+          >
+            {missingHistoryIcons.delete ? (
+              <span className={styles.historyFallback} aria-hidden="true">
+                {HISTORY_ICON_SPECS.delete.fallbackLabel}
+              </span>
+            ) : (
+              <img
+                src={HISTORY_ICON_SPECS.delete.src}
+                alt=""
+                className={styles.historyIcon}
+                draggable="false"
+                onError={handleHistoryIconError("delete")}
+              />
+            )}
+          </button>
+        </div>
+      )}
+
+      <div className={styles.overlayBottomCenter}>
+        {/* Toolbar */}
+        <div className={styles.toolbar}>
 
         <button
           type="button"
@@ -2000,8 +2000,12 @@ const EditorCanvas = forwardRef(function EditorCanvas(
             {busy ? "Creando…" : "Crear job"}
           </button>
         )}
+        </div>
       </div>
     </div>
+
+    {lastDiag && <p className={styles.errorBox}>{lastDiag}</p>}
+  </div>
   );
 });
 

--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -219,8 +219,8 @@
   border: 1px solid #2b2b33;
   background: #1a1a1f;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
-  align-self: center;
   max-width: 100%;
+  pointer-events: auto;
 }
 
 .iconOnlyButton {
@@ -404,10 +404,22 @@
 .qualityWarn { background: #f59e0b22; color: #f59e0b; border: 1px solid #f59e0b; }
 .qualityOk { background: #10b98122; color: #10b981; border: 1px solid #10b981; }
 
-.canvasWrapper {
+
+.lienzo {
+  position: relative;
   width: 100%;
   min-height: 420px;
   height: clamp(420px, 60vh, 640px);
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+}
+
+.canvasWrapper {
+  flex: 1;
+  width: 100%;
+  min-height: 0;
+  height: 100%;
   border: 1px solid rgba(70, 70, 98, 0.5);
   border-radius: 30px;
   overflow: hidden;
@@ -424,17 +436,48 @@
   border-color: rgba(70, 70, 98, 0.35);
 }
 
+.overlayTopLeft {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.overlayTopRight {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.overlayBottomCenter {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 30;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  max-width: calc(100% - 32px);
+  pointer-events: none;
+}
+
 .grabbing {
   cursor: grabbing;
 }
 
 .historyControls {
-  position: absolute;
-  top: 24px;
-  right: 24px;
-  z-index: 60;
   display: flex;
-  gap: 10px;
+  align-items: center;
+  gap: 12px;
 }
 
 .historyButton {
@@ -532,6 +575,29 @@
   font-size: 0.85rem;
   max-width: 520px;
   text-align: center;
+}
+
+
+@media (max-width: 640px) {
+  .lienzo {
+    min-height: 360px;
+    height: clamp(360px, 65vh, 560px);
+  }
+
+  .overlayTopLeft {
+    top: 12px;
+    left: 12px;
+  }
+
+  .overlayTopRight {
+    top: 12px;
+    right: 12px;
+  }
+
+  .overlayBottomCenter {
+    bottom: 12px;
+    max-width: calc(100% - 24px);
+  }
 }
 
 

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -329,6 +329,71 @@ export default function Home() {
     .filter(Boolean)
     .join(' ');
 
+  const configDropdown = (
+    <div className={styles.configDropdown}>
+      <button
+        type="button"
+        className={configTriggerClasses}
+        onClick={() => setConfigOpen((open) => !open)}
+        disabled={!hasImage}
+        aria-expanded={configOpen}
+        aria-controls="configuracion-editor"
+      >
+        <span className={styles.configTriggerIcon} aria-hidden="true">
+          <img src={CONFIG_ICON_SRC} alt="" />
+        </span>
+        <span className={styles.configTriggerLabel}>Configura tu mousepad</span>
+        <span className={styles.configTriggerArrow} aria-hidden="true">
+          <img
+            src={CONFIG_ARROW_ICON_SRC}
+            alt=""
+            className={configOpen ? styles.configTriggerArrowOpen : ''}
+          />
+        </span>
+      </button>
+      {configOpen && (
+        <div
+          id="configuracion-editor"
+          className={configPanelClasses}
+          aria-disabled={!hasImage}
+        >
+          <div className={styles.field}>
+            <label className={styles.fieldLabel} htmlFor="design-name">
+              Nombre de tu diseño
+            </label>
+            <input
+              type="text"
+              id="design-name"
+              ref={designNameInputRef}
+              className={designNameInputClasses}
+              placeholder="Ej: Nubes y cielo rosa"
+              value={designName}
+              onChange={handleDesignNameChange}
+              disabled={!hasImage}
+              aria-invalid={designNameError ? 'true' : 'false'}
+              aria-describedby={
+                designNameError ? 'design-name-error' : undefined
+              }
+            />
+            {designNameError && (
+              <p className={styles.fieldError} id="design-name-error">
+                {designNameError}
+              </p>
+            )}
+          </div>
+          <SizeControls
+            material={material}
+            size={size}
+            mode={mode}
+            onChange={handleSizeChange}
+            locked={material === 'Glasspad'}
+            disabled={!hasImage}
+          />
+        </div>
+      )}
+    </div>
+  );
+
   return (
     <div className={styles.page}>
       <SeoJsonLd
@@ -345,69 +410,7 @@ export default function Home() {
       />
       <section className={styles.editor}>
         <div className={styles.editorHeader}>
-          <div className={styles.headerPrimary}>
-            <h1 className={styles.title}>Crea tu mousepad</h1>
-            <div className={styles.configDropdown}>
-              <button
-                type="button"
-                className={configTriggerClasses}
-                onClick={() => setConfigOpen(open => !open)}
-                disabled={!hasImage}
-                aria-expanded={configOpen}
-                aria-controls="configuracion-editor"
-              >
-                <span className={styles.configTriggerIcon} aria-hidden="true">
-                  <img src={CONFIG_ICON_SRC} alt="" />
-                </span>
-                <span className={styles.configTriggerLabel}>Configura tu mousepad</span>
-                <span className={styles.configTriggerArrow} aria-hidden="true">
-                  <img
-                    src={CONFIG_ARROW_ICON_SRC}
-                    alt=""
-                    className={configOpen ? styles.configTriggerArrowOpen : ''}
-                  />
-                </span>
-              </button>
-              {configOpen && (
-                <div
-                  id="configuracion-editor"
-                  className={configPanelClasses}
-                  aria-disabled={!hasImage}
-                >
-                  <div className={styles.field}>
-                    <label className={styles.fieldLabel} htmlFor="design-name">
-                      Nombre de tu diseño
-                    </label>
-                    <input
-                      type="text"
-                      id="design-name"
-                      ref={designNameInputRef}
-                      className={designNameInputClasses}
-                      placeholder="Ej: Nubes y cielo rosa"
-                      value={designName}
-                      onChange={handleDesignNameChange}
-                      disabled={!hasImage}
-                      aria-invalid={designNameError ? 'true' : 'false'}
-                      aria-describedby={designNameError ? 'design-name-error' : undefined}
-                    />
-                    {designNameError && (
-                      <p className={styles.fieldError} id="design-name-error">
-                        {designNameError}
-                      </p>
-                    )}
-                  </div>
-                  <SizeControls
-                    material={material}
-                    size={size}
-                    mode={mode}
-                    onChange={handleSizeChange}
-                    locked={material === 'Glasspad'}
-                    disabled={!hasImage}
-                  />
-                </div>
-              )}
-            </div>
-          </div>
+          <h1 className={styles.title}>Crea tu mousepad</h1>
         </div>
 
         <div className={canvasStageClasses}>
@@ -423,6 +426,7 @@ export default function Home() {
               onLayoutChange={setLayout}
               onClearImage={handleClearImage}
               showCanvas={isCanvasReady}
+              topLeftOverlay={configDropdown}
             />
             {!hasImage && (
               <div className={styles.uploadOverlay}>


### PR DESCRIPTION
## Summary
- wrap the editor canvas in a dedicated `lienzo` container and render the history controls and toolbar as absolute overlays inside it
- update canvas styling to position the overlay layers and keep the toolbar interactive across viewports
- surface the existing configuration dropdown inside the canvas by passing it through the new `topLeftOverlay` prop from the home page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1cd3765808327b7be492f9f2a7865