### PR TITLE
Adjust color picker scaling and contain toggle workflow

### DIFF
--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -1,3 +1,14 @@
+.colorPickerWrapper {
+  --picker-scale: 0.5;
+  position: relative;
+  display: inline-block;
+  overflow: visible;
+  width: calc(320px * var(--picker-scale));
+  height: calc(416px * var(--picker-scale));
+  min-width: calc(320px * var(--picker-scale));
+  min-height: calc(416px * var(--picker-scale));
+}
+
 .colorPopover {
   display: flex;
   flex-direction: column;
@@ -10,6 +21,11 @@
   border: 1px solid rgba(255, 255, 255, 0.06);
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.55);
   color: #f3f4f6;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: scale(var(--picker-scale));
+  transform-origin: top left;
 }
 
 .pickerArea {
@@ -409,6 +425,29 @@
   bottom: 100%;
   left: 0;
   margin-bottom: 8px;
+}
+
+.toolbarStack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  pointer-events: none;
+}
+
+.colorToast {
+  pointer-events: none;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: rgba(16, 185, 129, 0.18);
+  border: 1px solid rgba(16, 185, 129, 0.45);
+  color: #bbf7d0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  line-height: 1.3;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.45);
+  text-align: center;
 }
 
 .qualityBadge {


### PR DESCRIPTION
## Summary
- scale the color picker through a wrapper that measures the scaled size, keeps layout intact, and focuses the HEX field when opened
- manage an explicit OPEN/CLOSED color picker state so the contain button saves on the second click, fires the existing color callback, and shows an accessible “Color aplicado” toast
- add styling hooks for the scaled picker wrapper, toast stack, and success badge so the toolbar layout and feedback remain consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ea7d4a9083279eeaabe3b162e3df