### PR TITLE
Reubicar acciones del lienzo en la tarjeta

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -611,15 +611,6 @@ export default function Home() {
                   </div>
                 )}
               </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className={styles.sectionTwo}>
-        <div className={styles.sectionTwoInner} style={editorMaxWidthStyle}>
-          <div className={styles.footerRow}>
-            <div className={styles.feedbackGroup}>
               {hasImage && level === 'bad' && (
                 <label className={styles.ackLabel}>
                   <span className={styles.ackLabelText}>
@@ -633,20 +624,31 @@ export default function Home() {
                   />
                 </label>
               )}
-              {err && <p className={`errorText ${styles.errorMessage}`}>{err}</p>}
+              {hasImage && (
+                <button
+                  className={styles.continueButton}
+                  disabled={busy}
+                  onClick={handleContinue}
+                >
+                  Continuar
+                </button>
+              )}
             </div>
-            {hasImage && (
-              <button
-                className={styles.continueButton}
-                disabled={busy}
-                onClick={handleContinue}
-              >
-                Continuar
-              </button>
-            )}
           </div>
         </div>
       </section>
+
+      {err && (
+        <section className={styles.sectionTwo}>
+          <div className={styles.sectionTwoInner} style={editorMaxWidthStyle}>
+            <div className={styles.footerRow}>
+              <div className={styles.feedbackGroup}>
+                <p className={`errorText ${styles.errorMessage}`}>{err}</p>
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
 
       <LoadingOverlay show={busy} messages={["Creando tu pedido…"]} />
     </div>

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -44,10 +44,6 @@
 /* fila del checkbox: texto izq, check der */
 
 
-/* botón ocupa todo el ancho del stack */
-.continueButton {
-  width: 100%;
-}
 .pageHeading {
   width: 100%;
   max-width: 1920px !important;
@@ -382,6 +378,12 @@
   border-radius: 12px;
 
   min-height: 320px;
+  --canvas-actions-right: 24px;
+  --canvas-actions-bottom: 24px;
+  --canvas-actions-gap: 12px;
+  --canvas-continue-height: 48px;
+  --canvas-actions-right: calc(24px + env(safe-area-inset-right, 0px));
+  --canvas-actions-bottom: calc(24px + env(safe-area-inset-bottom, 0px));
 }
 
 .canvasStageEmpty {
@@ -522,10 +524,17 @@
 }
 
 .ackLabel {
+  position: absolute;
+  right: var(--canvas-actions-right);
+  bottom: calc(
+    var(--canvas-actions-bottom) + var(--canvas-continue-height) +
+      var(--canvas-actions-gap)
+  );
+  z-index: 40;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  width: 100%;
+  width: clamp(220px, 26vw, 320px);
   min-height: 44px;
   padding: 12px 24px;
   border-radius: 11px;
@@ -576,8 +585,13 @@
 }
 
 .continueButton {
-  width: 100%;
-  min-height: 52px;
+  position: absolute;
+  right: var(--canvas-actions-right);
+  bottom: var(--canvas-actions-bottom);
+  z-index: 40;
+  width: clamp(220px, 26vw, 320px);
+  min-height: var(--canvas-continue-height);
+  height: var(--canvas-continue-height);
   border-radius: 11px;
   border: 1px solid #34343b;
   background: #282828a8;


### PR DESCRIPTION
## Summary
- mover la cápsula de aceptación y el botón Continuar dentro del LienzoCard con posición absoluta y z-index superior
- ajustar los estilos para usar anchos clamp, altura fija y compensar safe-area al alinear los controles en la esquina inferior derecha
- mostrar la sección de error únicamente cuando existe un mensaje

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d32584d01c8327bd658805aa1dad09