### PR TITLE
Restyle low-quality acknowledgement and continue button

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -574,12 +574,14 @@ export default function Home() {
           <div className={styles.feedbackGroup}>
             {hasImage && level === 'bad' && (
               <label className={styles.ackLabel}>
+                <span className={styles.ackLabelText}>
+                  Acepto imprimir en baja calidad ({effDpi} DPI)
+                </span>
                 <input
                   type="checkbox"
                   checked={ackLow}
                   onChange={e => setAckLow(e.target.checked)}
-                />{' '}
-                <span>Acepto imprimir en baja calidad ({effDpi} DPI)</span>
+                />
               </label>
             )}
             {err && <p className={`errorText ${styles.errorMessage}`}>{err}</p>}

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -433,34 +433,61 @@
 
 .footerRow {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
 }
 
 .feedbackGroup {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  flex: 1 1 320px;
+  width: 100%;
   min-width: 0;
 }
 
 .ackLabel {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 12px 18px;
-  border-radius: 14px;
-  border: 1px solid rgba(63, 63, 77, 0.55);
-  background: rgba(16, 16, 22, 0.9);
-  color: rgba(229, 231, 235, 0.9);
-  font-size: 0.9rem;
+  justify-content: space-between;
+  gap: 16px;
+  width: 100%;
+  min-height: 44px;
+  padding: 12px 16px;
+  border-radius: 11px;
+  border: 1px solid rgba(128, 128, 128, 0.2);
+  background: rgba(40, 40, 40, 0.6);
+  color: rgba(245, 245, 248, 0.92);
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.ackLabel:hover {
+  border-color: rgba(128, 128, 128, 0.35);
+  background: rgba(40, 40, 40, 0.7);
+}
+
+.ackLabel:focus-within {
+  border-color: rgba(148, 163, 255, 0.45);
+  box-shadow: 0 0 0 3px rgba(148, 163, 255, 0.18);
+}
+
+.ackLabelText {
+  flex: 1;
+  font-family: 'Poppins', sans-serif;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.45;
+  letter-spacing: 0;
+  color: inherit;
 }
 
 .ackLabel input {
+  width: 18px;
+  height: 18px;
   accent-color: initial;
+  flex-shrink: 0;
 }
 
 .errorMessage {
@@ -475,27 +502,38 @@
 }
 
 .continueButton {
-  border-radius: 16px;
-  border: 1px solid rgba(63, 63, 77, 0.6);
-  background: rgba(238, 238, 242, 0.95);
-  color: #111;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 52px;
+  padding: 0 20px;
+  border-radius: 11px;
+  border: 1px solid rgba(128, 128, 128, 0.2);
+  background: rgba(40, 40, 40, 0.6);
+  color: rgba(245, 245, 248, 0.95);
   font-size: 1rem;
   font-weight: 600;
-  padding: 14px 28px;
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.4);
+  line-height: 1;
+  text-align: center;
   cursor: pointer;
-  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.continueButton:hover:not(:disabled) {
+  background: rgba(40, 40, 40, 0.72);
+  border-color: rgba(128, 128, 128, 0.35);
+}
+
+.continueButton:focus-visible {
+  outline: 2px solid rgba(148, 163, 255, 0.55);
+  outline-offset: 3px;
 }
 
 .continueButton:disabled {
-  opacity: 0.5;
+  opacity: 0.45;
   cursor: not-allowed;
-  box-shadow: none;
-}
-
-.continueButton:not(:disabled):hover {
-  transform: translateY(-2px);
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
 }
 @media (prefers-reduced-motion: reduce) {
   .tutorialButton,


### PR DESCRIPTION
## Summary
- restyle the low-quality printing acknowledgement as a full-width capsule with the checkbox aligned to the right
- update the Continue button to match the new capsule styling, including hover, focus-visible, and disabled states
- adjust the footer layout so both controls span the full width with consistent vertical spacing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2f2b38e3c8327ae57a8bcbad5ecd0