### PR TITLE
Fix Shopify publication matching and improve nazi flag detection

### DIFF
--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -289,7 +289,6 @@ async function detectNazi(buffer) {
       redMask[p] = 1;
     }
     if (isWhite) {
-      whiteInCircle++;
       whiteMask[p] = 1;
     }
     if (isBlack) {
@@ -299,16 +298,17 @@ async function detectNazi(buffer) {
     const x = p % w, y = Math.floor(p / w);
     const dist = Math.hypot(x - cx, y - cy);
     if (dist <= r) inCircleCount++;
+    if (dist <= r && isWhite) whiteInCircle++;
     if (dist > r * 0.85 && dist < r * 1.1) inRingCount++;
   }
   const redRatio = redDom / total;
   const whiteCircleRatio = inCircleCount ? whiteInCircle / inCircleCount : 0;
   const blackStrokeRatio = inRingCount ? blackStroke / inRingCount : 0;
   const COLOR_MATCH_THRESHOLDS = {
-    red: 0.5,
-    white: 0.75,
-    black: 0.18,
-    minDist: 24,
+    red: 0.12,
+    white: 0.25,
+    black: 0.12,
+    minDist: 28,
   };
   if (
     minDist <= COLOR_MATCH_THRESHOLDS.minDist &&

--- a/lib/shopify/publication.js
+++ b/lib/shopify/publication.js
@@ -87,9 +87,14 @@ async function fetchOnlineStorePublicationId() {
     .map((edge) => edge?.node)
     .filter((node) => node && typeof node === 'object');
   const match = nodes.find((node) => {
-    const handle = normalizeId(node?.channel?.handle)
+    const rawHandle = normalizeId(node?.channel?.handle)
       || normalizeId(node?.channelDefinition?.handle);
-    if (handle && handle.toLowerCase() === 'online_store') return true;
+    if (rawHandle) {
+      const lowerHandle = rawHandle.toLowerCase();
+      if (lowerHandle === 'online_store' || lowerHandle === 'online-store') return true;
+      const squashedHandle = lowerHandle.replace(/[^a-z0-9]+/g, '');
+      if (squashedHandle === 'onlinestore') return true;
+    }
     const name = typeof node?.name === 'string' ? node.name.toLowerCase() : '';
     if (!name) return false;
     return name.includes('online store');


### PR DESCRIPTION
## Summary
- make the Shopify publication discovery tolerant to `online-store` handles
- adjust the nazi flag heuristic to count colors in the correct regions and use relaxed thresholds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5842194308327bed1cf207d3b6a2f