### PR TITLE
Restore contain button background color popover

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -1187,10 +1187,32 @@ const EditorCanvas = forwardRef(function EditorCanvas(
   const [busy, setBusy] = useState(false);
   const [lastDiag, setLastDiag] = useState(null);
   const toggleContain = () => {
+    if (!imgEl) return;
+    if (mode === "contain") {
+      setColorOpen((prev) => !prev);
+      return;
+    }
     fitContain();
     setColorOpen(true);
   };
   const closeColor = () => setColorOpen(false);
+  useEffect(() => {
+    if (mode !== "contain" && colorOpen) {
+      setColorOpen(false);
+    }
+  }, [mode, colorOpen]);
+  useEffect(() => {
+    if (!imgEl && colorOpen) {
+      setColorOpen(false);
+    }
+  }, [imgEl, colorOpen]);
+  const handleBgColorChange = useCallback(
+    (hex) => {
+      setBgColor(hex);
+      onPickedColor?.(hex);
+    },
+    [onPickedColor],
+  );
   const iconButtonClass = (isActive) =>
     isActive
       ? `${styles.iconOnlyButton} ${styles.iconOnlyButtonActive}`
@@ -1872,26 +1894,43 @@ const EditorCanvas = forwardRef(function EditorCanvas(
               )}
             </button>
           </ToolbarTooltip>
-          <ToolbarTooltip label="Contener">
-            <button
-              type="button"
-              onClick={fitContain}
-              disabled={!imgEl}
-              aria-label="Contener"
-              title="Contener"
-              className={iconButtonClass(mode === "contain")}
-            >
-              {missingIcons.contener ? (
-                <span className={styles.iconFallback} aria-hidden="true" />
-              ) : (
-                <img
-                  src={ACTION_ICON_MAP.contener}
-                  alt="Contener"
-                  className={styles.iconOnlyButtonImage}
-                  onError={handleIconError("contener")}
-                />
+          <ToolbarTooltip label="Contener" disabled={!imgEl}>
+            <div className={styles.colorWrapper}>
+              <button
+                type="button"
+                onClick={toggleContain}
+                disabled={!imgEl}
+                aria-label="Contener"
+                title="Contener"
+                className={iconButtonClass(mode === "contain")}
+              >
+                {missingIcons.contener ? (
+                  <span className={styles.iconFallback} aria-hidden="true" />
+                ) : (
+                  <img
+                    src={ACTION_ICON_MAP.contener}
+                    alt="Contener"
+                    className={styles.iconOnlyButtonImage}
+                    onError={handleIconError("contener")}
+                  />
+                )}
+              </button>
+              {mode === "contain" && colorOpen && (
+                <div className={styles.colorPopoverWrap}>
+                  <ColorPopover
+                    value={bgColor}
+                    onChange={handleBgColorChange}
+                    open={colorOpen}
+                    onClose={closeColor}
+                    onPickFromCanvas={() =>
+                      startPickColor((hex) => {
+                        setBgColor(hex);
+                      })
+                    }
+                  />
+                </div>
               )}
-            </button>
+            </div>
           </ToolbarTooltip>
           <ToolbarTooltip label="Estirar">
             <button


### PR DESCRIPTION
## Summary
- reopen the contain mode background color popover when the contain control is used
- ensure the popover closes when leaving contain mode or clearing the image and propagate color changes to the parent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1dc4bf8948327b8bc8cd4292ac0d5