### PR TITLE
Adjust color picker layout and toggle behavior

### DIFF
--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -127,9 +127,9 @@
 
 .hexRow {
   display: flex;
-  align-items: stretch;
+  align-items: center;
   width: 100%;
-  min-height: 48px;
+  min-height: 72px;
   border: 1px solid rgba(15, 15, 20, 0.7);
   border-top: none;
   border-radius: 0 0 16px 16px;
@@ -154,7 +154,7 @@
   flex: 1 1 auto;
   min-width: 0;
   width: 100%;
-  min-height: 48px;
+  min-height: 72px;
 }
 
 .visuallyHidden {
@@ -171,13 +171,14 @@
 
 .eyedropperButton {
   position: absolute;
-  top: 8px;
-  bottom: 8px;
-  left: 12px;
+  top: 50%;
+  left: 16px;
+  transform: translateY(-50%);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
+  width: 44px;
+  height: 44px;
   padding: 0;
   border: none;
   background: transparent;
@@ -185,7 +186,7 @@
   cursor: pointer;
   transition: background-color 0.18s ease, color 0.18s ease;
   z-index: 1;
-  border-radius: 8px;
+  border-radius: 10px;
 }
 
 .eyedropperButton:hover {
@@ -205,12 +206,13 @@
   flex: 1;
   min-width: 0;
   width: 100%;
-  height: 100%;
-  padding: 10px 12px 10px 56px;
+  height: auto;
+  padding: 14px 18px 14px 78px;
   border: none;
   background: transparent;
   color: #f9fafb;
-  font-size: 15px;
+  font-size: 25px;
+  line-height: 28px;
   font-family: "JetBrains Mono", "SFMono-Regular", Menlo, monospace;
   text-transform: uppercase;
   letter-spacing: 0.05em;


### PR DESCRIPTION
## Summary
- enlarge the HEX row typography and spacing for the color picker eyedropper/input
- add debounced change completion handling so colors apply from the picker without using the button
- make the "contener" button simply toggle the picker while keeping the label static

## Testing
- npm --prefix mgm-front run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1f967b1048327990a2f4274985dc5