### PR TITLE
feat: refine dimension inputs commit workflow

### DIFF
--- a/mgm-front/src/components/SizeControls.jsx
+++ b/mgm-front/src/components/SizeControls.jsx
@@ -1,5 +1,5 @@
 // src/components/SizeControls.jsx
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import styles from './SizeControls.module.css';
 import { LIMITS, STANDARD, GLASSPAD_SIZE_CM } from '../lib/material.js';
 import { resolveIconAsset } from '../lib/iconRegistry.js';
@@ -7,6 +7,40 @@ import { resolveIconAsset } from '../lib/iconRegistry.js';
 const WIDTH_ICON_SRC = resolveIconAsset('largo.svg');
 const HEIGHT_ICON_SRC = resolveIconAsset('ancho.svg');
 const DOWN_ICON_SRC = resolveIconAsset('down.svg');
+
+const INVALID_NUMBER_MESSAGE = 'Ingresá un número';
+const DIMENSION_MIN_CM = 1;
+const DECIMALS = 2;
+const EPSILON = 1e-4;
+
+const clampValue = (val, min, max) => Math.max(min, Math.min(max, val));
+
+const roundToDecimals = (value, decimals = DECIMALS) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return NaN;
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+};
+
+const toNumeric = (value) => {
+  if (value === null || value === undefined) return NaN;
+  if (typeof value === 'number') return value;
+  const parsed = Number.parseFloat(String(value));
+  return Number.isFinite(parsed) ? parsed : NaN;
+};
+
+const formatDisplayValue = (value) => {
+  const numeric = toNumeric(value);
+  if (!Number.isFinite(numeric)) return '';
+  const rounded = roundToDecimals(numeric);
+  if (!Number.isFinite(rounded)) return '';
+  if (Number.isInteger(rounded)) {
+    return String(Math.trunc(rounded));
+  }
+  return rounded
+    .toFixed(DECIMALS)
+    .replace(/\.?0+$/, '')
+    .replace(/\.$/, '');
+};
 
 const MATERIAL_OPTIONS = [
   { value: 'Glasspad', title: 'GLASSPAD', subtitle: 'speed' },
@@ -25,14 +59,51 @@ export default function SizeControls({ material, size, onChange, locked = false,
   const presets = STANDARD[material] || [];
   const isGlasspad = material === 'Glasspad';
 
-  const [wText, setWText] = useState(String(size.w || ''));
-  const [hText, setHText] = useState(String(size.h || ''));
+  const widthErrorId = useId();
+  const heightErrorId = useId();
+
+  const [wText, setWText] = useState(formatDisplayValue(size.w));
+  const [hText, setHText] = useState(formatDisplayValue(size.h));
+  const [errors, setErrors] = useState({ w: '', h: '' });
   const [isSeriesOpen, setSeriesOpen] = useState(false);
 
   const seriesSelectRef = useRef(null);
+  const wInputRef = useRef(null);
+  const hInputRef = useRef(null);
+  const initialW = toNumeric(size.w);
+  const initialH = toNumeric(size.h);
+  const lastCommittedRef = useRef({
+    w: Number.isFinite(initialW) ? roundToDecimals(initialW) : null,
+    h: Number.isFinite(initialH) ? roundToDecimals(initialH) : null,
+  });
 
-  useEffect(() => { setWText(String(size.w ?? '')); }, [size.w]);
-  useEffect(() => { setHText(String(size.h ?? '')); }, [size.h]);
+  useEffect(() => {
+    const numericW = toNumeric(size.w);
+    setWText(formatDisplayValue(numericW));
+    if (Number.isFinite(numericW)) {
+      lastCommittedRef.current.w = roundToDecimals(numericW);
+    } else {
+      lastCommittedRef.current.w = null;
+    }
+    setErrors((prev) => {
+      if (!prev.w) return prev;
+      return { ...prev, w: '' };
+    });
+  }, [size.w]);
+
+  useEffect(() => {
+    const numericH = toNumeric(size.h);
+    setHText(formatDisplayValue(numericH));
+    if (Number.isFinite(numericH)) {
+      lastCommittedRef.current.h = roundToDecimals(numericH);
+    } else {
+      lastCommittedRef.current.h = null;
+    }
+    setErrors((prev) => {
+      if (!prev.h) return prev;
+      return { ...prev, h: '' };
+    });
+  }, [size.h]);
 
   const glasspadInitRef = useRef(false);
   useEffect(() => {
@@ -42,13 +113,15 @@ export default function SizeControls({ material, size, onChange, locked = false,
     }
     if (glasspadInitRef.current && !disabled) return;
 
-    setWText(prev => {
-      const target = String(GLASSPAD_SIZE_CM.w);
-      return prev === target ? prev : target;
-    });
-    setHText(prev => {
-      const target = String(GLASSPAD_SIZE_CM.h);
-      return prev === target ? prev : target;
+    const targetW = formatDisplayValue(GLASSPAD_SIZE_CM.w);
+    const targetH = formatDisplayValue(GLASSPAD_SIZE_CM.h);
+    setWText((prev) => (prev === targetW ? prev : targetW));
+    setHText((prev) => (prev === targetH ? prev : targetH));
+    lastCommittedRef.current.w = roundToDecimals(GLASSPAD_SIZE_CM.w);
+    lastCommittedRef.current.h = roundToDecimals(GLASSPAD_SIZE_CM.h);
+    setErrors((prev) => {
+      if (!prev.w && !prev.h) return prev;
+      return { w: '', h: '' };
     });
 
     if (disabled) {
@@ -89,35 +162,166 @@ export default function SizeControls({ material, size, onChange, locked = false,
 
   const numPattern = /^[0-9]{0,3}(\.[0-9]{0,2})?$/;
 
+  const focusInputRef = (ref) => {
+    setTimeout(() => {
+      const input = ref.current;
+      if (!input) return;
+      input.focus();
+      if (typeof input.select === 'function') {
+        input.select();
+      }
+    }, 0);
+  };
+
+  const parseAndNormalizeDimension = (field, text) => {
+    const normalizedText = (text ?? '').trim().replace(',', '.');
+    if (!normalizedText) return { valid: false };
+    const parsed = Number.parseFloat(normalizedText);
+    if (!Number.isFinite(parsed)) return { valid: false };
+    const maxLimit = field === 'w' ? limits.maxW : limits.maxH;
+    const max = typeof maxLimit === 'number' && Number.isFinite(maxLimit)
+      ? maxLimit
+      : Number.POSITIVE_INFINITY;
+    const clamped = clampValue(parsed, DIMENSION_MIN_CM, max);
+    const value = roundToDecimals(clamped);
+    if (!Number.isFinite(value)) return { valid: false };
+    return { valid: true, value, display: formatDisplayValue(value) };
+  };
+
   const handleWChange = (e) => {
     if (disabled || locked || isGlasspad) return;
     const v = e.target.value;
-    if (v === '' || numPattern.test(v)) setWText(v);
+    if (v === '' || numPattern.test(v)) {
+      setWText(v);
+      setErrors((prev) => {
+        if (!prev.w) return prev;
+        return { ...prev, w: '' };
+      });
+    }
   };
   const handleHChange = (e) => {
     if (disabled || locked || isGlasspad) return;
     const v = e.target.value;
-    if (v === '' || numPattern.test(v)) setHText(v);
+    if (v === '' || numPattern.test(v)) {
+      setHText(v);
+      setErrors((prev) => {
+        if (!prev.h) return prev;
+        return { ...prev, h: '' };
+      });
+    }
   };
-  const clamp = (val, min, max) => Math.max(min, Math.min(max, val));
-  const handleWBlur = () => {
+
+  const revertDimension = (field) => {
+    const inputRef = field === 'w' ? wInputRef : hInputRef;
+    const lastValue = lastCommittedRef.current[field];
+    const fallbackSource = Number.isFinite(lastValue)
+      ? lastValue
+      : field === 'w'
+        ? size.w
+        : size.h;
+    const fallbackDisplay = formatDisplayValue(fallbackSource);
+    if (field === 'w') {
+      setWText(fallbackDisplay);
+    } else {
+      setHText(fallbackDisplay);
+    }
+    setErrors((prev) => {
+      if (!prev[field]) return prev;
+      return { ...prev, [field]: '' };
+    });
+    focusInputRef(inputRef);
+  };
+
+  const commitDimension = (field) => {
+    if (disabled || locked || isGlasspad) return { status: 'disabled' };
+    const inputRef = field === 'w' ? wInputRef : hInputRef;
+    const text = field === 'w' ? wText : hText;
+    const result = parseAndNormalizeDimension(field, text);
+    if (!result.valid) {
+      const lastValue = lastCommittedRef.current[field];
+      const fallbackSource = Number.isFinite(lastValue)
+        ? lastValue
+        : field === 'w'
+          ? size.w
+          : size.h;
+      const fallbackDisplay = formatDisplayValue(fallbackSource);
+      if (field === 'w') {
+        setWText(fallbackDisplay);
+      } else {
+        setHText(fallbackDisplay);
+      }
+      setErrors((prev) => ({ ...prev, [field]: INVALID_NUMBER_MESSAGE }));
+      focusInputRef(inputRef);
+      return { status: 'error' };
+    }
+
+    const { value, display } = result;
+    const previousValue = lastCommittedRef.current[field];
+
+    if (field === 'w') {
+      setWText(display);
+    } else {
+      setHText(display);
+    }
+
+    setErrors((prev) => {
+      if (!prev[field]) return prev;
+      return { ...prev, [field]: '' };
+    });
+
+    if (typeof previousValue === 'number' && Number.isFinite(previousValue)) {
+      if (Math.abs(previousValue - value) < EPSILON) {
+        lastCommittedRef.current[field] = value;
+        return { status: 'unchanged', value, display };
+      }
+    }
+
+    lastCommittedRef.current[field] = value;
+    if (field === 'w') {
+      onChange?.({ w: value });
+    } else {
+      onChange?.({ h: value });
+    }
+
+    return { status: 'saved', value, display };
+  };
+
+  const handleDimensionKeyDown = (field) => (event) => {
     if (disabled || locked || isGlasspad) return;
-    const num = clamp(parseFloat(wText || '0'), 1, limits.maxW);
-    setWText(num ? String(num) : '');
-    onChange({ w: num, h: parseFloat(hText || size.h) });
+    if (event.key === 'Enter' && !event.nativeEvent?.isComposing) {
+      event.preventDefault();
+      const outcome = commitDimension(field);
+      if (outcome.status !== 'error') {
+        event.currentTarget.blur();
+      }
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      revertDimension(field);
+    }
   };
-  const handleHBlur = () => {
-    if (disabled || locked || isGlasspad) return;
-    const num = clamp(parseFloat(hText || '0'), 1, limits.maxH);
-    setHText(num ? String(num) : '');
-    onChange({ w: parseFloat(wText || size.w), h: num });
-  };
+
+  const handleWBlur = () => { commitDimension('w'); };
+  const handleHBlur = () => { commitDimension('h'); };
 
   const applyPreset = (w, h) => {
     if (disabled || locked) return;
-    setWText(String(w));
-    setHText(String(h));
-    onChange({ w, h });
+    const numericW = toNumeric(w);
+    const numericH = toNumeric(h);
+    setWText(formatDisplayValue(numericW));
+    setHText(formatDisplayValue(numericH));
+    if (Number.isFinite(numericW)) {
+      lastCommittedRef.current.w = roundToDecimals(numericW);
+    }
+    if (Number.isFinite(numericH)) {
+      lastCommittedRef.current.h = roundToDecimals(numericH);
+    }
+    setErrors((prev) => {
+      if (!prev.w && !prev.h) return prev;
+      return { w: '', h: '' };
+    });
+    if (Number.isFinite(numericW) && Number.isFinite(numericH)) {
+      onChange?.({ w: numericW, h: numericH });
+    }
   };
 
   const containerClasses = [
@@ -152,15 +356,24 @@ export default function SizeControls({ material, size, onChange, locked = false,
                 aria-hidden="true"
               />
               <input
+                ref={wInputRef}
                 className={styles.input}
                 value={isGlasspad ? GLASSPAD_SIZE_CM.w : wText}
                 onChange={!isGlasspad ? handleWChange : undefined}
                 onBlur={!isGlasspad ? handleWBlur : undefined}
+                onKeyDown={!isGlasspad ? handleDimensionKeyDown('w') : undefined}
                 inputMode="decimal"
                 pattern="[0-9]*"
+                aria-invalid={errors.w ? 'true' : 'false'}
+                aria-describedby={errors.w ? widthErrorId : undefined}
                 disabled={locked || isGlasspad || disabled}
               />
             </div>
+            {errors.w && (
+              <p className="errorText" id={widthErrorId} aria-live="polite">
+                {errors.w}
+              </p>
+            )}
           </label>
           <label className={styles.inputLabel}>
             <span className={styles.visuallyHidden}>Ancho</span>
@@ -175,15 +388,24 @@ export default function SizeControls({ material, size, onChange, locked = false,
                 aria-hidden="true"
               />
               <input
+                ref={hInputRef}
                 className={styles.input}
                 value={isGlasspad ? GLASSPAD_SIZE_CM.h : hText}
                 onChange={!isGlasspad ? handleHChange : undefined}
                 onBlur={!isGlasspad ? handleHBlur : undefined}
+                onKeyDown={!isGlasspad ? handleDimensionKeyDown('h') : undefined}
                 inputMode="decimal"
                 pattern="[0-9]*"
+                aria-invalid={errors.h ? 'true' : 'false'}
+                aria-describedby={errors.h ? heightErrorId : undefined}
                 disabled={locked || isGlasspad || disabled}
               />
             </div>
+            {errors.h && (
+              <p className="errorText" id={heightErrorId} aria-live="polite">
+                {errors.h}
+              </p>
+            )}
           </label>
         </div>
 


### PR DESCRIPTION
## Summary
- normalize dimension values with helper utilities to clamp, round, and track last committed measurements
- add commit/revert handlers that guard against duplicate saves, handle enter/escape, and report inline validation errors
- wire Largo/Ancho inputs to new logic with refs, accessibility attributes, and aria-live error messages while preserving layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2f63ee4f4832781d086ecc7c8f448