### PR TITLE
Compute editor canvas height at runtime

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -161,6 +161,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
     showHistoryControls = true,
     onHistoryChange,
     topLeftOverlay,
+    lienzoHeight,
   },
   ref,
 ) {
@@ -1373,6 +1374,8 @@ const EditorCanvas = forwardRef(function EditorCanvas(
   ]
     .filter(Boolean)
     .join(' ');
+  const lienzoStyle = lienzoHeight != null ? { height: `${lienzoHeight}px` } : undefined;
+  const canvasSurfaceStyle = useMemo(() => ({ height: '100%' }), []);
   // track latest callback to avoid effect loops when parent re-renders
   const layoutChangeRef = useRef(onLayoutChange);
   useEffect(() => {
@@ -1446,10 +1449,10 @@ const EditorCanvas = forwardRef(function EditorCanvas(
 
   return (
     <div className={styles.editorRoot}>
-      <div className={styles.lienzo}>
+      <div className={styles.lienzo} style={lienzoStyle}>
         {/* Canvas */}
-        <div ref={wrapRef} className={wrapperClassName}>
-        <Stage
+        <div ref={wrapRef} className={wrapperClassName} style={canvasSurfaceStyle}>
+          <Stage
           ref={stageRef}
           width={wrapSize.w}
           height={wrapSize.h}

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -27,8 +27,8 @@ const TUTORIAL_ICON_SRC = resolveIconAsset('play.svg');
 const iconStroke = 2;
 
 const CANVAS_MAX_WIDTH = 1280;
-const CANVAS_IDEAL_HEIGHT = 960;
-const CANVAS_MIN_HEIGHT = 420;
+const LIENZO_MIN_HEIGHT = 560;
+const LIENZO_MAX_VH = 0.88;
 
 
 export default function Home() {
@@ -323,14 +323,13 @@ export default function Home() {
 
     const viewportWidth = window.innerWidth || 0;
     const viewportHeight = window.innerHeight || 0;
-    const headerEl = document.querySelector('header');
-    const headerHeight = headerEl?.getBoundingClientRect()?.height || 0;
 
-    const pageStyles = window.getComputedStyle(pageEl);
-    const parsePx = value => {
+    const parsePx = (value) => {
       const parsed = Number.parseFloat(value);
       return Number.isFinite(parsed) ? parsed : 0;
     };
+
+    const pageStyles = window.getComputedStyle(pageEl);
     const paddingTop = parsePx(pageStyles?.paddingTop);
     const paddingBottom = parsePx(pageStyles?.paddingBottom);
     const paddingLeft = parsePx(pageStyles?.paddingLeft);
@@ -345,7 +344,7 @@ export default function Home() {
     const isDesktop = viewportWidth >= 960;
 
     if (!isDesktop) {
-      setCanvasFit(prev => (
+      setCanvasFit((prev) => (
         prev.height === null && prev.maxWidth === widthLimit
           ? prev
           : { height: null, maxWidth: widthLimit }
@@ -353,31 +352,38 @@ export default function Home() {
       return;
     }
 
-    const headingHeight = headingRef.current?.getBoundingClientRect()?.height || 0;
+    const headerHeight = document
+      .querySelector('header')
+      ?.getBoundingClientRect()?.height || 0;
+
+    const headingEl = headingRef.current;
+    const headingRect = headingEl?.getBoundingClientRect();
+    const headingStyles = headingEl ? window.getComputedStyle(headingEl) : null;
+    const headingMarginTop = parsePx(headingStyles?.marginTop);
+    const headingMarginBottom = parsePx(headingStyles?.marginBottom);
+    const titleGap = (headingRect?.height || 0) + headingMarginTop + headingMarginBottom;
+
     const editorStyles = window.getComputedStyle(editorEl);
     const editorGap = parsePx(editorStyles?.rowGap || editorStyles?.gap);
-    const footerHeight = footerRef.current?.getBoundingClientRect()?.height || 0;
 
-    const availableHeight = viewportHeight
-      - headerHeight
-      - paddingTop
-      - paddingBottom
-      - pageGap
-      - editorGap
-      - headingHeight
-      - footerHeight;
+    const footerEl = footerRef.current;
+    const footerRect = footerEl?.getBoundingClientRect();
+    const footerStyles = footerEl ? window.getComputedStyle(footerEl) : null;
+    const footerMarginTop = parsePx(footerStyles?.marginTop);
+    const footerMarginBottom = parsePx(footerStyles?.marginBottom);
+    const footerBlock = (footerRect?.height || 0) + footerMarginTop + footerMarginBottom;
 
-    let nextHeight = CANVAS_IDEAL_HEIGHT;
-    if (availableHeight > 0) {
-      nextHeight = Math.min(CANVAS_IDEAL_HEIGHT, availableHeight);
-      if (availableHeight >= CANVAS_MIN_HEIGHT) {
-        nextHeight = Math.max(nextHeight, CANVAS_MIN_HEIGHT);
-      }
-    } else {
-      nextHeight = CANVAS_MIN_HEIGHT;
-    }
+    const outerGap = paddingTop + paddingBottom + pageGap + editorGap + footerBlock;
 
-    setCanvasFit(prev => (
+    const rawHeight = viewportHeight - headerHeight - titleGap - outerGap;
+    const maxHeight = Math.max(LIENZO_MIN_HEIGHT, viewportHeight * LIENZO_MAX_VH);
+
+    const nextHeight = Math.max(
+      LIENZO_MIN_HEIGHT,
+      Math.min(maxHeight, Number.isFinite(rawHeight) ? rawHeight : LIENZO_MIN_HEIGHT),
+    );
+
+    setCanvasFit((prev) => (
       prev.height === nextHeight && prev.maxWidth === widthLimit
         ? prev
         : { height: nextHeight, maxWidth: widthLimit }
@@ -407,10 +413,6 @@ export default function Home() {
   const editorMaxWidthStyle = useMemo(() => (
     canvasFit.maxWidth ? { maxWidth: `${canvasFit.maxWidth}px` } : undefined
   ), [canvasFit.maxWidth]);
-
-  const canvasStageStyle = useMemo(() => (
-    canvasFit.height ? { height: `${canvasFit.height}px` } : undefined
-  ), [canvasFit.height]);
 
   const configDropdown = (
     <div className={styles.configDropdown}>
@@ -511,7 +513,7 @@ export default function Home() {
         ref={editorRef}
         style={editorMaxWidthStyle}
       >
-        <div className={canvasStageClasses} style={canvasStageStyle}>
+        <div className={canvasStageClasses}>
           <div className={styles.canvasViewport}>
 
             <EditorCanvas
@@ -525,6 +527,7 @@ export default function Home() {
               onClearImage={handleClearImage}
               showCanvas={isCanvasReady}
               topLeftOverlay={configDropdown}
+              lienzoHeight={canvasFit.height}
             />
             {!hasImage && (
               <div className={styles.uploadOverlay}>

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -332,9 +332,8 @@
   background: rgba(12, 12, 18, 0.95);
   border: 1px solid rgba(63, 63, 77, 0.55);
   border-radius: 30px;
-  
+
   min-height: 320px;
-  height: clamp(560px, 70vh, 760px);
 }
 
 .canvasStageEmpty {


### PR DESCRIPTION
## Summary
- measure the viewport, header, title and footer gaps on resize to derive a clamped runtime height for the editor card and pass it into the canvas component
- give the lienzo container an inline height and let the canvas surface fill 100% so the toolbar stays anchored while restoring the original overlay stacking
- revert the section wrapper CSS back to the original flex layout, keeping the previous spacing while removing the extra height and padding hacks

## Testing
- npm run build (from mgm-front)


------
https://chatgpt.com/codex/tasks/task_e_68d2e85e89b8832794cab9d6e4cca9ed