### PR TITLE
Ensure Shopify variants publish before cart redirect

### DIFF
--- a/api/[...slug].js
+++ b/api/[...slug].js
@@ -18,6 +18,8 @@ const RATE_LIMITS = {
   'POST upload-url': { limit: 30, windowMs: 60_000 },
   'POST create-cart-link': { limit: 45, windowMs: 60_000 },
   'POST create-checkout': { limit: 45, windowMs: 60_000 },
+  'POST ensure-product-publication': { limit: 30, windowMs: 60_000 },
+  'POST variant-status': { limit: 90, windowMs: 60_000 },
   'GET search-assets': { limit: 30, windowMs: 60_000 },
   'POST shopify-webhook': { limit: 60, windowMs: 60_000 },
 };
@@ -54,6 +56,14 @@ export default withCors(async function handler(req, res) {
       }
       case 'POST create-checkout': {
         const m = await import('../lib/handlers/createCheckout.js');
+        return m.default(req, res);
+      }
+      case 'POST ensure-product-publication': {
+        const m = await import('../lib/handlers/ensureProductPublication.js');
+        return m.default(req, res);
+      }
+      case 'POST variant-status': {
+        const m = await import('../lib/handlers/variantStatus.js');
         return m.default(req, res);
       }
       case 'POST finalize-assets': {

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,6 +14,8 @@ Requests are throttled per client IP. Current limits:
 | POST | `/api/upload-url` | 60 s | 30 |
 | POST | `/api/create-cart-link` | 60 s | 45 |
 | POST | `/api/create-checkout` | 60 s | 45 |
+| POST | `/api/ensure-product-publication` | 60 s | 30 |
+| POST | `/api/variant-status` | 60 s | 90 |
 | POST | `/api/shopify-webhook` | 60 s | 60 |
 | GET | `/api/search-assets` | 60 s | 30 |
 
@@ -46,6 +48,14 @@ Generates a Shopify cart URL. Request body must be JSON matching:
 ### `POST /api/create-checkout`
 
 Builds a Shopify checkout URL with the same body schema as `create-cart-link`. Returns `{ ok: true, url }`. Validation and error codes mirror the cart-link endpoint.
+
+### `POST /api/ensure-product-publication`
+
+Ensures a Shopify product is published to the Online Store channel. The request body must include `productId` (numeric or GraphQL ID). When the product is already available it returns `{ ok: true, published: true }`. Otherwise it triggers publication using the `SHOPIFY_PUBLICATION_ID` (or auto-detected channel) and verifies the resulting status. Responds with `400` for invalid payloads, `404` if the product cannot be found and `502` when Shopify rejects the publication check.
+
+### `POST /api/variant-status`
+
+Checks whether a product variant is published and available for sale in the Online Store channel. Accepts `variantId` (numeric or GraphQL ID) and optional `productId`. Returns `{ ok: true, ready, published, available }` where `ready` is `true` when the variant is published and available. Intended for short polling loops (exponential backoff up to ~30 s) after creating a product. Returns `404` when the variant is not yet accessible and `502` when Shopify cannot fulfill the status query.
 
 ### `POST /api/upload-url`
 

--- a/lib/handlers/ensureProductPublication.js
+++ b/lib/handlers/ensureProductPublication.js
@@ -1,0 +1,122 @@
+import { z } from 'zod';
+import { parseJsonBody } from '../_lib/http.js';
+import { shopifyAdminGraphQL } from '../shopify.js';
+import {
+  ensureProductGid,
+  getOnlineStorePublicationId,
+  publishToOnlineStore,
+} from '../shopify/publication.js';
+
+const BodySchema = z.object({
+  productId: z.union([z.string(), z.number()]),
+  publicationId: z.string().optional(),
+}).passthrough();
+
+function buildQuery(publicationId) {
+  const hasPublication = Boolean(publicationId);
+  const publicationVar = hasPublication ? ', $publicationId: ID!' : '';
+  const publicationField = hasPublication
+    ? 'publishedOnPublication(publicationId: $publicationId)'
+    : '';
+  return `query ProductPublicationStatus($id: ID!${publicationVar}) {
+    product(id: $id) {
+      id
+      status
+      publishedAt
+      publishedOnCurrentPublication
+      ${publicationField}
+    }
+  }`;
+}
+
+function interpretPublicationStatus(product, publicationId) {
+  if (!product || typeof product !== 'object') return false;
+  if (product.publishedAt) return true;
+  if (product.publishedOnCurrentPublication === true) return true;
+  if (publicationId && product.publishedOnPublication === true) return true;
+  return false;
+}
+
+export default async function ensureProductPublication(req, res) {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    return res.json({ ok: false, error: 'method_not_allowed' });
+  }
+  try {
+    const body = await parseJsonBody(req).catch((err) => {
+      if (err?.code === 'payload_too_large') {
+        if (typeof res.status === 'function') res.status(413); else res.statusCode = 413;
+        throw err;
+      }
+      if (err?.code === 'invalid_json') {
+        if (typeof res.status === 'function') res.status(400); else res.statusCode = 400;
+        throw err;
+      }
+      throw err;
+    });
+    const parsed = BodySchema.safeParse(body);
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: 'invalid_body', issues: parsed.error.flatten().fieldErrors });
+    }
+    const { productId, publicationId: overridePublicationId } = parsed.data;
+    const productGid = ensureProductGid(productId);
+    if (!productGid) {
+      return res.status(400).json({ ok: false, error: 'invalid_product' });
+    }
+
+    let publicationId = overridePublicationId?.trim();
+    if (!publicationId) {
+      publicationId = await getOnlineStorePublicationId();
+    }
+    if (!publicationId) {
+      return res.status(502).json({ ok: false, error: 'publication_missing' });
+    }
+
+    const query = buildQuery(publicationId);
+    const variables = publicationId ? { id: productGid, publicationId } : { id: productGid };
+    const statusResp = await shopifyAdminGraphQL(query, variables);
+    const statusJson = await statusResp.json().catch(() => null);
+    if (!statusResp.ok) {
+      return res.status(502).json({ ok: false, error: 'publication_status_failed', status: statusResp.status, detail: statusJson });
+    }
+    const product = statusJson?.data?.product;
+    if (!product) {
+      return res.status(404).json({ ok: false, error: 'product_not_found' });
+    }
+    const alreadyPublished = interpretPublicationStatus(product, publicationId);
+    if (alreadyPublished) {
+      return res.status(200).json({ ok: true, published: true, publicationId });
+    }
+
+    await publishToOnlineStore(productGid, publicationId);
+
+    let finalPublished = true;
+    try {
+      const verifyResp = await shopifyAdminGraphQL(query, variables);
+      const verifyJson = await verifyResp.json().catch(() => null);
+      if (verifyResp.ok) {
+        const verifyProduct = verifyJson?.data?.product;
+        finalPublished = interpretPublicationStatus(verifyProduct, publicationId);
+      }
+    } catch (err) {
+      console.error('ensure_product_publication_verify_failed', err);
+    }
+
+    return res.status(200).json({ ok: true, published: finalPublished, publicationId });
+  } catch (err) {
+    if (err?.message === 'SHOPIFY_ENV_MISSING') {
+      return res.status(400).json({ ok: false, error: 'shopify_env_missing', missing: err?.missing });
+    }
+    if (err?.message === 'online_store_publication_missing') {
+      return res.status(502).json({ ok: false, error: 'publication_missing' });
+    }
+    if (res.statusCode === 413) {
+      return res.json({ ok: false, error: 'payload_too_large' });
+    }
+    if (res.statusCode === 400) {
+      return res.json({ ok: false, error: 'invalid_json' });
+    }
+    console.error('ensure_product_publication_error', err);
+    return res.status(500).json({ ok: false, error: 'ensure_publication_failed' });
+  }
+}

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1,5 +1,6 @@
-import { shopifyAdmin, shopifyAdminGraphQL } from '../shopify.js';
+import { shopifyAdmin } from '../shopify.js';
 import { buildProductUrl } from '../publicStorefront.js';
+import { publishToOnlineStore } from '../shopify/publication.js';
 
 const DEFAULT_VENDOR = 'MgMGamers';
 
@@ -73,70 +74,6 @@ function buildMetaDescription({ productTypeLabel, designName, widthCm, heightCm,
   if (measurement) sections.push(`Medida ${measurement} cm`);
   if (materialLabel) sections.push(`Material ${materialLabel}`);
   return `${sections.join('. ')}.`;
-}
-
-let onlineStorePublicationIdPromise;
-
-async function getOnlineStorePublicationId() {
-  if (!onlineStorePublicationIdPromise) {
-    onlineStorePublicationIdPromise = (async () => {
-      const query = `query OnlineStorePublication {
-        publications(first: 15) {
-          nodes {
-            id
-            name
-            channelDefinition { handle }
-          }
-        }
-      }`;
-      const resp = await shopifyAdminGraphQL(query);
-      const json = await resp.json().catch(() => null);
-      if (!resp.ok) {
-        const err = new Error(`publication_fetch_failed_${resp.status}`);
-        err.body = json;
-        throw err;
-      }
-      const nodes = json?.data?.publications?.nodes || [];
-      const match = nodes.find((node) => node?.channelDefinition?.handle === 'online_store')
-        || nodes.find((node) => typeof node?.name === 'string' && /online/i.test(node.name));
-      if (!match?.id) {
-        throw new Error('online_store_publication_missing');
-      }
-      return String(match.id);
-    })().catch((err) => {
-      onlineStorePublicationIdPromise = undefined;
-      throw err;
-    });
-  }
-  return onlineStorePublicationIdPromise;
-}
-
-async function publishToOnlineStore(productGid) {
-  if (!productGid) return;
-  try {
-    const publicationId = await getOnlineStorePublicationId();
-    if (!publicationId) return;
-    const mutation = `mutation PublishProduct($id: ID!, $publicationId: ID!) {
-      publishablePublish(id: $id, input: { publicationId: $publicationId }) {
-        userErrors { code message field }
-      }
-    }`;
-    const resp = await shopifyAdminGraphQL(mutation, { id: productGid, publicationId });
-    const json = await resp.json().catch(() => null);
-    if (!resp.ok) {
-      const err = new Error(`publish_product_publication_http_${resp.status}`);
-      err.body = json;
-      throw err;
-    }
-    const userErrors = Array.isArray(json?.data?.publishablePublish?.userErrors)
-      ? json.data.publishablePublish.userErrors.filter((err) => err && err.message)
-      : [];
-    if (userErrors.length) {
-      console.error('publish_product_publish_errors', userErrors);
-    }
-  } catch (err) {
-    console.error('publish_product_publish_failed', err);
-  }
 }
 
 export async function publishProduct(req, res) {

--- a/lib/handlers/variantStatus.js
+++ b/lib/handlers/variantStatus.js
@@ -1,0 +1,136 @@
+import { z } from 'zod';
+import { parseJsonBody } from '../_lib/http.js';
+import { shopifyAdminGraphQL } from '../shopify.js';
+import {
+  ensureProductGid,
+  ensureVariantGid,
+  getOnlineStorePublicationId,
+} from '../shopify/publication.js';
+
+const BodySchema = z.object({
+  variantId: z.union([z.string(), z.number()]),
+  productId: z.union([z.string(), z.number()]).optional(),
+  publicationId: z.string().optional(),
+}).passthrough();
+
+function buildQuery(includePublication) {
+  const publicationVar = includePublication ? ', $publicationId: ID!' : '';
+  const publicationArg = includePublication ? '(publicationId: $publicationId)' : '';
+  return `query VariantPublicationStatus($variantId: ID!${publicationVar}) {
+    productVariant(id: $variantId) {
+      id
+      availableForSale
+      currentlyNotInStock
+      inventoryQuantity
+      publishedOnCurrentPublication
+      ${includePublication ? `publishedOnPublication${publicationArg}` : ''}
+      product {
+        id
+        status
+        publishedAt
+        publishedOnCurrentPublication
+        ${includePublication ? `publishedOnPublication${publicationArg}` : ''}
+      }
+    }
+  }`;
+}
+
+function interpretPublicationFlags(entity, includePublication) {
+  if (!entity || typeof entity !== 'object') return { published: false };
+  const flags = [];
+  if (entity.publishedOnCurrentPublication === true) flags.push(true);
+  if (includePublication && entity.publishedOnPublication === true) flags.push(true);
+  if (entity.publishedAt) flags.push(true);
+  return { published: flags.some(Boolean) };
+}
+
+export default async function variantStatus(req, res) {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    return res.json({ ok: false, error: 'method_not_allowed' });
+  }
+  try {
+    const body = await parseJsonBody(req).catch((err) => {
+      if (err?.code === 'payload_too_large') {
+        if (typeof res.status === 'function') res.status(413); else res.statusCode = 413;
+        throw err;
+      }
+      if (err?.code === 'invalid_json') {
+        if (typeof res.status === 'function') res.status(400); else res.statusCode = 400;
+        throw err;
+      }
+      throw err;
+    });
+    const parsed = BodySchema.safeParse(body);
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: 'invalid_body', issues: parsed.error.flatten().fieldErrors });
+    }
+    const { variantId, productId, publicationId: overridePublicationId } = parsed.data;
+    const variantGid = ensureVariantGid(variantId);
+    if (!variantGid) {
+      return res.status(400).json({ ok: false, error: 'invalid_variant' });
+    }
+
+    let publicationId = overridePublicationId?.trim() || '';
+    if (!publicationId) {
+      try {
+        publicationId = await getOnlineStorePublicationId();
+      } catch (err) {
+        if (err?.message === 'SHOPIFY_ENV_MISSING' || err?.message === 'online_store_publication_missing') {
+          publicationId = '';
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    const includePublication = Boolean(publicationId);
+    const query = buildQuery(includePublication);
+    const variables = includePublication
+      ? { variantId: variantGid, publicationId }
+      : { variantId: variantGid };
+
+    const resp = await shopifyAdminGraphQL(query, variables);
+    const json = await resp.json().catch(() => null);
+    if (!resp.ok) {
+      return res.status(502).json({ ok: false, error: 'variant_status_failed', status: resp.status, detail: json });
+    }
+    const variant = json?.data?.productVariant;
+    if (!variant) {
+      return res.status(404).json({ ok: false, error: 'variant_not_found' });
+    }
+
+    const product = variant.product || (productId ? { id: ensureProductGid(productId) } : null);
+    const variantPublication = interpretPublicationFlags(variant, includePublication);
+    const productPublication = interpretPublicationFlags(product, includePublication);
+    const published = variantPublication.published || productPublication.published;
+    const available = variant.availableForSale === true && variant.currentlyNotInStock !== true;
+    const ready = Boolean(published && available);
+
+    return res.status(200).json({
+      ok: true,
+      ready,
+      published,
+      available,
+      variantPublished: Boolean(variantPublication.published),
+      productPublished: Boolean(productPublication.published),
+      productStatus: product?.status || null,
+      productId: product?.id || null,
+      productPublishedAt: product?.publishedAt || null,
+      publicationId: publicationId || null,
+      variantId: variantGid,
+    });
+  } catch (err) {
+    if (res.statusCode === 413) {
+      return res.json({ ok: false, error: 'payload_too_large' });
+    }
+    if (res.statusCode === 400) {
+      return res.json({ ok: false, error: 'invalid_json' });
+    }
+    if (err?.message === 'SHOPIFY_ENV_MISSING') {
+      return res.status(400).json({ ok: false, error: 'shopify_env_missing', missing: err?.missing });
+    }
+    console.error('variant_status_error', err);
+    return res.status(500).json({ ok: false, error: 'variant_status_failed' });
+  }
+}

--- a/lib/shopify/publication.js
+++ b/lib/shopify/publication.js
@@ -1,0 +1,124 @@
+import { shopifyAdminGraphQL } from '../shopify.js';
+
+let onlineStorePublicationIdPromise;
+
+function normalizeId(value) {
+  if (value == null) return '';
+  const raw = String(value).trim();
+  if (!raw) return '';
+  return raw;
+}
+
+function extractNumericId(value) {
+  if (value == null) return '';
+  const raw = String(value).trim();
+  if (!raw) return '';
+  if (/^\d+$/.test(raw)) return raw;
+  const match = raw.match(/(\d+)(?:[^\d]*)$/);
+  return match ? match[1] : '';
+}
+
+export function ensureProductGid(value) {
+  if (!value) return '';
+  const raw = String(value).trim();
+  if (!raw) return '';
+  if (raw.startsWith('gid://')) return raw;
+  const numeric = extractNumericId(raw);
+  if (!numeric) return '';
+  return `gid://shopify/Product/${numeric}`;
+}
+
+export function ensureVariantGid(value) {
+  if (!value) return '';
+  const raw = String(value).trim();
+  if (!raw) return '';
+  if (raw.startsWith('gid://')) return raw;
+  const numeric = extractNumericId(raw);
+  if (!numeric) return '';
+  return `gid://shopify/ProductVariant/${numeric}`;
+}
+
+function getPublicationIdFromEnv() {
+  const raw = normalizeId(process.env.SHOPIFY_PUBLICATION_ID);
+  if (!raw) return '';
+  return raw;
+}
+
+async function fetchOnlineStorePublicationId() {
+  const query = `query OnlineStorePublication {
+    publications(first: 15) {
+      nodes {
+        id
+        name
+        channelDefinition { handle }
+      }
+    }
+  }`;
+  const resp = await shopifyAdminGraphQL(query);
+  const json = await resp.json().catch(() => null);
+  if (!resp.ok) {
+    const err = new Error(`publication_fetch_failed_${resp.status}`);
+    err.body = json;
+    throw err;
+  }
+  const nodes = json?.data?.publications?.nodes || [];
+  const match = nodes.find((node) => node?.channelDefinition?.handle === 'online_store')
+    || nodes.find((node) => typeof node?.name === 'string' && /online/i.test(node.name));
+  if (!match?.id) {
+    throw new Error('online_store_publication_missing');
+  }
+  return String(match.id);
+}
+
+export async function getOnlineStorePublicationId() {
+  const fromEnv = getPublicationIdFromEnv();
+  if (fromEnv) return fromEnv;
+  if (!onlineStorePublicationIdPromise) {
+    onlineStorePublicationIdPromise = fetchOnlineStorePublicationId().catch((err) => {
+      onlineStorePublicationIdPromise = undefined;
+      throw err;
+    });
+  }
+  return onlineStorePublicationIdPromise;
+}
+
+export function resetCachedPublicationId() {
+  onlineStorePublicationIdPromise = undefined;
+}
+
+export async function publishToOnlineStore(productGid, publicationIdOverride) {
+  const publishableId = ensureProductGid(productGid);
+  if (!publishableId) return;
+  try {
+    const publicationId = normalizeId(publicationIdOverride) || await getOnlineStorePublicationId();
+    if (!publicationId) return;
+    const mutation = `mutation PublishProduct($id: ID!, $publicationId: ID!) {
+      publishablePublish(id: $id, input: { publicationId: $publicationId }) {
+        userErrors { code message field }
+      }
+    }`;
+    const resp = await shopifyAdminGraphQL(mutation, { id: publishableId, publicationId });
+    const json = await resp.json().catch(() => null);
+    if (!resp.ok) {
+      const err = new Error(`publish_product_publication_http_${resp.status}`);
+      err.body = json;
+      throw err;
+    }
+    const userErrors = Array.isArray(json?.data?.publishablePublish?.userErrors)
+      ? json.data.publishablePublish.userErrors.filter((err) => err && err.message)
+      : [];
+    if (userErrors.length) {
+      console.error('publish_product_publish_errors', userErrors);
+    }
+  } catch (err) {
+    console.error('publish_product_publish_failed', err);
+  }
+}
+
+export default {
+  ensureProductGid,
+  ensureVariantGid,
+  getOnlineStorePublicationId,
+  publishToOnlineStore,
+  resetCachedPublicationId,
+};

--- a/mgm-front/src/components/Toast.jsx
+++ b/mgm-front/src/components/Toast.jsx
@@ -1,0 +1,25 @@
+import styles from './Toast.module.css';
+
+export default function Toast({ message, actionLabel, onAction, onClose }) {
+  if (!message) return null;
+  return (
+    <div className={styles.toast} role="status" aria-live="assertive">
+      <span className={styles.message}>{message}</span>
+      {actionLabel && onAction ? (
+        <button type="button" className={styles.action} onClick={onAction}>
+          {actionLabel}
+        </button>
+      ) : null}
+      {onClose ? (
+        <button
+          type="button"
+          className={styles.close}
+          onClick={onClose}
+          aria-label="Cerrar notificación"
+        >
+          ×
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/mgm-front/src/components/Toast.module.css
+++ b/mgm-front/src/components/Toast.module.css
@@ -1,0 +1,53 @@
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 32px;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: rgba(17, 17, 17, 0.94);
+  color: #f5f5f5;
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  z-index: 2000;
+  max-width: calc(100% - 32px);
+  backdrop-filter: blur(6px);
+}
+
+.message {
+  flex: 1;
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+.action {
+  border: 1px solid transparent;
+  background: #2563eb;
+  color: #f5f5f5;
+  font-weight: 600;
+  padding: 0.45em 1em;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.action:hover:not(:disabled) {
+  background: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+.close {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1.25rem;
+  padding: 0 4px;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.close:hover {
+  color: #f87171;
+}

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -1,26 +1,34 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { PDFDocument } from 'pdf-lib';
+import Toast from '@/components/Toast.jsx';
 import { useFlow } from '@/state/flow.js';
 import { downloadBlob } from '@/lib/mockup.js';
 import { buildExportBaseName } from '@/lib/filename.ts';
-import { openCartUrl } from '@/lib/cart.ts';
-import { createJobAndProduct } from '@/lib/shopify.ts';
+import {
+  buildCartPermalink,
+  createJobAndProduct,
+  ensureProductPublication,
+  waitForVariantAvailability,
+} from '@/lib/shopify.ts';
 
-const safeClosePopup = (popup) => {
-  if (popup && !popup.closed) {
-    try {
-      popup.close();
-    } catch (closeErr) {
-      console.warn('No se pudo cerrar la ventana emergente', closeErr);
-    }
-  }
+const CART_STATUS_LABELS = {
+  idle: 'Agregar al carrito y seguir creando',
+  creating: 'Creando producto…',
+  publishing: 'Publicando producto…',
+  waiting: 'Preparando carrito…',
+  adding: 'Abriendo carrito…',
 };
+
+const CART_DEFAULT_QUANTITY = 1;
 
 export default function Mockup() {
   const flow = useFlow();
   const navigate = useNavigate();
   const [busy, setBusy] = useState(false);
+  const [cartStatus, setCartStatus] = useState('idle');
+  const [pendingCart, setPendingCart] = useState(null);
+  const [toast, setToast] = useState(null);
 
   if (!flow.mockupUrl) {
     return (
@@ -31,14 +39,181 @@ export default function Mockup() {
     );
   }
 
-  async function handle(mode) {
+  const cartButtonLabel = CART_STATUS_LABELS[cartStatus] || CART_STATUS_LABELS.idle;
 
+  function showFriendlyError(error) {
+    console.error('[mockup]', error);
+    const reasonRaw = typeof error?.reason === 'string' && error.reason
+      ? error.reason
+      : typeof error?.message === 'string' && error.message
+        ? error.message
+        : 'Error';
+    const messageRaw = typeof error?.friendlyMessage === 'string' && error.friendlyMessage
+      ? error.friendlyMessage
+      : String(error?.message || 'Error');
+    let friendly = messageRaw;
+    if (reasonRaw === 'missing_mockup') friendly = 'No se encontró el mockup para publicar.';
+    else if (reasonRaw === 'missing_variant') friendly = 'No se pudo obtener la variante del producto creado en Shopify.';
+    else if (reasonRaw === 'cart_link_failed') friendly = 'No se pudo generar el enlace del carrito. Revisá la configuración de Shopify.';
+    else if (reasonRaw === 'checkout_link_failed') friendly = 'No se pudo generar el enlace de compra.';
+    else if (reasonRaw === 'missing_customer_email' || reasonRaw === 'missing_email') friendly = 'Completá un correo electrónico válido para comprar en privado.';
+    else if (reasonRaw.startsWith('publish_failed')) friendly = 'Shopify rechazó la creación del producto. Revisá los datos enviados.';
+    else if (reasonRaw === 'shopify_error') friendly = 'Shopify devolvió un error al crear el producto.';
+    else if (reasonRaw === 'shopify_env_missing') {
+      const missing = Array.isArray(error?.missing) && error.missing.length
+        ? error.missing.join(', ')
+        : 'SHOPIFY_STORE_DOMAIN, SHOPIFY_ADMIN_TOKEN';
+      friendly = `La integración con Shopify no está configurada. Faltan las variables: ${missing}.`;
+    } else if (reasonRaw === 'shopify_storefront_env_missing') {
+      const missing = Array.isArray(error?.missing) && error.missing.length
+        ? error.missing.join(', ')
+        : 'SHOPIFY_STOREFRONT_TOKEN, SHOPIFY_STOREFRONT_DOMAIN';
+      friendly = `La API Storefront de Shopify no está configurada. Faltan las variables: ${missing}.`;
+    } else if (reasonRaw === 'shopify_cart_user_error') {
+      friendly = 'Shopify rechazó el carrito generado. Intentá nuevamente en unos segundos.';
+    }
+    alert(friendly);
+  }
+
+  function openCartWindow(permalink) {
+    if (typeof window === 'undefined' || !permalink) return false;
+    try {
+      const popup = window.open(permalink, '_blank', 'noopener');
+      if (popup) {
+        try { popup.focus?.(); } catch (focusErr) { console.warn('[cart-popup-focus]', focusErr); }
+        return true;
+      }
+      window.location.assign(permalink);
+      return true;
+    } catch (err) {
+      console.error('[openCartWindow]', err);
+      return false;
+    }
+  }
+
+  function finalizeCartSuccess() {
+    setPendingCart(null);
+    setToast(null);
+    setCartStatus('idle');
+    setBusy(false);
+    flow.reset();
+    try {
+      navigate('/', { replace: true });
+    } catch (navErr) {
+      console.warn('[cart-success-navigate]', navErr);
+    }
+  }
+
+  function attemptCartRedirect(permalink) {
+    const link = permalink
+      || pendingCart?.permalink
+      || (pendingCart?.variantId
+        ? buildCartPermalink(
+          pendingCart.variantId,
+          pendingCart.quantity || CART_DEFAULT_QUANTITY,
+          { returnTo: '/cart' },
+        )
+        : '');
+    if (!link) return;
+    const opened = openCartWindow(link);
+    if (opened) {
+      finalizeCartSuccess();
+    } else {
+      setToast({
+        message: 'No pudimos agregar tu producto al carrito',
+        actionLabel: 'Reintentar',
+        action: () => attemptCartRedirect(link),
+      });
+    }
+  }
+
+  async function startCartFlow(options = {}) {
+    const skipCreation = Boolean(options.skipCreation);
+    if (busy && cartStatus !== 'idle' && !skipCreation) return;
+    setToast(null);
+    let current = pendingCart;
+    try {
+      setBusy(true);
+      if (!skipCreation || !current) {
+        setCartStatus('creating');
+        const result = await createJobAndProduct('cart', flow);
+        if (!result?.variantId) throw new Error('missing_variant');
+        current = {
+          productId: result.productId,
+          variantId: result.variantId,
+          quantity: CART_DEFAULT_QUANTITY,
+        };
+        setPendingCart(current);
+      }
+      if (!current?.variantId) throw new Error('missing_variant');
+
+      setCartStatus('publishing');
+      if (current.productId) {
+        try {
+          await ensureProductPublication(current.productId);
+        } catch (err) {
+          console.warn('[cart-flow] ensure publication failed', err);
+        }
+      }
+
+      setCartStatus('waiting');
+      const waitResult = await waitForVariantAvailability(current.variantId, current.productId, { timeoutMs: 30_000 });
+      if (!waitResult.ready) {
+        setCartStatus('idle');
+        setBusy(false);
+        setToast({
+          message: 'Tu producto se está creando, probá de nuevo',
+          actionLabel: 'Reintentar',
+          action: () => startCartFlow({ skipCreation: true }),
+        });
+        return;
+      }
+
+      const permalink = buildCartPermalink(current.variantId, current.quantity, { returnTo: '/cart' });
+      if (!permalink) {
+        throw new Error('invalid_cart_permalink');
+      }
+      setPendingCart({ ...current, permalink });
+
+      setCartStatus('adding');
+      const opened = openCartWindow(permalink);
+      if (!opened) {
+        setCartStatus('idle');
+        setBusy(false);
+        setToast({
+          message: 'No pudimos agregar tu producto al carrito',
+          actionLabel: 'Reintentar',
+          action: () => attemptCartRedirect(permalink),
+        });
+        return;
+      }
+
+      finalizeCartSuccess();
+    } catch (err) {
+      setCartStatus('idle');
+      setBusy(false);
+      if (err?.name === 'AbortError') return;
+      if (err?.message === 'invalid_cart_permalink') {
+        setToast({
+          message: 'No pudimos agregar tu producto al carrito',
+          actionLabel: 'Reintentar',
+          action: () => startCartFlow({ skipCreation: true }),
+        });
+        return;
+      }
+      showFriendlyError(err);
+    }
+  }
+
+  async function handle(mode) {
     if (mode !== 'checkout' && mode !== 'cart' && mode !== 'private') return;
 
+    if (mode === 'cart') {
+      await startCartFlow();
+      return;
+    }
 
     let submissionFlow = flow;
-    let cartTarget;
-    let cartPopup;
 
     if (mode === 'private') {
       const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -69,13 +244,8 @@ export default function Mockup() {
       submissionFlow = { ...flow, customerEmail: emailRaw };
     }
 
-
     try {
       setBusy(true);
-      if (mode === 'cart' && typeof window !== 'undefined') {
-        cartTarget = `mgm_cart_${Date.now()}`;
-        cartPopup = window.open('https://www.mgmgamers.store/', cartTarget, 'noopener');
-      }
       const result = await createJobAndProduct(mode, submissionFlow);
       if (mode === 'checkout' && result.checkoutUrl) {
         window.location.assign(result.checkoutUrl);
@@ -85,49 +255,13 @@ export default function Mockup() {
         window.location.assign(result.checkoutUrl);
         return;
       }
-      if (mode === 'cart' && result.cartUrl) {
-        openCartUrl(result.cartUrl, { target: cartTarget, popup: cartPopup });
-        flow.reset();
-        navigate('/', { replace: true });
-        return;
-      }
-
       if (result.productUrl) {
-        safeClosePopup(cartPopup);
         window.open(result.productUrl, '_blank', 'noopener');
         return;
       }
-      safeClosePopup(cartPopup);
       alert('El producto se creó pero no se pudo obtener un enlace.');
-    } catch (e) {
-      console.error('[mockup-handle]', e);
-      safeClosePopup(cartPopup);
-      const reasonRaw = typeof e?.reason === 'string' && e.reason ? e.reason : String(e?.message || 'Error');
-      const messageRaw = typeof e?.friendlyMessage === 'string' && e.friendlyMessage
-        ? e.friendlyMessage
-        : String(e?.message || 'Error');
-      let friendly = messageRaw;
-      if (reasonRaw === 'missing_mockup') friendly = 'No se encontró el mockup para publicar.';
-      else if (reasonRaw === 'missing_variant') friendly = 'No se pudo obtener la variante del producto creado en Shopify.';
-      else if (reasonRaw === 'cart_link_failed') friendly = 'No se pudo generar el enlace del carrito. Revisá la configuración de Shopify.';
-      else if (reasonRaw === 'checkout_link_failed') friendly = 'No se pudo generar el enlace de compra.';
-      else if (reasonRaw === 'missing_customer_email' || reasonRaw === 'missing_email') friendly = 'Completá un correo electrónico válido para comprar en privado.';
-      else if (reasonRaw.startsWith('publish_failed')) friendly = 'Shopify rechazó la creación del producto. Revisá los datos enviados.';
-      else if (reasonRaw === 'shopify_error') friendly = 'Shopify devolvió un error al crear el producto.';
-      else if (reasonRaw === 'shopify_env_missing') {
-        const missing = Array.isArray(e?.missing) && e.missing.length
-          ? e.missing.join(', ')
-          : 'SHOPIFY_STORE_DOMAIN, SHOPIFY_ADMIN_TOKEN';
-        friendly = `La integración con Shopify no está configurada. Faltan las variables: ${missing}.`;
-      } else if (reasonRaw === 'shopify_storefront_env_missing') {
-        const missing = Array.isArray(e?.missing) && e.missing.length
-          ? e.missing.join(', ')
-          : 'SHOPIFY_STOREFRONT_TOKEN, SHOPIFY_STOREFRONT_DOMAIN';
-        friendly = `La API Storefront de Shopify no está configurada. Faltan las variables: ${missing}.`;
-      } else if (reasonRaw === 'shopify_cart_user_error') {
-        friendly = 'Shopify rechazó el carrito generado. Intentá nuevamente en unos segundos.';
-      }
-      alert(friendly);
+    } catch (error) {
+      showFriendlyError(error);
     } finally {
       setBusy(false);
     }
@@ -190,12 +324,19 @@ export default function Mockup() {
       />
       <div style={{ marginTop: 16, display: 'flex', gap: 12, justifyContent: 'center' }}>
         <button disabled={busy} onClick={() => { flow.reset(); navigate('/'); }}>Cancelar y volver</button>
-        <button disabled={busy} onClick={() => handle('cart')}>Agregar al carrito y seguir creando</button>
+        <button disabled={busy} onClick={() => handle('cart')}>{cartButtonLabel}</button>
         <button disabled={busy} onClick={() => handle('checkout')}>Comprar ahora</button>
         <button disabled={busy} onClick={() => handle('private')}>Comprar en privado</button>
         <button disabled={busy} onClick={handleDownloadPdf} style={{ display: 'none' }}>Descargar PDF</button>
       </div>
+      {toast ? (
+        <Toast
+          message={toast.message}
+          actionLabel={toast.actionLabel}
+          onAction={toast.action}
+          onClose={() => setToast(null)}
+        />
+      ) : null}
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- add reusable Shopify publication helpers and new API handlers to ensure products/variants reach the Online Store channel before use
- document and expose ensure-product-publication and variant-status endpoints through the API router
- update the add-to-cart UX to poll availability, build a Shopify cart permalink, and surface retry toasts via a new Toast component

## Testing
- npm test *(fails: moderation fixtures expect local model data)*
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1e9faff7c832793ddac81958d4e51