### PR TITLE
Fix Supabase uploads URL canonicalization

### DIFF
--- a/mgm-front/src/lib/jobPayload.js
+++ b/mgm-front/src/lib/jobPayload.js
@@ -1,7 +1,15 @@
 // src/lib/jobPayload.js
 
-export const uploadsPrefix =
-  "https://vxkewodclwozoennpqqv.supabase.co/storage/v1/object/uploads/";
+const DEFAULT_UPLOADS_PREFIX =
+  "https://vxkewodclwozoennpqqv.supabase.co/storage/v1/object/public/uploads/";
+
+function buildUploadsPrefix() {
+  const base = (import.meta?.env?.VITE_SUPABASE_URL || "").trim();
+  if (!base) return DEFAULT_UPLOADS_PREFIX;
+  return `${base.replace(/\/$/, "")}/storage/v1/object/public/uploads/`;
+}
+
+export const uploadsPrefix = buildUploadsPrefix();
 
 export function makeJobId() {
   try {
@@ -18,11 +26,15 @@ export function canonicalizeSupabaseUploadsUrl(input) {
     let p = u.pathname
       .replace(
         "/storage/v1/object/upload/sign/uploads/",
-        "/storage/v1/object/uploads/",
+        "/storage/v1/object/public/uploads/",
       )
       .replace(
         "/storage/v1/object/sign/uploads/",
+        "/storage/v1/object/public/uploads/",
+      )
+      .replace(
         "/storage/v1/object/uploads/",
+        "/storage/v1/object/public/uploads/",
       );
     return `${u.origin}${p}`;
   } catch {
@@ -32,7 +44,7 @@ export function canonicalizeSupabaseUploadsUrl(input) {
 
 export function buildUploadsUrlFromObjectKey(baseUrl, object_key) {
   const origin = baseUrl.replace(/\/$/, "");
-  return `${origin}/storage/v1/object/uploads/${object_key}`;
+  return `${origin}/storage/v1/object/public/uploads/${object_key}`;
 }
 
 function normalizeFit(mode) {

--- a/mgm-front/src/lib/supabaseUrl.ts
+++ b/mgm-front/src/lib/supabaseUrl.ts
@@ -6,11 +6,15 @@ export function canonicalizeSupabaseUploadsUrl(input: string): string {
     let p = u.pathname
       .replace(
         "/storage/v1/object/upload/sign/uploads/",
-        "/storage/v1/object/uploads/",
+        "/storage/v1/object/public/uploads/",
       )
       .replace(
         "/storage/v1/object/sign/uploads/",
+        "/storage/v1/object/public/uploads/",
+      )
+      .replace(
         "/storage/v1/object/uploads/",
+        "/storage/v1/object/public/uploads/",
       );
     // eliminar query (?token=...)
     return `${u.origin}${p}`;
@@ -25,5 +29,5 @@ export function buildUploadsUrlFromObjectKey(
   object_key: string,
 ): string {
   const origin = new URL(signed_url).origin; // https://<project>.supabase.co
-  return `${origin}/storage/v1/object/uploads/${object_key}`;
+  return `${origin}/storage/v1/object/public/uploads/${object_key}`;
 }


### PR DESCRIPTION
## Summary
- align the front-end Supabase uploads prefix with the public bucket path expected by the API
- derive the uploads base URL from the configured Supabase project instead of a hard-coded host

## Testing
- npm test *(fails: `evaluateImage blocks nazi symbols` – returns ALLOW instead of BLOCK in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5867ec0c88327bd693d30ed61df0d