### PR TITLE
Limit toolbar scrolling to dedicated container

### DIFF
--- a/mgm-front/src/App.module.css
+++ b/mgm-front/src/App.module.css
@@ -46,7 +46,3 @@
 
 ._brand_1doot_43{font-size: 28px;}
 
-html,
-body {
-  overflow-x: auto;
-}

--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -1448,7 +1448,8 @@ const EditorCanvas = forwardRef(function EditorCanvas(
   }
 
   return (
-    <div className={styles.editorRoot}>
+    <>
+      <div className={styles.editorRoot}>
       <div className={styles.lienzo} style={lienzoStyle}>
         {/* Canvas */}
         <div ref={wrapRef} className={wrapperClassName} style={canvasSurfaceStyle}>
@@ -1810,9 +1811,8 @@ const EditorCanvas = forwardRef(function EditorCanvas(
 
       <div className={styles.overlayBottomCenter}>
         {/* Toolbar */}
-        <div className={styles.toolbarStack}>
-          <div className={styles.toolbarScroller}>
-            <div className={styles.toolbar}>
+        <div className={styles.toolbarScroller}>
+          <div className={styles.toolbar}>
           <ToolbarTooltip label="Alinear a la izquierda">
             <button
               type="button"
@@ -2124,8 +2124,8 @@ const EditorCanvas = forwardRef(function EditorCanvas(
       </div>
     </div>
 
-    {lastDiag && <p className={styles.errorBox}>{lastDiag}</p>}
-  </div>
+      {lastDiag && <p className={styles.errorBox}>{lastDiag}</p>}
+    </>
   );
 });
 

--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -263,9 +263,13 @@
   border-radius: 14px;
   border: 1px solid #80808070;
   background: #282828cb;
-  
+
   max-width: 100%;
   pointer-events: auto;
+}
+
+.toolbar > * {
+  flex: 0 0 auto;
 }
 
 .toolbarScroller {
@@ -273,6 +277,8 @@
   justify-content: center;
   pointer-events: auto;
   min-width: 0;
+  max-width: 100%;
+  white-space: nowrap;
 }
 
 .iconOnlyButton {
@@ -438,16 +444,9 @@
   margin-bottom: 8px;
 }
 
-.toolbarStack {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-  pointer-events: none;
-}
 
 @media (max-width: 768px) {
-  .toolbarStack {
+  .overlayBottomCenter {
     align-items: stretch;
   }
 
@@ -569,7 +568,10 @@
   transform: translateX(-50%);
   z-index: 30;
   display: flex;
+  flex-direction: column;
+  align-items: center;
   justify-content: center;
+  gap: 10px;
   width: 100%;
   max-width: calc(100% - 32px);
   pointer-events: none;


### PR DESCRIPTION
## Summary
- wrap the editor toolbar buttons in a dedicated scroller directly under the canvas overlay and keep the diagnostic message alongside via a fragment
- update the toolbar styling so only the scroller handles horizontal overflow on mobile while centering content and preventing wrapping of actions
- remove the global html/body overflow rule so the rest of the page stays fixed while swiping the toolbar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3316e3d288327b4f3391713aa34c8