### PR TITLE
Move acknowledgement controls into canvas overlay

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -611,15 +611,6 @@ export default function Home() {
                   </div>
                 )}
               </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className={styles.sectionTwo}>
-        <div className={styles.sectionTwoInner} style={editorMaxWidthStyle}>
-          <div className={styles.footerRow}>
-            <div className={styles.feedbackGroup}>
               {hasImage && level === 'bad' && (
                 <label className={styles.ackLabel}>
                   <span className={styles.ackLabelText}>
@@ -633,17 +624,26 @@ export default function Home() {
                   />
                 </label>
               )}
+              {hasImage && (
+                <button
+                  className={styles.continueButton}
+                  disabled={busy}
+                  onClick={handleContinue}
+                >
+                  Continuar
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.sectionTwo}>
+        <div className={styles.sectionTwoInner} style={editorMaxWidthStyle}>
+          <div className={styles.footerRow}>
+            <div className={styles.feedbackGroup}>
               {err && <p className={`errorText ${styles.errorMessage}`}>{err}</p>}
             </div>
-            {hasImage && (
-              <button
-                className={styles.continueButton}
-                disabled={busy}
-                onClick={handleContinue}
-              >
-                Continuar
-              </button>
-            )}
           </div>
         </div>
       </section>

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -362,6 +362,10 @@
   background: rgba(12, 12, 18, 0.95);
   border: 1px solid rgba(63, 63, 77, 0.55);
   border-radius: 30px;
+  --canvas-actions-right: 24px;
+  --canvas-actions-bottom: 24px;
+  --canvas-actions-gap: 12px;
+  --continue-button-height: 48px;
 
   min-height: 320px;
 }
@@ -477,10 +481,19 @@
 }
 
 .ackLabel {
+  position: absolute;
+  right: calc(env(safe-area-inset-right, 0px) + var(--canvas-actions-right));
+  bottom: calc(
+    env(safe-area-inset-bottom, 0px) +
+      var(--canvas-actions-bottom) +
+      var(--continue-button-height) +
+      var(--canvas-actions-gap)
+  );
+  z-index: 40;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  width: 100%;
+  width: clamp(220px, 26vw, 320px);
   min-height: 44px;
   padding: 12px 16px;
   border-radius: 11px;
@@ -531,8 +544,13 @@
 }
 
 .continueButton {
-  width: 100%;
-  min-height: 52px;
+  position: absolute;
+  right: calc(env(safe-area-inset-right, 0px) + var(--canvas-actions-right));
+  bottom: calc(env(safe-area-inset-bottom, 0px) + var(--canvas-actions-bottom));
+  z-index: 40;
+  width: clamp(220px, 26vw, 320px);
+  min-height: var(--continue-button-height);
+  height: var(--continue-button-height);
   border-radius: 11px;
   border: 1px solid rgba(128, 128, 128, 0.2);
   background: rgba(40, 40, 40, 0.6);
@@ -632,7 +650,4 @@
     gap: 16px;
   }
 
-  .continueButton {
-    width: 100%;
-  }
 }


### PR DESCRIPTION
## Summary
- move the low-quality acknowledgement toggle and Continue CTA inside the canvas card so they float over the editor
- adjust the acknowledgement and Continue styles to use safe-area-aware absolute positioning with clamp-based sizing and a high z-index

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d31fdae0708327b761bf3d047aa626