### PR TITLE
Refactor editor hero layout for larger canvas

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -25,8 +25,8 @@ const CONFIG_ARROW_ICON_SRC = resolveIconAsset('down.svg');
 
 const iconStroke = 2;
 
-const CANVAS_MAX_WIDTH = 1280;
-const CANVAS_IDEAL_HEIGHT = 760;
+const CANVAS_MAX_WIDTH = 1400;
+const CANVAS_IDEAL_HEIGHT = 840;
 const CANVAS_MIN_HEIGHT = 520;
 
 
@@ -358,8 +358,6 @@ export default function Home() {
     const paddingBottom = parsePx(pageStyles?.paddingBottom);
     const paddingLeft = parsePx(pageStyles?.paddingLeft);
     const paddingRight = parsePx(pageStyles?.paddingRight);
-    const pageGap = parsePx(pageStyles?.rowGap || pageStyles?.gap);
-
     const availableWidth = viewportWidth - paddingLeft - paddingRight;
     const widthLimit = availableWidth > 0
       ? Math.min(CANVAS_MAX_WIDTH, availableWidth)
@@ -379,16 +377,21 @@ export default function Home() {
     const headingHeight = headingRef.current?.getBoundingClientRect()?.height || 0;
     const editorStyles = window.getComputedStyle(editorEl);
     const editorGap = parsePx(editorStyles?.rowGap || editorStyles?.gap);
-    const footerHeight = footerRef.current?.getBoundingClientRect()?.height || 0;
+    const editorPaddingTop = parsePx(editorStyles?.paddingTop);
+    const editorPaddingBottom = parsePx(editorStyles?.paddingBottom);
+    const editorMarginTop = parsePx(editorStyles?.marginTop);
+    const editorMarginBottom = parsePx(editorStyles?.marginBottom);
 
     const availableHeight = viewportHeight
       - headerHeight
       - paddingTop
       - paddingBottom
-      - pageGap
+      - editorPaddingTop
+      - editorPaddingBottom
+      - editorMarginTop
+      - editorMarginBottom
       - editorGap
-      - headingHeight
-      - footerHeight;
+      - headingHeight;
 
     let nextHeight = CANVAS_IDEAL_HEIGHT;
     if (availableHeight > 0) {
@@ -514,34 +517,31 @@ export default function Home() {
           sameAs: ['https://www.instagram.com/mgmgamers.store']
         }}
       />
-      <div
-        className={styles.pageHeading}
-        ref={headingRef}
-        style={editorMaxWidthStyle}
-      >
-        <h1 className={styles.title}>Crea tu mousepad</h1>
-      </div>
-
       <section
         className={styles.editor}
         ref={editorRef}
         style={editorMaxWidthStyle}
       >
-        <div className={canvasStageClasses} style={canvasStageStyle}>
-          <div className={styles.canvasViewport}>
+        <div className={styles.editorHeading} ref={headingRef}>
+          <h1 className={styles.title}>Crea tu mousepad</h1>
+        </div>
 
-            <EditorCanvas
-              ref={canvasRef}
-              imageUrl={imageUrl}
-              imageFile={uploaded?.file}
-              sizeCm={activeSizeCm}
-              bleedMm={3}
-              dpi={300}
-              onLayoutChange={setLayout}
-              onClearImage={handleClearImage}
-              showCanvas={isCanvasReady}
-              topLeftOverlay={configDropdown}
-            />
+        <div className={styles.editorStage}>
+          <div className={canvasStageClasses} style={canvasStageStyle}>
+            <div className={styles.canvasViewport}>
+
+              <EditorCanvas
+                ref={canvasRef}
+                imageUrl={imageUrl}
+                imageFile={uploaded?.file}
+                sizeCm={activeSizeCm}
+                bleedMm={3}
+                dpi={300}
+                onLayoutChange={setLayout}
+                onClearImage={handleClearImage}
+                showCanvas={isCanvasReady}
+                topLeftOverlay={configDropdown}
+              />
             {!hasImage && (
               <div className={styles.uploadOverlay}>
                 <UploadStep
@@ -568,7 +568,10 @@ export default function Home() {
             )}
           </div>
         </div>
+        </div>
+      </section>
 
+      <section className={styles.afterFold} style={editorMaxWidthStyle}>
         <div className={styles.footerRow} ref={footerRef}>
           <div className={styles.feedbackGroup}>
             {hasImage && level === 'bad' && (

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -1,17 +1,16 @@
 .page {
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
-  padding: 32px 48px 56px;
-  min-height: 100%;
-}
+  --header-h: 88px;
+  --editor-max-w: 1400px;
+  --lienzo-max-h: 840px;
+  --page-padding-block-start: 32px;
+  --page-padding-block-end: 72px;
 
-.pageHeading {
-  width: 100%;
-  max-width: 1280px;
-  margin: 0 auto;
   display: flex;
   flex-direction: column;
+  align-items: center;
+  gap: 64px;
+  padding: var(--page-padding-block-start) 48px var(--page-padding-block-end);
+  min-height: 100%;
 }
 
 .editor {
@@ -19,8 +18,31 @@
   flex-direction: column;
   gap: 32px;
   width: 100%;
-  max-width: 1280px;
+  max-width: var(--editor-max-w);
   margin: 0 auto;
+  min-height: calc(100vh - var(--header-h) - var(--page-padding-block-start) - var(--page-padding-block-end));
+}
+
+.editorHeading {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.editorStage {
+  flex: 1;
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  min-height: 0;
+}
+
+.afterFold {
+  width: 100%;
+  max-width: var(--editor-max-w);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .configAccordion {
@@ -270,7 +292,9 @@
   border-radius: 30px;
   padding: 32px;
   min-height: 320px;
-  height: clamp(560px, 70vh, 760px);
+  width: 100%;
+  height: clamp(520px, 72vh, var(--lienzo-max-h));
+  max-height: var(--lienzo-max-h);
 }
 
 .canvasStageEmpty {
@@ -409,24 +433,36 @@
 
 @media (max-width: 960px) {
   .page {
-    padding: 28px 28px 48px;
+    --header-h: 80px;
+    --page-padding-block-start: 28px;
+    --page-padding-block-end: 56px;
+    gap: 56px;
+    padding: var(--page-padding-block-start) 28px var(--page-padding-block-end);
   }
 
-  .pageHeading,
-  .editor {
+  .editor,
+  .afterFold {
     max-width: 100%;
+  }
+
+  .editor {
+    gap: 28px;
   }
 
   .canvasStage {
     padding: 28px;
-    height: auto;
-    min-height: 520px;
+    height: clamp(500px, 68vh, var(--lienzo-max-h));
+    min-height: 500px;
   }
 }
 
 @media (max-width: 640px) {
   .page {
-    padding: 22px 18px 40px;
+    --header-h: 72px;
+    --page-padding-block-start: 24px;
+    --page-padding-block-end: 48px;
+    gap: 48px;
+    padding: var(--page-padding-block-start) 18px var(--page-padding-block-end);
   }
 
   .editor {
@@ -449,8 +485,8 @@
   .canvasStage {
     padding: 22px;
     border-radius: 24px;
-    height: auto;
-    min-height: 460px;
+    height: clamp(420px, 72vh, var(--lienzo-max-h));
+    min-height: 420px;
   }
 
   .canvasHistoryActions {


### PR DESCRIPTION
## Summary
- widen the editor hero by introducing layout tokens for max width and canvas height so the first fold fills the viewport without fixed positioning
- restructure the editor markup so the title and canvas live in the first section and move the acknowledgement + Continue controls into a second section after the fold
- adjust the desktop canvas-fit computation to respect the new spacing and paddings while keeping overlay controls inside the canvas card

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1e2a65c8c832797457e9808652b3f