### PR TITLE
Refine background fill color picker layout

### DIFF
--- a/mgm-front/src/components/ColorPopover.jsx
+++ b/mgm-front/src/components/ColorPopover.jsx
@@ -78,40 +78,42 @@ export default function ColorPopover({
         <label className={styles.visuallyHidden} htmlFor={inputId}>
           Hex
         </label>
-        <button
-          type="button"
-          title="Elegir del lienzo"
-          aria-label="Elegir color del lienzo"
-          onClick={handlePick}
-          className={styles.eyedropperButton}
-        >
-          {showEyedropperIcon ? (
-            <img
-              src={EYEDROPPER_ICON_SRC}
-              alt=""
-              className={styles.eyedropperIcon}
-              onError={() => setIconError(true)}
-              draggable="false"
-            />
-          ) : (
-            <span className={styles.eyedropperFallback} aria-hidden="true" />
-          )}
-        </button>
-        <HexColorInput
-          id={inputId}
-          color={hex}
-          onChange={(c) => {
-            const normalized = c.startsWith("#") ? c : `#${c}`;
-            setHex(normalized);
-            onChange?.(normalized);
-          }}
-          prefixed
-          className={styles.hexInput}
-          spellCheck={false}
-          autoComplete="off"
-          autoCorrect="off"
-          autoCapitalize="off"
-        />
+        <div className={styles.hexInputWrapper}>
+          <button
+            type="button"
+            title="Elegir del lienzo"
+            aria-label="Elegir color del lienzo"
+            onClick={handlePick}
+            className={styles.eyedropperButton}
+          >
+            {showEyedropperIcon ? (
+              <img
+                src={EYEDROPPER_ICON_SRC}
+                alt=""
+                className={styles.eyedropperIcon}
+                onError={() => setIconError(true)}
+                draggable="false"
+              />
+            ) : (
+              <span className={styles.eyedropperFallback} aria-hidden="true" />
+            )}
+          </button>
+          <HexColorInput
+            id={inputId}
+            color={hex}
+            onChange={(c) => {
+              const normalized = c.startsWith("#") ? c : `#${c}`;
+              setHex(normalized);
+              onChange?.(normalized);
+            }}
+            prefixed
+            className={styles.hexInput}
+            spellCheck={false}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+          />
+        </div>
       </div>
     </div>
   );

--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -26,30 +26,39 @@
 
 .colorPicker {
   width: 100%;
-  height: 100%;
 }
 
-.colorPicker :global(.react-colorful) {
+/* React Colorful layout overrides: keep selectors in sync with library markup (v5.6.1). */
+:global(.react-colorful).colorPicker {
   width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  height: 100%;
+  max-width: none;
+  height: auto;
   min-height: 0;
+  min-width: 0;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  grid-template-columns: 100%;
+  align-content: stretch;
+  align-items: stretch;
+  justify-items: stretch;
+  gap: 4px;
+  padding: 0;
+  box-sizing: border-box;
 }
 
 .colorPicker :global(.react-colorful__saturation) {
   width: 100%;
   aspect-ratio: 1 / 1;
-  border-radius: 0;
+  border-radius: 16px 16px 0 0;
   overflow: hidden;
   border: none;
   background-color: #1f1f23;
   background-image: linear-gradient(0deg, #000, transparent),
     linear-gradient(90deg, #fff, rgba(255, 255, 255, 0));
   box-shadow: none;
-  flex: 1 1 auto;
   min-height: 0;
+  margin: 0;
+  box-sizing: border-box;
 }
 
 .colorPicker :global(.react-colorful__saturation-pointer) {
@@ -68,7 +77,7 @@
   width: 100%;
   border: none;
   box-shadow: none;
-  flex-shrink: 0;
+  box-sizing: border-box;
 }
 
 .colorPicker :global(.react-colorful__hue-pointer) {
@@ -80,23 +89,10 @@
   background: #ffffff;
 }
 
-.colorPicker :global(.react-colorful__alpha) {
-  height: 12px;
-  border-radius: 0;
-  margin: 0;
-  width: 100%;
-  border: none;
-  box-shadow: none;
-  flex-shrink: 0;
-}
-
-.colorPicker :global(.react-colorful__alpha-pointer) {
-  width: 14px;
-  height: 14px;
-  border-radius: 999px;
-  border: 2px solid #ffffff;
-  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.4);
-  background: #ffffff;
+.colorPicker :global(.react-colorful__alpha),
+.colorPicker :global(.react-colorful__alpha-pointer),
+.colorPicker :global(.react-colorful__alpha-gradient) {
+  display: none;
 }
 
 .eyedropperIcon {
@@ -132,7 +128,17 @@
 }
 
 .hexRow:focus-within .eyedropperButton {
-  border-right-color: rgba(255, 255, 255, 0.24);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.hexInputWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+  width: 100%;
+  min-height: 48px;
 }
 
 .visuallyHidden {
@@ -148,19 +154,22 @@
 }
 
 .eyedropperButton {
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  left: 12px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 48px;
-  min-width: 48px;
-  height: 100%;
+  width: 36px;
   padding: 0;
   border: none;
-  border-right: 1px solid rgba(15, 15, 20, 0.7);
   background: transparent;
   color: inherit;
   cursor: pointer;
   transition: background-color 0.18s ease, color 0.18s ease;
+  z-index: 1;
+  border-radius: 8px;
 }
 
 .eyedropperButton:hover {
@@ -181,7 +190,7 @@
   min-width: 0;
   width: 100%;
   height: 100%;
-  padding: 10px 12px;
+  padding: 10px 12px 10px 56px;
   border: none;
   background: transparent;
   color: #f9fafb;
@@ -189,6 +198,7 @@
   font-family: "JetBrains Mono", "SFMono-Regular", Menlo, monospace;
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  box-sizing: border-box;
 }
 
 .hexInput:focus {


### PR DESCRIPTION
## Summary
- force the react-colorful picker to render as a single-column layout that fills the card and hides unused controls
- preserve a 1:1 saturation square with matching radii and scoped overrides for future library updates
- restyle the HEX row so the eyedropper prefix and input share a clean, aligned field

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1e69f5bb883278b69bdccc0b6e858