### PR TITLE
Adjust editor layout to fit viewport

### DIFF
--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -6,18 +6,21 @@
   min-height: 100%;
 }
 
+.pageHeading {
+  width: 100%;
+  max-width: 1280px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+
 .editor {
   display: flex;
   flex-direction: column;
   gap: 32px;
   width: 100%;
-  max-width: 1180px;
+  max-width: 1280px;
   margin: 0 auto;
-  padding: 40px;
-  border-radius: 32px;
-  border: 1px solid rgba(37, 37, 48, 0.6);
-  background: rgba(14, 14, 20, 0.96);
-  box-shadow: 0 32px 72px rgba(0, 0, 0, 0.45);
 }
 
 .configAccordion {
@@ -266,7 +269,8 @@
   border: 1px solid rgba(63, 63, 77, 0.55);
   border-radius: 30px;
   padding: 32px;
-  min-height: 520px;
+  min-height: 320px;
+  height: clamp(560px, 70vh, 760px);
 }
 
 .canvasStageEmpty {
@@ -408,13 +412,15 @@
     padding: 28px 28px 48px;
   }
 
+  .pageHeading,
   .editor {
-    padding: 32px;
-    border-radius: 28px;
+    max-width: 100%;
   }
 
   .canvasStage {
     padding: 28px;
+    height: auto;
+    min-height: 520px;
   }
 }
 
@@ -424,13 +430,7 @@
   }
 
   .editor {
-    padding: 24px;
     gap: 24px;
-    border-radius: 24px;
-  }
-
-  .editorHeader {
-    gap: 20px;
   }
 
   .configDropdown {
@@ -449,6 +449,8 @@
   .canvasStage {
     padding: 22px;
     border-radius: 24px;
+    height: auto;
+    min-height: 460px;
   }
 
   .canvasHistoryActions {


### PR DESCRIPTION
## Summary
- move the mousepad editor heading outside the canvas card and compute viewport-based sizing so the stage grows without triggering scroll
- simplify the surrounding layout styles so the canvas is the only visible card while keeping overlays and bottom actions aligned beneath it

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d741951c8327a47365ddcec97341