### PR TITLE
Make editor toolbar horizontally scrollable on mobile

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -1811,7 +1811,8 @@ const EditorCanvas = forwardRef(function EditorCanvas(
       <div className={styles.overlayBottomCenter}>
         {/* Toolbar */}
         <div className={styles.toolbarStack}>
-          <div className={styles.toolbar}>
+          <div className={styles.toolbarScroller}>
+            <div className={styles.toolbar}>
           <ToolbarTooltip label="Alinear a la izquierda">
             <button
               type="button"
@@ -2117,6 +2118,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
             {busy ? "Creando…" : "Crear job"}
           </button>
         )}
+            </div>
           </div>
         </div>
       </div>

--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -268,6 +268,13 @@
   pointer-events: auto;
 }
 
+.toolbarScroller {
+  display: inline-flex;
+  justify-content: center;
+  pointer-events: auto;
+  min-width: 0;
+}
+
 .iconOnlyButton {
   display: inline-flex;
   align-items: center;
@@ -287,6 +294,7 @@
     border-color 0.18s ease,
     background 0.18s ease,
     opacity 0.18s ease;
+  scroll-snap-align: start;
 }
 
 .iconOnlyButtonActive {
@@ -436,6 +444,39 @@
   align-items: center;
   gap: 10px;
   pointer-events: none;
+}
+
+@media (max-width: 768px) {
+  .toolbarStack {
+    align-items: stretch;
+  }
+
+  .toolbarScroller {
+    display: flex;
+    width: 100%;
+    justify-content: flex-start;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    scroll-snap-type: x mandatory;
+    scroll-padding-inline: 16px;
+    padding-inline: 16px;
+    touch-action: pan-x;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+  }
+
+  .toolbarScroller::-webkit-scrollbar {
+    display: none;
+  }
+
+  .toolbar {
+    flex: none;
+    flex-wrap: nowrap;
+    width: max-content;
+    max-width: none;
+    justify-content: flex-start;
+  }
 }
 
 .colorToast {


### PR DESCRIPTION
## Summary
- wrap the editor toolbar controls in a scroll container so the bar can slide horizontally on mobile without touching individual button markup
- add responsive styles that enable touch scrolling with scroll snap, hide the horizontal scrollbar on small screens, and keep the desktop layout unchanged

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d329e7f3fc8327a58860d7b3b6e4e7