### PR TITLE
Fix color picker contain button behavior

### DIFF
--- a/mgm-front/src/components/ColorPopover.jsx
+++ b/mgm-front/src/components/ColorPopover.jsx
@@ -18,6 +18,7 @@ export default function ColorPopover({
   open,
   onClose,
   onPickFromCanvas,
+  anchorRef,
 }) {
   const wrapperRef = useRef(null);
   const contentRef = useRef(null);
@@ -36,7 +37,12 @@ export default function ColorPopover({
     if (!open) return;
     const onDown = (e) => {
       if (!wrapperRef.current) return;
-      if (!wrapperRef.current.contains(e.target)) onClose?.();
+      if (
+        !wrapperRef.current.contains(e.target) &&
+        !(anchorRef?.current && anchorRef.current.contains(e.target))
+      ) {
+        onClose?.();
+      }
     };
     const onKey = (e) => {
       if (e.key === "Escape") onClose?.();
@@ -47,7 +53,7 @@ export default function ColorPopover({
       document.removeEventListener("mousedown", onDown);
       document.removeEventListener("keydown", onKey);
     };
-  }, [open, onClose]);
+  }, [open, onClose, anchorRef]);
 
   useEffect(() => {
     if (open) setIconError(false);


### PR DESCRIPTION
## Summary
- remove the "Color aplicado" toast so color selections apply silently
- rework the contain button handler to manage the picker with an explicit open state and interaction lock
- ignore contain-button clicks in the color popover's outside click handler to prevent unintended reopens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1fd160278832790c003df235da4c8