### PR TITLE
style: restyle image upload trigger

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -556,8 +556,12 @@ export default function Home() {
                       className={styles.uploadButton}
                       onClick={openPicker}
                       disabled={busy}
+                      aria-label="Agregar imagen"
+                      role="button"
                     >
-                      <span className={styles.uploadButtonIcon}>+</span>
+                      <span className={styles.uploadButtonIcon} aria-hidden="true">
+                        +
+                      </span>
                       <span className={styles.uploadButtonText}>
                         {busy ? 'Subiendo…' : 'Agregar imagen'}
                       </span>

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -295,48 +295,75 @@
 
 .uploadControl {
   pointer-events: auto;
-  display: inline-flex;
-  padding: 24px 32px;
-  border-radius: 20px;
-  border: 1px solid rgba(63, 63, 77, 0.55);
-  background: rgba(16, 16, 22, 0.96);
-  box-shadow: 0 32px 60px rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
 }
 
 .uploadButton {
-  border: none;
-  background: transparent;
-  font: inherit;
-  font-size: 1.05rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  display: inline-flex;
+  width: min(100%, 640px);
+  min-height: 52px;
+  height: 52px;
+  display: flex;
   align-items: center;
-  gap: 16px;
+  justify-content: space-between;
+  padding: 0 24px;
+  border-radius: 16px;
+  border: 1px solid rgba(63, 63, 77, 0.65);
+  background: rgba(20, 20, 26, 0.92);
+  color: rgba(235, 236, 245, 0.95);
+  font-family: 'Poppins', sans-serif;
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1;
   cursor: pointer;
-  padding: 0;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.4);
+  transition: background-color 0.18s ease, border-color 0.18s ease,
+    box-shadow 0.18s ease;
+  text-align: left;
+  text-transform: none;
+}
+
+.uploadButton:not(:disabled):hover {
+  background: rgba(26, 26, 34, 0.96);
+  border-color: rgba(170, 170, 190, 0.75);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+}
+
+.uploadButton:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.35);
+  outline-offset: 3px;
 }
 
 .uploadButton:disabled {
-  opacity: 0.6;
+  opacity: 0.45;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .uploadButtonIcon {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  border: 1px solid rgba(170, 170, 190, 0.45);
-  background: rgba(170, 170, 190, 0.18);
+  order: 2;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 2rem;
+  font-size: 32px;
+  font-weight: 600;
+  letter-spacing: 0;
   line-height: 1;
-  color: rgba(235, 236, 245, 0.95);
+  color: inherit;
+  flex-shrink: 0;
 }
 
 .uploadButtonText {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 1;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- update the upload trigger layout to occupy a 640×52 button with balanced spacing between label and plus sign
- apply Poppins typography rules and interaction states consistent with the existing theme
- improve accessibility by adding an aria label on the trigger and hiding the decorative plus from screen readers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1e4adc350832788baf7141fed62bf