### PR TITLE
Remove duplicate tooltip from Contener button

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -1943,7 +1943,6 @@ const EditorCanvas = forwardRef(function EditorCanvas(
                 onClick={toggleContain}
                 disabled={!imgEl}
                 aria-label="Contener"
-                title="Contener"
                 className={iconButtonClass(mode === "contain")}
               >
                 {missingIcons.contener ? (


### PR DESCRIPTION
## Summary
- remove the extra browser tooltip from the Contener action button by dropping the redundant `title` attribute

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1e0abae688327a28051c050347070