### PR TITLE
Revamp color picker popover and toggles

### DIFF
--- a/mgm-front/src/components/ColorPopover.jsx
+++ b/mgm-front/src/components/ColorPopover.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { HexColorPicker, HexColorInput } from "react-colorful";
 import { resolveIconAsset } from "@/lib/iconRegistry.js";
 import styles from "./EditorCanvas.module.css";
@@ -11,18 +11,88 @@ const PICKER_SCALE = 0.5;
 const PICKER_BASE_WIDTH = 320;
 const PICKER_BASE_HEIGHT = 416;
 
+const computeReadableTextColor = (hex) => {
+  if (!hex) return "#f9fafb";
+  let normalized = hex.trim().replace(/^#/, "");
+  if (normalized.length === 3) {
+    normalized = normalized
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+  if (normalized.length !== 6) return "#f9fafb";
+  const r = parseInt(normalized.slice(0, 2), 16);
+  const g = parseInt(normalized.slice(2, 4), 16);
+  const b = parseInt(normalized.slice(4, 6), 16);
+  if ([r, g, b].some((v) => Number.isNaN(v))) return "#f9fafb";
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+  return brightness > 155 ? "#111827" : "#f9fafb";
+};
+
+const PencilIcon = (props) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.6"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="M4.25 20l3.9-.84L18.6 8.71a1.75 1.75 0 0 0 0-2.47l-2.84-2.84a1.75 1.75 0 0 0-2.47 0L2.84 15.9 2 20.75" />
+    <path d="M12.92 5.08l6 6" />
+  </svg>
+);
+
+const GridIcon = (props) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.6"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <rect x="3.5" y="3.5" width="17" height="17" rx="3" />
+    <path d="M3.5 12h17" />
+    <path d="M12 3.5v17" />
+  </svg>
+);
+
+const BlankIcon = (props) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.6"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <rect x="3.5" y="3.5" width="17" height="17" rx="3" />
+  </svg>
+);
+
 export default function ColorPopover({
   value,
   onChange,
   open,
   onClose,
   onPickFromCanvas,
+  activeMode,
+  onToggleMode,
+  quality,
 }) {
   const wrapperRef = useRef(null);
   const contentRef = useRef(null);
   const inputId = useId();
   const [hex, setHex] = useState(value || "#ffffff");
   const [iconError, setIconError] = useState(false);
+  const inputRef = useRef(null);
   const [wrapperSize, setWrapperSize] = useState({
     width: PICKER_BASE_WIDTH * PICKER_SCALE,
     height: PICKER_BASE_HEIGHT * PICKER_SCALE,
@@ -91,7 +161,7 @@ export default function ColorPopover({
 
   useEffect(() => {
     if (!open) return;
-    const el = document.getElementById(inputId);
+    const el = inputRef.current;
     if (!el) return;
     requestAnimationFrame(() => {
       el.focus({ preventScroll: true });
@@ -99,7 +169,7 @@ export default function ColorPopover({
         el.select();
       }
     });
-  }, [open, inputId]);
+  }, [open]);
 
   const handlePick = async () => {
     try {
@@ -117,6 +187,14 @@ export default function ColorPopover({
     onClose?.();
   };
 
+  const normalizedHex = hex?.startsWith("#") ? hex : `#${hex}`;
+  const hexTextColor = useMemo(
+    () => computeReadableTextColor(normalizedHex),
+    [normalizedHex],
+  );
+  const qualityLabel = quality?.label ? quality.label : "—";
+  const qualityColor = quality?.color ? quality.color : "#f9fafb";
+
   if (!open) return null;
 
   const showEyedropperIcon = EYEDROPPER_ICON_SRC && !iconError;
@@ -125,6 +203,20 @@ export default function ColorPopover({
     "--picker-scale": PICKER_SCALE,
     width: `${wrapperSize.width}px`,
     height: `${wrapperSize.height}px`,
+  };
+
+  const handleModeClick = (mode) => {
+    if (!onToggleMode) return;
+    onToggleMode(mode);
+  };
+
+  const focusHexInput = () => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.focus({ preventScroll: true });
+    if (typeof el.select === "function") {
+      el.select();
+    }
   };
 
   return (
@@ -148,13 +240,16 @@ export default function ColorPopover({
           <label className={styles.visuallyHidden} htmlFor={inputId}>
             Hex
           </label>
-          <div className={styles.hexInputWrapper}>
+          <div
+            className={styles.hexInputWrapper}
+            style={{ background: normalizedHex, color: hexTextColor }}
+          >
             <button
               type="button"
               title="Elegir del lienzo"
               aria-label="Elegir color del lienzo"
               onClick={handlePick}
-              className={styles.eyedropperButton}
+              className={styles.hexIconButton}
             >
               {showEyedropperIcon ? (
                 <img
@@ -169,6 +264,7 @@ export default function ColorPopover({
               )}
             </button>
             <HexColorInput
+              ref={inputRef}
               id={inputId}
               color={hex}
               onChange={(c) => {
@@ -182,7 +278,44 @@ export default function ColorPopover({
               autoComplete="off"
               autoCorrect="off"
               autoCapitalize="off"
+              style={{ color: hexTextColor }}
             />
+            <button
+              type="button"
+              className={`${styles.hexIconButton} ${styles.hexIconButtonRight}`}
+              onClick={focusHexInput}
+              title="Editar código hexadecimal"
+              aria-label="Editar código hexadecimal"
+            >
+              <PencilIcon className={styles.panelIcon} />
+            </button>
+          </div>
+          <div className={styles.modeToggleRow}>
+            <button
+              type="button"
+              onClick={() => handleModeClick("contain")}
+              className={`${styles.modeToggleButton} ${
+                activeMode === "contain" ? styles.modeToggleButtonActive : ""
+              }`}
+              aria-pressed={activeMode === "contain"}
+            >
+              <GridIcon className={styles.modeToggleIcon} />
+              <span>Contener</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => handleModeClick("cover")}
+              className={`${styles.modeToggleButton} ${
+                activeMode === "cover" ? styles.modeToggleButtonActive : ""
+              }`}
+              aria-pressed={activeMode === "cover"}
+            >
+              <BlankIcon className={styles.modeToggleIcon} />
+              <span>Diseño completo</span>
+            </button>
+            <span className={styles.qualityText} style={{ color: qualityColor }}>
+              Calidad: {qualityLabel}
+            </span>
           </div>
         </div>
       </div>

--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -119,22 +119,23 @@
 }
 
 .eyedropperFallback {
-  width: 20px;
-  height: 20px;
+  width: 25px;
+  height: 25px;
   border-radius: 999px;
   border: 2px dashed rgba(249, 250, 251, 0.55);
 }
 
 .hexRow {
   display: flex;
-  align-items: stretch;
+  flex-direction: column;
+  gap: 18px;
   width: 100%;
-  min-height: 48px;
   border: 1px solid rgba(15, 15, 20, 0.7);
   border-top: none;
   border-radius: 0 0 16px 16px;
-  background: #25252c;
-  overflow: hidden;
+  background: radial-gradient(circle at 20% 0%, #2f2f35, #23232a);
+  padding: 22px 20px 26px;
+  box-sizing: border-box;
   transition: border-color 0.18s ease, box-shadow 0.18s ease;
 }
 
@@ -143,18 +144,23 @@
   box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
-.hexRow:focus-within .eyedropperButton {
-  background: rgba(255, 255, 255, 0.06);
+.hexRow:focus-within .hexIconButton {
+  border-color: rgba(255, 255, 255, 0.4);
+  background: rgba(8, 8, 16, 0.4);
 }
 
 .hexInputWrapper {
-  position: relative;
   display: flex;
   align-items: center;
-  flex: 1 1 auto;
+  gap: 12px;
   min-width: 0;
   width: 100%;
-  min-height: 48px;
+  min-height: 62px;
+  border-radius: 18px;
+  padding: 8px 12px 8px 16px;
+  box-sizing: border-box;
+  background: rgba(12, 12, 18, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .visuallyHidden {
@@ -169,52 +175,57 @@
   border: 0;
 }
 
-.eyedropperButton {
-  position: absolute;
-  top: 8px;
-  bottom: 8px;
-  left: 12px;
+.hexIconButton {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
+  width: 54px;
+  height: 54px;
   padding: 0;
-  border: none;
-  background: transparent;
+  margin: 0;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: rgba(8, 8, 16, 0.3);
   color: inherit;
   cursor: pointer;
-  transition: background-color 0.18s ease, color 0.18s ease;
-  z-index: 1;
-  border-radius: 8px;
+  transition: background-color 0.18s ease, border-color 0.18s ease,
+    box-shadow 0.18s ease;
 }
 
-.eyedropperButton:hover {
-  background: rgba(255, 255, 255, 0.08);
+.hexIconButton:hover {
+  background: rgba(8, 8, 16, 0.5);
+  border-color: rgba(255, 255, 255, 0.4);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
 }
 
-.eyedropperButton:active {
-  background: rgba(255, 255, 255, 0.14);
+.hexIconButton:active {
+  background: rgba(4, 4, 10, 0.55);
+  border-color: rgba(255, 255, 255, 0.26);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
-.eyedropperButton:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.65);
-  outline-offset: -2px;
+.hexIconButton:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 3px;
+}
+
+.hexIconButtonRight {
+  background: rgba(8, 8, 16, 0.4);
 }
 
 .hexInput {
-  flex: 1;
+  flex: 1 1 auto;
   min-width: 0;
-  width: 100%;
-  height: 100%;
-  padding: 10px 12px 10px 56px;
   border: none;
   background: transparent;
-  color: #f9fafb;
-  font-size: 15px;
+  color: inherit;
+  font-size: 25px;
   font-family: "JetBrains Mono", "SFMono-Regular", Menlo, monospace;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  box-sizing: border-box;
+  letter-spacing: 0.08em;
+  text-align: center;
+  line-height: 1.1;
+  padding: 4px 12px;
 }
 
 .hexInput:focus {
@@ -223,6 +234,77 @@
 
 .hexInput::placeholder {
   color: rgba(249, 250, 251, 0.35);
+}
+
+.panelIcon,
+.modeToggleIcon {
+  width: 25px;
+  height: 25px;
+  display: block;
+  flex-shrink: 0;
+}
+
+.modeToggleRow {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.modeToggleButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 20px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(20, 20, 28, 0.55);
+  color: #f9fafb;
+  font-size: 25px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  line-height: 1.15;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease,
+    background 0.18s ease, box-shadow 0.18s ease;
+  flex: 0 0 auto;
+}
+
+.modeToggleButton:hover {
+  transform: translateY(-1px);
+  background: rgba(32, 32, 42, 0.7);
+  border-color: rgba(255, 255, 255, 0.4);
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.45);
+}
+
+.modeToggleButton:active {
+  transform: translateY(0);
+  background: rgba(18, 18, 28, 0.75);
+  border-color: rgba(255, 255, 255, 0.3);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.modeToggleButton:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.75);
+  outline-offset: 3px;
+}
+
+.modeToggleButtonActive {
+  background: rgba(75, 75, 95, 0.75);
+  border-color: rgba(255, 255, 255, 0.5);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.45);
+}
+
+.qualityText {
+  margin-left: auto;
+  font-size: 25px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1.2;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  flex: 1 1 200px;
+  min-width: 0;
+  text-align: right;
 }
 
 
@@ -417,14 +499,8 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-}
-
-.colorPopoverWrap {
-  position: absolute;
-  z-index: 20;
-  bottom: 100%;
-  left: 0;
-  margin-bottom: 8px;
+  gap: 6px;
+  pointer-events: auto;
 }
 
 .toolbarStack {
@@ -433,21 +509,6 @@
   align-items: center;
   gap: 10px;
   pointer-events: none;
-}
-
-.colorToast {
-  pointer-events: none;
-  padding: 6px 16px;
-  border-radius: 999px;
-  background: rgba(16, 185, 129, 0.18);
-  border: 1px solid rgba(16, 185, 129, 0.45);
-  color: #bbf7d0;
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  line-height: 1.3;
-  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.45);
-  text-align: center;
 }
 
 .qualityBadge {
@@ -660,15 +721,38 @@
     bottom: 12px;
     max-width: calc(100% - 24px);
   }
+
+  .hexInputWrapper {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 16px;
+    gap: 16px;
+  }
+
+  .hexIconButton {
+    width: 100%;
+    height: 56px;
+  }
+
+  .modeToggleRow {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 18px;
+  }
+
+  .modeToggleButton {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .qualityText {
+    margin-left: 0;
+    width: 100%;
+    text-align: center;
+  }
 }
 
 
-
-/* El wrapper del botón + popover sirve de ancla para el popover */
-.colorWrapper {
-  position: relative;
-          /* <- ancla local para posicionar el popover */
-}
 
 /* Sacamos el popover del flujo para que NO empuje el ancho del toolbar */
 .colorPopoverWrap {
@@ -676,6 +760,12 @@
   inset-block-end: calc(100% + 4px);   /* bottom */
   inset-inline-start: 0;               /* left */
   z-index: 1000;
+  margin-bottom: 4px;
+}
+
+.colorPopoverAlignRight {
+  inset-inline-start: auto;
+  inset-inline-end: 0;
 }
 
 /* El badge de calidad no rompe línea (si querés que no se corte) */


### PR DESCRIPTION
## Summary
- Redesign the color popover with a larger bottom panel, new inline icons, contain/design toggles, and quality status display.
- Update toolbar logic so the Contener and Diseño completo buttons share the popover, toggle it open/closed, and respect outside-click dismissal.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1efdd6de08327ab31942c4e331b5c