### PR TITLE
Restyle low quality acknowledgement capsule and continue button

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -622,12 +622,15 @@ export default function Home() {
             <div className={styles.feedbackGroup}>
               {hasImage && level === 'bad' && (
                 <label className={styles.ackLabel}>
+                  <span className={styles.ackLabelText}>
+                    Acepto imprimir en baja calidad ({effDpi} DPI)
+                  </span>
                   <input
+                    className={styles.ackCheckbox}
                     type="checkbox"
                     checked={ackLow}
                     onChange={e => setAckLow(e.target.checked)}
-                  />{' '}
-                  <span>Acepto imprimir en baja calidad ({effDpi} DPI)</span>
+                  />
                 </label>
               )}
               {err && <p className={`errorText ${styles.errorMessage}`}>{err}</p>}

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -462,10 +462,9 @@
 
 .footerRow {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 16px;
 }
 
 .feedbackGroup {
@@ -474,21 +473,49 @@
   gap: 12px;
   flex: 1 1 320px;
   min-width: 0;
+  width: 100%;
 }
 
 .ackLabel {
-  display: inline-flex;
+  display: flex;
   align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 44px;
+  padding: 12px 16px;
+  border-radius: 11px;
+  border: 1px solid rgba(128, 128, 128, 0.2);
+  background: rgba(40, 40, 40, 0.6);
+  color: inherit;
+  font-size: 13px;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.4;
+  cursor: pointer;
   gap: 12px;
-  padding: 12px 18px;
-  border-radius: 14px;
-  border: 1px solid rgba(63, 63, 77, 0.55);
-  background: rgba(16, 16, 22, 0.9);
-  color: rgba(229, 231, 235, 0.9);
-  font-size: 0.9rem;
+  transition: background-color 0.18s ease, border-color 0.18s ease,
+    box-shadow 0.18s ease;
 }
 
-.ackLabel input {
+.ackLabel:hover {
+  background: rgba(40, 40, 40, 0.68);
+  border-color: rgba(128, 128, 128, 0.32);
+}
+
+.ackLabel:focus-within {
+  border-color: rgba(128, 128, 128, 0.4);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.15);
+}
+
+.ackLabelText {
+  flex: 1 1 auto;
+  margin-right: 12px;
+  min-width: 0;
+}
+
+.ackCheckbox {
+  margin: 0;
+  flex-shrink: 0;
   accent-color: initial;
 }
 
@@ -504,16 +531,23 @@
 }
 
 .continueButton {
-  border-radius: 16px;
-  border: 1px solid rgba(63, 63, 77, 0.6);
-  background: rgba(238, 238, 242, 0.95);
-  color: #111;
+  width: 100%;
+  min-height: 52px;
+  border-radius: 11px;
+  border: 1px solid rgba(128, 128, 128, 0.2);
+  background: rgba(40, 40, 40, 0.6);
+  color: inherit;
   font-size: 1rem;
   font-weight: 600;
-  padding: 14px 28px;
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.4);
+  letter-spacing: 0;
+  padding: 0 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
   cursor: pointer;
-  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  transition: background-color 0.18s ease, border-color 0.18s ease,
+    box-shadow 0.18s ease;
 }
 
 .continueButton:disabled {
@@ -523,8 +557,13 @@
 }
 
 .continueButton:not(:disabled):hover {
-  transform: translateY(-2px);
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+  background: rgba(40, 40, 40, 0.72);
+  border-color: rgba(128, 128, 128, 0.32);
+}
+
+.continueButton:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.35);
+  outline-offset: 3px;
 }
 @media (prefers-reduced-motion: reduce) {
   .tutorialButton,
@@ -590,12 +629,10 @@
   }
 
   .footerRow {
-    flex-direction: column;
-    align-items: stretch;
+    gap: 16px;
   }
 
   .continueButton {
-    align-self: flex-end;
     width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- restyle the low-quality print acknowledgement into a full-width pill label with text and checkbox alignment plus updated hover/focus treatments
- update the Continue button to use the same capsule aesthetic, span the container width, and add consistent state styling and spacing

## Testing
- npm --prefix mgm-front run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2fe5f9d9c832782ec91522a92bac5