### PR TITLE
Hide PDF download button on mockup page

### DIFF
--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -193,7 +193,7 @@ export default function Mockup() {
         <button disabled={busy} onClick={() => handle('cart')}>Agregar al carrito y seguir creando</button>
         <button disabled={busy} onClick={() => handle('checkout')}>Comprar ahora</button>
         <button disabled={busy} onClick={() => handle('private')}>Comprar en privado</button>
-        <button disabled={busy} onClick={handleDownloadPdf}>Descargar PDF</button>
+        <button disabled={busy} onClick={handleDownloadPdf} style={{ display: 'none' }}>Descargar PDF</button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- hide the PDF download button on the mockup page so it is no longer visible while leaving the underlying handler intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1e557a2b08327bf9d25bc2d2c19bb