### PR TITLE
Relocate acknowledgement and continue controls onto canvas

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -611,17 +611,8 @@ export default function Home() {
                   </div>
                 )}
               </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className={styles.sectionTwo}>
-        <div className={styles.sectionTwoInner} style={editorMaxWidthStyle}>
-          <div className={styles.footerRow}>
-            <div className={styles.feedbackGroup}>
               {hasImage && level === 'bad' && (
-                <label className={styles.ackLabel}>
+                <label className={`${styles.ackLabel} ${styles.canvasAck}`}>
                   <span className={styles.ackLabelText}>
                     Acepto imprimir en baja calidad ({effDpi} DPI)
                   </span>
@@ -633,17 +624,26 @@ export default function Home() {
                   />
                 </label>
               )}
+              {hasImage && (
+                <button
+                  className={`${styles.continueButton} ${styles.canvasContinue}`}
+                  disabled={busy}
+                  onClick={handleContinue}
+                >
+                  Continuar
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.sectionTwo}>
+        <div className={styles.sectionTwoInner} style={editorMaxWidthStyle}>
+          <div className={styles.footerRow}>
+            <div className={styles.feedbackGroup}>
               {err && <p className={`errorText ${styles.errorMessage}`}>{err}</p>}
             </div>
-            {hasImage && (
-              <button
-                className={styles.continueButton}
-                disabled={busy}
-                onClick={handleContinue}
-              >
-                Continuar
-              </button>
-            )}
           </div>
         </div>
       </section>

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -44,10 +44,6 @@
 /* fila del checkbox: texto izq, check der */
 
 
-/* botón ocupa todo el ancho del stack */
-.continueButton {
-  width: 100%;
-}
 .pageHeading {
   width: 100%;
   max-width: 1920px !important;
@@ -375,6 +371,10 @@
 
 .canvasStage {
   position: relative;
+  --canvas-floating-right: calc(24px + env(safe-area-inset-right, 0px));
+  --canvas-floating-bottom: calc(24px + env(safe-area-inset-bottom, 0px));
+  --canvas-floating-gap: 12px;
+  --canvas-continue-height: 48px;
   display: flex;
   flex-direction: column;
   background: rgba(12, 12, 18, 0.95);
@@ -525,7 +525,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  width: 100%;
+  width: clamp(220px, 26vw, 320px);
   min-height: 44px;
   padding: 12px 24px;
   border-radius: 11px;
@@ -576,8 +576,9 @@
 }
 
 .continueButton {
-  width: 100%;
-  min-height: 52px;
+  width: clamp(220px, 26vw, 320px);
+  min-height: var(--canvas-continue-height, 48px);
+  height: var(--canvas-continue-height, 48px);
   border-radius: 11px;
   border: 1px solid #34343b;
   background: #282828a8;
@@ -591,7 +592,21 @@
   justify-content: center;
   text-align: center;
   cursor: pointer;
- 
+
+}
+
+.canvasAck {
+  position: absolute;
+  right: var(--canvas-floating-right);
+  bottom: calc(var(--canvas-floating-bottom) + var(--canvas-continue-height, 48px) + var(--canvas-floating-gap, 12px));
+  z-index: 40;
+}
+
+.canvasContinue {
+  position: absolute;
+  right: var(--canvas-floating-right);
+  bottom: var(--canvas-floating-bottom);
+  z-index: 40;
 }
 
 .continueButton:disabled {
@@ -676,7 +691,4 @@
     gap: 16px;
   }
 
-  .continueButton {
-    width: 100%;
-  }
 }


### PR DESCRIPTION
## Summary
- move the low-quality acknowledgement capsule and Continue button into the canvas card as absolute overlays with high z-index
- adjust Home module styles to clamp widths, share spacing variables, and ensure the overlays respect safe areas

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d329dbd20083278abfd36d2a8640b9