### PR TITLE
Fix editor toolbar layout

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -1644,339 +1644,276 @@ const EditorCanvas = forwardRef(function EditorCanvas(
       <div className={styles.overlayBottomCenter}>
         {/* Toolbar */}
         <div className={styles.toolbar}>
-
-        <button
-          type="button"
-          onClick={() => {
-            alignEdge("left");
-            setActiveAlignAxis("horizontal", "left");
-          }}
-          disabled={!imgEl}
-          aria-label="Alinear a la izquierda"
-          title="Alinear a la izquierda"
-          className={iconButtonClass(activeAlign.horizontal === "left")}
-        >
-          {missingIcons.izquierda ? (
-            <span className={styles.iconFallback} aria-hidden="true" />
-          ) : (
-            <img
-              src={ACTION_ICON_MAP.izquierda}
-              alt="Izquierda"
-              className={styles.iconOnlyButtonImage}
-
-              onError={handleIconError("izquierda")}
-
-            />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={() => {
-            centerHoriz();
-            setActiveAlignAxis("horizontal", "center");
-          }}
-          disabled={!imgEl}
-          aria-label="Centrar horizontal"
-          title="Centrar horizontal"
-          className={iconButtonClass(activeAlign.horizontal === "center")}
-        >
-          {missingIcons.centrado_V ? (
-            <span className={styles.iconFallback} aria-hidden="true" />
-          ) : (
-            <img
-              src={ACTION_ICON_MAP.centrado_V}
-              alt="Centrar horizontal"
-              className={styles.iconOnlyButtonImage}
-
-              onError={handleIconError("centrado_V")}
-
-            />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={() => {
-            alignEdge("right");
-            setActiveAlignAxis("horizontal", "right");
-          }}
-          disabled={!imgEl}
-          aria-label="Alinear a la derecha"
-          title="Alinear a la derecha"
-          className={iconButtonClass(activeAlign.horizontal === "right")}
-        >
-          {missingIcons.derecha ? (
-            <span className={styles.iconFallback} aria-hidden="true" />
-          ) : (
-            <img
-              src={ACTION_ICON_MAP.derecha}
-              alt="Derecha"
-              className={styles.iconOnlyButtonImage}
-
-              onError={handleIconError("derecha")}
-
-            />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={() => {
-            alignEdge("top");
-            setActiveAlignAxis("vertical", "top");
-          }}
-          disabled={!imgEl}
-          aria-label="Alinear arriba"
-          title="Alinear arriba"
-          className={iconButtonClass(activeAlign.vertical === "top")}
-        >
-          {missingIcons.arriba ? (
-            <span className={styles.iconFallback} aria-hidden="true" />
-          ) : (
-            <img
-              src={ACTION_ICON_MAP.arriba}
-              alt="Arriba"
-              className={styles.iconOnlyButtonImage}
-
-              onError={handleIconError("arriba")}
-
-            />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={() => {
-            centerVert();
-            setActiveAlignAxis("vertical", "center");
-          }}
-          disabled={!imgEl}
-          aria-label="Centrar vertical"
-          title="Centrar vertical"
-          className={iconButtonClass(activeAlign.vertical === "center")}
-        >
-          {missingIcons.centrado_h ? (
-            <span className={styles.iconFallback} aria-hidden="true" />
-          ) : (
-            <img
-              src={ACTION_ICON_MAP.centrado_h}
-              alt="Centrar vertical"
-              className={styles.iconOnlyButtonImage}
-
-              onError={handleIconError("centrado_h")}
-
-            />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={() => {
-            alignEdge("bottom");
-            setActiveAlignAxis("vertical", "bottom");
-          }}
-          disabled={!imgEl}
-          aria-label="Alinear abajo"
-          title="Alinear abajo"
-          className={iconButtonClass(activeAlign.vertical === "bottom")}
-        >
-          {missingIcons.abajo ? (
-            <span className={styles.iconFallback} aria-hidden="true" />
-          ) : (
-            <img
-              src={ACTION_ICON_MAP.abajo}
-              alt="Abajo"
-              className={styles.iconOnlyButtonImage}
-
-              onError={handleIconError("abajo")}
-            />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={rotate90}
-          disabled={!imgEl}
-          aria-label="Rotar 90°"
-          title="Rotar 90°"
-          className={iconButtonClass(false)}
-        >
-          {missingIcons.rotar ? (
-            <span className={styles.iconFallback} aria-hidden="true" />
-          ) : (
-            <img
-              src={ACTION_ICON_MAP.rotar}
-              alt="Rotar"
-              className={styles.iconOnlyButtonImage}
-
-              onError={handleIconError("rotar")}
-
-            />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={flipVertical}
-          disabled={!imgEl}
-          aria-label="Espejo vertical"
-          title="Espejo vertical"
-          className={iconButtonClass(Boolean(imgTx.flipY))}
-        >
-          {missingIcons.espejo_v ? (
-            <span className={styles.iconFallback} aria-hidden="true" />
-          ) : (
-            <img
-              src={ACTION_ICON_MAP.espejo_v}
-              alt="Espejo vertical"
-              className={styles.iconOnlyButtonImage}
-
-              onError={handleIconError("espejo_v")}
-
-            />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={flipHorizontal}
-          disabled={!imgEl}
-          aria-label="Espejo horizontal"
-          title="Espejo horizontal"
-          className={iconButtonClass(Boolean(imgTx.flipX))}
-        >
-          {missingIcons.espejo_h ? (
-            <span className={styles.iconFallback} aria-hidden="true" />
-          ) : (
-            <img
-              src={ACTION_ICON_MAP.espejo_h}
-              alt="Espejo horizontal"
-              className={styles.iconOnlyButtonImage}
-
-              onError={handleIconError("espejo_h")}
-
-            />
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={fitCover}
-          disabled={!imgEl}
-          aria-label="Cubrir"
-          title="Cubrir"
-          className={iconButtonClass(mode === "cover")}
-        >
-          {missingIcons.cubrir ? (
-            <span className={styles.iconFallback} aria-hidden="true" />
-          ) : (
-            <img
-              src={ACTION_ICON_MAP.cubrir}
-              alt="Cubrir"
-              className={styles.iconOnlyButtonImage}
-              onError={handleIconError("cubrir")}
-            />
-          )}
-        </button>
-        <ToolbarTooltip label="Alinear a la izquierda">
-          <button
-            type="button"
-            onClick={() => {
-              alignEdge("left");
-              setActiveAlignAxis("horizontal", "left");
-            }}
-            disabled={!imgEl}
-            aria-label="Alinear a la izquierda"
-            className={styles.iconOnlyButton}
-          >
-            {missingIcons.izquierda ? (
-              <span className={styles.iconFallback} aria-hidden="true" />
-            ) : (
-              <img
-                src={ACTION_ICON_MAP.izquierda}
-                alt="Alinear a la izquierda"
-                className={styles.iconOnlyButtonImage}
-                onError={handleIconError("izquierda")}
-              />
-            )}
-          </button>
-        </ToolbarTooltip>
-        <ToolbarTooltip label="Alinear verticalmente">
-          <button
-            type="button"
-            onClick={centerHoriz}
-            disabled={!imgEl}
-
-            aria-label="Contener"
-            title="Contener"
-            className={iconButtonClass(mode === "contain")}
-
-          >
-            {missingIcons.centrado_V ? (
-              <span className={styles.iconFallback} aria-hidden="true" />
-            ) : (
-              <img
-                src={ACTION_ICON_MAP.centrado_V}
-                alt="Alinear verticalmente"
-                className={styles.iconOnlyButtonImage}
-                onError={handleIconError("centrado_V")}
-              />
-
-            )}
-          </button>
-        </ToolbarTooltip>
-        <ToolbarTooltip label="Alinear a la derecha">
-          <button
-            type="button"
-            onClick={() => alignEdge("right")}
-            disabled={!imgEl}
-            aria-label="Alinear a la derecha"
-            className={styles.iconOnlyButton}
-          >
-            {missingIcons.derecha ? (
-              <span className={styles.iconFallback} aria-hidden="true" />
-            ) : (
-              <img
-                src={ACTION_ICON_MAP.derecha}
-                alt="Alinear a la derecha"
-                className={styles.iconOnlyButtonImage}
-                onError={handleIconError("derecha")}
-              />
-            )}
-          </button>
-        </ToolbarTooltip>
-        <ToolbarTooltip label="Alinear arriba">
-          <button
-            type="button"
-            onClick={() => alignEdge("top")}
-            disabled={!imgEl}
-            aria-label="Alinear arriba"
-            className={styles.iconOnlyButton}
-          >
-            {missingIcons.arriba ? (
-              <span className={styles.iconFallback} aria-hidden="true" />
-            ) : (
-              <img
-                src={ACTION_ICON_MAP.arriba}
-                alt="Alinear arriba"
-                className={styles.iconOnlyButtonImage}
-                onError={handleIconError("arriba")}
-              />
-            )}
-          </button>
-        </ToolbarTooltip>
-
-        <button
-          type="button"
-          onClick={fitStretchCentered}
-          disabled={!imgEl}
-          aria-label="Estirar"
-          title="Estirar"
-          className={iconButtonClass(mode === "stretch")}
-        >
-          {missingIcons.estirar ? (
-            <span className={styles.iconFallback} aria-hidden="true" />
-          ) : (
-            <img
-              src={ACTION_ICON_MAP.estirar}
-              alt="Estirar"
-              className={styles.iconOnlyButtonImage}
-              onError={handleIconError("estirar")}
-            />
-          )}
-        </button>
+          <ToolbarTooltip label="Alinear a la izquierda">
+            <button
+              type="button"
+              onClick={() => {
+                alignEdge("left");
+                setActiveAlignAxis("horizontal", "left");
+              }}
+              disabled={!imgEl}
+              aria-label="Alinear a la izquierda"
+              title="Alinear a la izquierda"
+              className={iconButtonClass(activeAlign.horizontal === "left")}
+            >
+              {missingIcons.izquierda ? (
+                <span className={styles.iconFallback} aria-hidden="true" />
+              ) : (
+                <img
+                  src={ACTION_ICON_MAP.izquierda}
+                  alt="Alinear a la izquierda"
+                  className={styles.iconOnlyButtonImage}
+                  onError={handleIconError("izquierda")}
+                />
+              )}
+            </button>
+          </ToolbarTooltip>
+          <ToolbarTooltip label="Centrar horizontal">
+            <button
+              type="button"
+              onClick={() => {
+                centerHoriz();
+                setActiveAlignAxis("horizontal", "center");
+              }}
+              disabled={!imgEl}
+              aria-label="Centrar horizontal"
+              title="Centrar horizontal"
+              className={iconButtonClass(activeAlign.horizontal === "center")}
+            >
+              {missingIcons.centrado_V ? (
+                <span className={styles.iconFallback} aria-hidden="true" />
+              ) : (
+                <img
+                  src={ACTION_ICON_MAP.centrado_V}
+                  alt="Centrar horizontal"
+                  className={styles.iconOnlyButtonImage}
+                  onError={handleIconError("centrado_V")}
+                />
+              )}
+            </button>
+          </ToolbarTooltip>
+          <ToolbarTooltip label="Alinear a la derecha">
+            <button
+              type="button"
+              onClick={() => {
+                alignEdge("right");
+                setActiveAlignAxis("horizontal", "right");
+              }}
+              disabled={!imgEl}
+              aria-label="Alinear a la derecha"
+              title="Alinear a la derecha"
+              className={iconButtonClass(activeAlign.horizontal === "right")}
+            >
+              {missingIcons.derecha ? (
+                <span className={styles.iconFallback} aria-hidden="true" />
+              ) : (
+                <img
+                  src={ACTION_ICON_MAP.derecha}
+                  alt="Alinear a la derecha"
+                  className={styles.iconOnlyButtonImage}
+                  onError={handleIconError("derecha")}
+                />
+              )}
+            </button>
+          </ToolbarTooltip>
+          <ToolbarTooltip label="Alinear arriba">
+            <button
+              type="button"
+              onClick={() => {
+                alignEdge("top");
+                setActiveAlignAxis("vertical", "top");
+              }}
+              disabled={!imgEl}
+              aria-label="Alinear arriba"
+              title="Alinear arriba"
+              className={iconButtonClass(activeAlign.vertical === "top")}
+            >
+              {missingIcons.arriba ? (
+                <span className={styles.iconFallback} aria-hidden="true" />
+              ) : (
+                <img
+                  src={ACTION_ICON_MAP.arriba}
+                  alt="Alinear arriba"
+                  className={styles.iconOnlyButtonImage}
+                  onError={handleIconError("arriba")}
+                />
+              )}
+            </button>
+          </ToolbarTooltip>
+          <ToolbarTooltip label="Centrar vertical">
+            <button
+              type="button"
+              onClick={() => {
+                centerVert();
+                setActiveAlignAxis("vertical", "center");
+              }}
+              disabled={!imgEl}
+              aria-label="Centrar vertical"
+              title="Centrar vertical"
+              className={iconButtonClass(activeAlign.vertical === "center")}
+            >
+              {missingIcons.centrado_h ? (
+                <span className={styles.iconFallback} aria-hidden="true" />
+              ) : (
+                <img
+                  src={ACTION_ICON_MAP.centrado_h}
+                  alt="Centrar vertical"
+                  className={styles.iconOnlyButtonImage}
+                  onError={handleIconError("centrado_h")}
+                />
+              )}
+            </button>
+          </ToolbarTooltip>
+          <ToolbarTooltip label="Alinear abajo">
+            <button
+              type="button"
+              onClick={() => {
+                alignEdge("bottom");
+                setActiveAlignAxis("vertical", "bottom");
+              }}
+              disabled={!imgEl}
+              aria-label="Alinear abajo"
+              title="Alinear abajo"
+              className={iconButtonClass(activeAlign.vertical === "bottom")}
+            >
+              {missingIcons.abajo ? (
+                <span className={styles.iconFallback} aria-hidden="true" />
+              ) : (
+                <img
+                  src={ACTION_ICON_MAP.abajo}
+                  alt="Alinear abajo"
+                  className={styles.iconOnlyButtonImage}
+                  onError={handleIconError("abajo")}
+                />
+              )}
+            </button>
+          </ToolbarTooltip>
+          <ToolbarTooltip label="Rotar 90°">
+            <button
+              type="button"
+              onClick={rotate90}
+              disabled={!imgEl}
+              aria-label="Rotar 90°"
+              title="Rotar 90°"
+              className={styles.iconOnlyButton}
+            >
+              {missingIcons.rotar ? (
+                <span className={styles.iconFallback} aria-hidden="true" />
+              ) : (
+                <img
+                  src={ACTION_ICON_MAP.rotar}
+                  alt="Rotar"
+                  className={styles.iconOnlyButtonImage}
+                  onError={handleIconError("rotar")}
+                />
+              )}
+            </button>
+          </ToolbarTooltip>
+          <ToolbarTooltip label="Espejo vertical">
+            <button
+              type="button"
+              onClick={flipVertical}
+              disabled={!imgEl}
+              aria-label="Espejo vertical"
+              title="Espejo vertical"
+              className={iconButtonClass(Boolean(imgTx.flipY))}
+            >
+              {missingIcons.espejo_v ? (
+                <span className={styles.iconFallback} aria-hidden="true" />
+              ) : (
+                <img
+                  src={ACTION_ICON_MAP.espejo_v}
+                  alt="Espejo vertical"
+                  className={styles.iconOnlyButtonImage}
+                  onError={handleIconError("espejo_v")}
+                />
+              )}
+            </button>
+          </ToolbarTooltip>
+          <ToolbarTooltip label="Espejo horizontal">
+            <button
+              type="button"
+              onClick={flipHorizontal}
+              disabled={!imgEl}
+              aria-label="Espejo horizontal"
+              title="Espejo horizontal"
+              className={iconButtonClass(Boolean(imgTx.flipX))}
+            >
+              {missingIcons.espejo_h ? (
+                <span className={styles.iconFallback} aria-hidden="true" />
+              ) : (
+                <img
+                  src={ACTION_ICON_MAP.espejo_h}
+                  alt="Espejo horizontal"
+                  className={styles.iconOnlyButtonImage}
+                  onError={handleIconError("espejo_h")}
+                />
+              )}
+            </button>
+          </ToolbarTooltip>
+          <ToolbarTooltip label="Cubrir">
+            <button
+              type="button"
+              onClick={fitCover}
+              disabled={!imgEl}
+              aria-label="Cubrir"
+              title="Cubrir"
+              className={iconButtonClass(mode === "cover")}
+            >
+              {missingIcons.cubrir ? (
+                <span className={styles.iconFallback} aria-hidden="true" />
+              ) : (
+                <img
+                  src={ACTION_ICON_MAP.cubrir}
+                  alt="Cubrir"
+                  className={styles.iconOnlyButtonImage}
+                  onError={handleIconError("cubrir")}
+                />
+              )}
+            </button>
+          </ToolbarTooltip>
+          <ToolbarTooltip label="Contener">
+            <button
+              type="button"
+              onClick={fitContain}
+              disabled={!imgEl}
+              aria-label="Contener"
+              title="Contener"
+              className={iconButtonClass(mode === "contain")}
+            >
+              {missingIcons.contener ? (
+                <span className={styles.iconFallback} aria-hidden="true" />
+              ) : (
+                <img
+                  src={ACTION_ICON_MAP.contener}
+                  alt="Contener"
+                  className={styles.iconOnlyButtonImage}
+                  onError={handleIconError("contener")}
+                />
+              )}
+            </button>
+          </ToolbarTooltip>
+          <ToolbarTooltip label="Estirar">
+            <button
+              type="button"
+              onClick={fitStretchCentered}
+              disabled={!imgEl}
+              aria-label="Estirar"
+              title="Estirar"
+              className={iconButtonClass(mode === "stretch")}
+            >
+              {missingIcons.estirar ? (
+                <span className={styles.iconFallback} aria-hidden="true" />
+              ) : (
+                <img
+                  src={ACTION_ICON_MAP.estirar}
+                  alt="Estirar"
+                  className={styles.iconOnlyButtonImage}
+                  onError={handleIconError("estirar")}
+                />
+              )}
+            </button>
+          </ToolbarTooltip>
 
         <span
           className={`${styles.qualityBadge} ${


### PR DESCRIPTION
## Summary
- replace duplicate toolbar button rows with a single ordered layout
- connect each icon to the corresponding existing action including cover, contain and stretch

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d5417adc8327bb210e046bc77f1a