### PR TITLE
Ensure canvas section fills initial viewport

### DIFF
--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -6,6 +6,32 @@
   min-height: 100%;
 }
 
+.sectionOne {
+  width: 100%;
+  display: flex;
+}
+
+.sectionOneInner {
+  width: 100%;
+  max-width: 1920px !important;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  min-height: 100%;
+}
+
+.sectionTwo {
+  width: 100%;
+  display: flex;
+}
+
+.sectionTwoInner {
+  width: 100%;
+  max-width: 1920px !important;
+  margin: 0 auto;
+}
+
 .pageHeading {
   width: 100%;
   max-width: 1920px !important;
@@ -24,6 +50,10 @@
   max-width: 1920px !important;
   margin: 0 auto;
   max-height: 800px !important;
+}
+
+.editorFullHeight {
+  max-height: none !important;
 }
 
 .configAccordion {


### PR DESCRIPTION
## Summary
- compute SectionOne and canvas heights from live header/title metrics so the card reaches the viewport bottom
- split the Home layout into SectionOne (title + lienzo card) and SectionTwo (ack + continue) with dedicated wrappers
- add CSS helpers to stretch the first section and remove the previous editor height cap

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2f9bf83e0832797ab03bc7ddbbf81