### PR TITLE
Handle Online Store publication retries and UX

### DIFF
--- a/lib/handlers/ensureProductPublication.js
+++ b/lib/handlers/ensureProductPublication.js
@@ -222,7 +222,7 @@ export default async function ensureProductPublication(req, res) {
     let publishResult = await publishToOnlineStore(productGid, publicationInfo.id, {
       maxAttempts: 5,
       initialDelayMs: 200,
-      maxDelayMs: 800,
+      maxDelayMs: 3200,
       preferEnv: publicationInfo.source === 'env' || publicationInfo.source === 'override',
     });
     meta.publishAttempts += publishResult?.attempt || 0;
@@ -240,7 +240,7 @@ export default async function ensureProductPublication(req, res) {
       publishResult = await publishToOnlineStore(productGid, publicationInfo.id, {
         maxAttempts: 5,
         initialDelayMs: 200,
-        maxDelayMs: 800,
+        maxDelayMs: 3200,
         preferEnv: false,
       });
       meta.publishAttempts += publishResult?.attempt || 0;

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1,8 +1,14 @@
 import { shopifyAdmin } from '../shopify.js';
 import { buildProductUrl } from '../publicStorefront.js';
-import { publishToOnlineStore } from '../shopify/publication.js';
+import { publishToOnlineStore, resolveOnlineStorePublicationId } from '../shopify/publication.js';
 
 const DEFAULT_VENDOR = 'MgMGamers';
+const ONLINE_STORE_MISSING_MESSAGE = [
+  'No pudimos encontrar el canal Online Store para publicar este producto.',
+  'Revisá: 1) que el canal esté instalado, 2) que la app tenga el scope write_publications.',
+  'Luego probá de nuevo.',
+].join('\n');
+const ONLINE_STORE_DISABLED_MESSAGE = 'Tu tienda no tiene el canal Online Store habilitado. Instalalo o bien omití la publicación y usa Storefront para el carrito.';
 
 function ensureBody(body) {
   if (body && typeof body === 'object') return body;
@@ -74,6 +80,81 @@ function buildMetaDescription({ productTypeLabel, designName, widthCm, heightCm,
   if (measurement) sections.push(`Medida ${measurement} cm`);
   if (materialLabel) sections.push(`Material ${materialLabel}`);
   return `${sections.join('. ')}.`;
+}
+
+function buildProductMeta(product, variant) {
+  const handle = typeof product?.handle === 'string' ? product.handle : undefined;
+  const productUrl = handle ? buildProductUrl(handle) : undefined;
+  const productId = product?.id ? String(product.id) : undefined;
+  const variantId = variant?.id ? String(variant.id) : undefined;
+  const variantAdminId = variant?.admin_graphql_api_id || undefined;
+  const productAdminId = product?.admin_graphql_api_id || undefined;
+  return {
+    productId,
+    productHandle: handle,
+    productUrl,
+    productAdminId,
+    variantId,
+    variantAdminId,
+  };
+}
+
+function respondWithPublicationIssue(res, meta, reason, message, options = {}) {
+  const payload = {
+    ok: false,
+    reason,
+    message,
+    recoverable: true,
+    retryable: true,
+    allowSkipPublication: Boolean(options.allowSkipPublication),
+    publicationId: options.publicationId || null,
+    publicationSource: options.publicationSource || null,
+    ...meta,
+  };
+  if (Array.isArray(options.missing) && options.missing.length) {
+    payload.missing = options.missing;
+  }
+  if (Array.isArray(options.publishAttempts)) {
+    payload.publishAttempts = options.publishAttempts.length;
+    payload.requestIds = options.publishAttempts.filter(Boolean);
+  } else if (Array.isArray(options.requestIds)) {
+    payload.requestIds = options.requestIds.filter(Boolean);
+  }
+  return res.status(200).json(payload);
+}
+
+function logPublicationAbort(meta, cause, extra = {}) {
+  try {
+    console.warn('publish_product_publication_abort', {
+      cause,
+      productId: meta?.productId || null,
+      variantId: meta?.variantId || null,
+      ...extra,
+    });
+  } catch {}
+}
+
+function isActiveStatus(product) {
+  const raw = typeof product?.status === 'string' ? product.status.trim().toUpperCase() : '';
+  return raw === 'ACTIVE';
+}
+
+function hasVariant(product) {
+  const variants = Array.isArray(product?.variants) ? product.variants : [];
+  return variants.length > 0 && variants[0] && typeof variants[0] === 'object';
+}
+
+function detectMissingScope(errorDetail) {
+  const list = Array.isArray(errorDetail) ? errorDetail : [];
+  return list.some((err) => {
+    const code = typeof err?.code === 'string' ? err.code.toUpperCase()
+      : typeof err?.extensions?.code === 'string' ? err.extensions.code.toUpperCase()
+        : '';
+    if (code.includes('ACCESS') || code.includes('PERMISSION')) return true;
+    const message = typeof err?.message === 'string' ? err.message.toLowerCase() : '';
+    if (!message) return false;
+    return message.includes('permission') || message.includes('scope') || message.includes('access');
+  });
 }
 
 export async function publishProduct(req, res) {
@@ -219,19 +300,107 @@ export async function publishProduct(req, res) {
     const data = await resp.json().catch(() => ({}));
     const product = data?.product || {};
     const variantResp = Array.isArray(product?.variants) ? product.variants[0] || {} : {};
+    const meta = buildProductMeta(product, variantResp);
 
-    await publishToOnlineStore(product?.admin_graphql_api_id);
+    if (!isActiveStatus(product)) {
+      return res.status(400).json({
+        ok: false,
+        reason: 'product_not_active',
+        message: 'El producto creado no quedó activo en Shopify. Revisá la visibilidad configurada y volvé a intentarlo.',
+        ...meta,
+        visibility,
+      });
+    }
+
+    if (!hasVariant(product)) {
+      return res.status(400).json({
+        ok: false,
+        reason: 'product_missing_variant',
+        message: 'Shopify no devolvió variantes para el producto creado.',
+        ...meta,
+        visibility,
+      });
+    }
+
+    let publicationInfo;
+    try {
+      publicationInfo = await resolveOnlineStorePublicationId({ preferEnv: true });
+      if (publicationInfo?.id) {
+        try {
+          console.info('publish_product_publication_resolved', {
+            id: publicationInfo.id,
+            source: publicationInfo.source || 'unknown',
+            name: publicationInfo.name || null,
+          });
+        } catch {}
+      }
+    } catch (err) {
+      if (err?.message === 'online_store_publication_empty') {
+        logPublicationAbort(meta, 'no_publications');
+        return respondWithPublicationIssue(res, { ...meta, visibility }, 'online_store_publication_empty', ONLINE_STORE_DISABLED_MESSAGE, {
+          allowSkipPublication: true,
+          missing: ['online_store_channel'],
+        });
+      }
+      if (err?.message === 'online_store_publication_missing') {
+        logPublicationAbort(meta, 'missing_scope');
+        return respondWithPublicationIssue(res, { ...meta, visibility }, 'online_store_publication_missing', ONLINE_STORE_MISSING_MESSAGE, {
+          missing: ['write_publications'],
+        });
+      }
+      throw err;
+    }
+
+    const publishResult = await publishToOnlineStore(product?.admin_graphql_api_id, publicationInfo?.id, {
+      maxAttempts: 5,
+      initialDelayMs: 200,
+      maxDelayMs: 3200,
+      preferEnv: publicationInfo?.source === 'env' || publicationInfo?.source === 'override',
+    });
+
+    if (!publishResult?.ok) {
+      const requestIds = Array.isArray(publishResult?.requestIds) ? publishResult.requestIds : [];
+      if (publishResult.reason === 'publication_missing') {
+        logPublicationAbort(meta, 'still_missing_after_retries', { requestIds });
+        return respondWithPublicationIssue(res, { ...meta, visibility }, 'online_store_publication_missing', ONLINE_STORE_MISSING_MESSAGE, {
+          publicationId: publicationInfo?.id || null,
+          publicationSource: publicationInfo?.source || null,
+          requestIds,
+          missing: ['write_publications'],
+        });
+      }
+      if (publishResult.reason === 'graphql_errors' || publishResult.reason === 'user_errors') {
+        const combined = publishResult.errors || publishResult.userErrors || [];
+        if (detectMissingScope(combined)) {
+          logPublicationAbort(meta, 'missing_scope', { requestIds });
+          return respondWithPublicationIssue(res, { ...meta, visibility }, 'online_store_publication_missing', ONLINE_STORE_MISSING_MESSAGE, {
+            publicationId: publicationInfo?.id || null,
+            publicationSource: publicationInfo?.source || null,
+            requestIds,
+            missing: ['write_publications'],
+          });
+        }
+      }
+
+      logPublicationAbort(meta, publishResult.reason || 'publish_failed', { requestIds });
+      return res.status(502).json({
+        ok: false,
+        reason: publishResult.reason || 'publish_failed',
+        message: 'Shopify rechazó la publicación del producto.',
+        detail: publishResult,
+        ...meta,
+        visibility,
+      });
+    }
 
     return res.status(200).json({
       ok: true,
-      productId: product?.id ? String(product.id) : undefined,
-      productHandle: product?.handle || undefined,
-      productAdminId: product?.admin_graphql_api_id,
-      variantId: variantResp?.id ? String(variantResp.id) : undefined,
-      variantAdminId: variantResp?.admin_graphql_api_id,
-      productUrl: product?.handle ? buildProductUrl(product.handle) : undefined,
+      ...meta,
       status: product?.status,
       visibility,
+      publicationId: publishResult.publicationId,
+      publicationSource: publicationInfo?.source || null,
+      requestIds: publishResult.requestIds || null,
     });
   } catch (e) {
     if (e?.message === 'SHOPIFY_ENV_MISSING') {

--- a/lib/shopify/publication.js
+++ b/lib/shopify/publication.js
@@ -4,6 +4,7 @@ let onlineStorePublicationIdPromise;
 let cachedOnlineStorePublicationId = '';
 let runtimeOnlineStorePublicationId = '';
 let runtimeOnlineStorePublicationSource = '';
+let runtimeOnlineStorePublicationName = '';
 
 function normalizeId(value) {
   if (value == null) return '';
@@ -51,13 +52,24 @@ function getPublicationIdFromEnv() {
   return raw;
 }
 
-function setRuntimePublicationId(id, source = 'runtime') {
+function setRuntimePublicationId(id, source = 'runtime', name = '') {
   const normalized = normalizeId(id);
   if (!normalized) return '';
   runtimeOnlineStorePublicationId = normalized;
   runtimeOnlineStorePublicationSource = source;
+  runtimeOnlineStorePublicationName = typeof name === 'string' ? name : '';
   cachedOnlineStorePublicationId = normalized;
   return normalized;
+}
+
+function extractRequestId(resp) {
+  if (!resp || typeof resp !== 'object' || typeof resp.headers?.get !== 'function') return '';
+  const candidates = ['x-request-id', 'X-Request-ID'];
+  for (const header of candidates) {
+    const value = resp.headers.get(header);
+    if (value) return String(value);
+  }
+  return '';
 }
 
 async function fetchOnlineStorePublicationId() {
@@ -86,6 +98,15 @@ async function fetchOnlineStorePublicationId() {
   const nodes = edges
     .map((edge) => edge?.node)
     .filter((node) => node && typeof node === 'object');
+  const total = nodes.length;
+  try {
+    console.info('online_store_publications_count', { total });
+  } catch {}
+  if (total === 0) {
+    const emptyErr = new Error('online_store_publication_empty');
+    emptyErr.total = 0;
+    throw emptyErr;
+  }
   const match = nodes.find((node) => {
     const rawHandle = normalizeId(node?.channel?.handle)
       || normalizeId(node?.channelDefinition?.handle);
@@ -100,9 +121,20 @@ async function fetchOnlineStorePublicationId() {
     return name.includes('online store');
   });
   if (!match?.id) {
+    try {
+      console.warn('online_store_publication_missing', { total });
+    } catch {}
     throw new Error('online_store_publication_missing');
   }
-  return String(match.id);
+  const publicationId = String(match.id);
+  const publicationName = typeof match.name === 'string' ? match.name : '';
+  try {
+    console.info('online_store_publication_selected', {
+      id: publicationId,
+      name: publicationName || null,
+    });
+  } catch {}
+  return { id: publicationId, name: publicationName };
 }
 
 async function resolvePublicationIdInternal(options = {}) {
@@ -134,9 +166,18 @@ async function resolvePublicationIdInternal(options = {}) {
   }
 
   if (!onlineStorePublicationIdPromise) {
-    const pending = fetchOnlineStorePublicationId().then((id) => {
-      setRuntimePublicationId(id, 'discovered');
-      return id;
+    const pending = fetchOnlineStorePublicationId().then((info) => {
+      if (info && typeof info === 'object') {
+        const id = normalizeId(info.id);
+        setRuntimePublicationId(id, 'discovered', info.name);
+        return id;
+      }
+      const normalized = normalizeId(info);
+      if (!normalized) {
+        throw new Error('online_store_publication_missing');
+      }
+      setRuntimePublicationId(normalized, 'discovered');
+      return normalized;
     });
     onlineStorePublicationIdPromise = pending.catch((err) => {
       if (onlineStorePublicationIdPromise === pending) {
@@ -150,6 +191,7 @@ async function resolvePublicationIdInternal(options = {}) {
   return {
     id,
     source: runtimeOnlineStorePublicationSource || 'discovered',
+    name: runtimeOnlineStorePublicationName || '',
   };
 }
 
@@ -171,6 +213,7 @@ export function resetCachedPublicationId() {
   cachedOnlineStorePublicationId = '';
   runtimeOnlineStorePublicationId = '';
   runtimeOnlineStorePublicationSource = '';
+  runtimeOnlineStorePublicationName = '';
 }
 
 function isPublicationMissingMessage(message) {
@@ -221,10 +264,11 @@ export async function publishToOnlineStore(productGid, publicationIdOverride, op
 
   const maxAttempts = Math.max(1, Number.isFinite(options.maxAttempts) ? Number(options.maxAttempts) : 5);
   const initialDelay = Math.max(0, Number.isFinite(options.initialDelayMs) ? Number(options.initialDelayMs) : 200);
-  const maxDelay = Math.max(initialDelay, Number.isFinite(options.maxDelayMs) ? Number(options.maxDelayMs) : 800);
+  const maxDelay = Math.max(initialDelay, Number.isFinite(options.maxDelayMs) ? Number(options.maxDelayMs) : 3200);
 
   let attempt = 0;
   let lastError;
+  const requestIds = [];
 
   while (attempt < maxAttempts) {
     attempt += 1;
@@ -241,25 +285,73 @@ export async function publishToOnlineStore(productGid, publicationIdOverride, op
         publicationId,
       });
       const json = await resp.json().catch(() => null);
+      const requestId = extractRequestId(resp);
+      if (requestId) requestIds.push(requestId);
       if (!resp.ok) {
         lastError = { reason: 'http_error', status: resp.status, body: json };
         if (isTransientStatus(resp.status) && attempt < maxAttempts) {
           retry = true;
         } else {
-          return { ok: false, reason: 'http_error', status: resp.status, body: json, attempt };
+          try {
+            console.error('publish_to_online_store_error', {
+              attempt,
+              publicationId,
+              status: resp.status,
+              requestId: requestId || null,
+            });
+          } catch {}
+          return {
+            ok: false,
+            reason: 'http_error',
+            status: resp.status,
+            body: json,
+            attempt,
+            requestId: requestId || null,
+            requestIds,
+          };
         }
       } else {
         const graphQLErrors = Array.isArray(json?.errors) ? json.errors : [];
         if (graphQLErrors.length) {
           if (graphQLErrors.some((err) => isPublicationMissingMessage(err?.message)
             || isPublicationMissingCode(err?.extensions?.code))) {
-            return { ok: false, reason: 'publication_missing', errors: graphQLErrors, attempt };
+            try {
+              console.error('publish_to_online_store_error', {
+                attempt,
+                publicationId,
+                requestId: requestId || null,
+                reason: 'publication_missing',
+              });
+            } catch {}
+            return {
+              ok: false,
+              reason: 'publication_missing',
+              errors: graphQLErrors,
+              attempt,
+              requestId: requestId || null,
+              requestIds,
+            };
           }
           lastError = { reason: 'graphql_errors', errors: graphQLErrors };
           if (graphQLErrors.some((err) => isTransientUserErrorCode(err?.extensions?.code)) && attempt < maxAttempts) {
             retry = true;
           } else {
-            return { ok: false, reason: 'graphql_errors', errors: graphQLErrors, attempt };
+            try {
+              console.error('publish_to_online_store_error', {
+                attempt,
+                publicationId,
+                requestId: requestId || null,
+                reason: 'graphql_errors',
+              });
+            } catch {}
+            return {
+              ok: false,
+              reason: 'graphql_errors',
+              errors: graphQLErrors,
+              attempt,
+              requestId: requestId || null,
+              requestIds,
+            };
           }
         } else {
           const userErrors = Array.isArray(json?.data?.publishablePublish?.userErrors)
@@ -268,16 +360,53 @@ export async function publishToOnlineStore(productGid, publicationIdOverride, op
           if (userErrors.length) {
             if (userErrors.some((err) => isPublicationMissingMessage(err?.message)
               || isPublicationMissingCode(err?.code))) {
-              return { ok: false, reason: 'publication_missing', userErrors, attempt };
+              try {
+                console.error('publish_to_online_store_error', {
+                  attempt,
+                  publicationId,
+                  requestId: requestId || null,
+                  reason: 'publication_missing',
+                });
+              } catch {}
+              return {
+                ok: false,
+                reason: 'publication_missing',
+                userErrors,
+                attempt,
+                requestId: requestId || null,
+                requestIds,
+              };
             }
             if (userErrors.some((err) => isTransientUserErrorCode(err?.code)) && attempt < maxAttempts) {
               lastError = { reason: 'user_errors', userErrors };
               retry = true;
             } else {
-              return { ok: false, reason: 'user_errors', userErrors, attempt };
+              try {
+                console.error('publish_to_online_store_error', {
+                  attempt,
+                  publicationId,
+                  requestId: requestId || null,
+                  reason: 'user_errors',
+                });
+              } catch {}
+              return {
+                ok: false,
+                reason: 'user_errors',
+                userErrors,
+                attempt,
+                requestId: requestId || null,
+                requestIds,
+              };
             }
           } else {
-            result = { ok: true, publicationId, attempt };
+            result = { ok: true, publicationId, attempt, requestId: requestId || null, requestIds };
+            try {
+              console.info('publish_to_online_store_success', {
+                attempt,
+                publicationId,
+                requestId: requestId || null,
+              });
+            } catch {}
           }
         }
       }
@@ -286,7 +415,21 @@ export async function publishToOnlineStore(productGid, publicationIdOverride, op
       if (attempt < maxAttempts) {
         retry = true;
       } else {
-        return { ok: false, reason: 'exception', error: err, attempt };
+        try {
+          console.error('publish_to_online_store_error', {
+            attempt,
+            publicationId,
+            reason: 'exception',
+            error: err?.message || String(err),
+          });
+        } catch {}
+        return {
+          ok: false,
+          reason: 'exception',
+          error: err,
+          attempt,
+          requestIds,
+        };
       }
     }
 
@@ -305,6 +448,7 @@ export async function publishToOnlineStore(productGid, publicationIdOverride, op
     reason: lastError?.reason || 'publish_failed',
     error: lastError,
     attempt,
+    requestIds,
   };
 }
 

--- a/mgm-front/src/components/Toast.jsx
+++ b/mgm-front/src/components/Toast.jsx
@@ -1,14 +1,34 @@
 import styles from './Toast.module.css';
 
-export default function Toast({ message, actionLabel, onAction, onClose }) {
+export default function Toast({
+  message,
+  actionLabel,
+  onAction,
+  secondaryActionLabel,
+  onSecondaryAction,
+  onClose,
+}) {
   if (!message) return null;
   return (
     <div className={styles.toast} role="status" aria-live="assertive">
       <span className={styles.message}>{message}</span>
-      {actionLabel && onAction ? (
-        <button type="button" className={styles.action} onClick={onAction}>
-          {actionLabel}
-        </button>
+      {(actionLabel && onAction) || (secondaryActionLabel && onSecondaryAction) ? (
+        <div className={styles.actions}>
+          {secondaryActionLabel && onSecondaryAction ? (
+            <button
+              type="button"
+              className={styles.secondaryAction}
+              onClick={onSecondaryAction}
+            >
+              {secondaryActionLabel}
+            </button>
+          ) : null}
+          {actionLabel && onAction ? (
+            <button type="button" className={styles.action} onClick={onAction}>
+              {actionLabel}
+            </button>
+          ) : null}
+        </div>
       ) : null}
       {onClose ? (
         <button

--- a/mgm-front/src/components/Toast.module.css
+++ b/mgm-front/src/components/Toast.module.css
@@ -5,7 +5,7 @@
   transform: translateX(-50%);
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
   padding: 12px 16px;
   background: rgba(17, 17, 17, 0.94);
   color: #f5f5f5;
@@ -22,6 +22,12 @@
   font-size: 0.95rem;
 }
 
+.actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
 .action {
   border: 1px solid transparent;
   background: #2563eb;
@@ -36,6 +42,22 @@
 .action:hover:not(:disabled) {
   background: #1d4ed8;
   transform: translateY(-1px);
+}
+
+.secondaryAction {
+  border: 1px solid rgba(245, 245, 245, 0.6);
+  background: transparent;
+  color: #f5f5f5;
+  font-weight: 500;
+  padding: 0.4em 0.9em;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.secondaryAction:hover:not(:disabled) {
+  background: rgba(245, 245, 245, 0.12);
+  color: #e0e7ff;
 }
 
 .close {


### PR DESCRIPTION
## Summary
- improve Online Store publication discovery and retry logging, including request IDs and extended backoff defaults
- harden publish-product validation with status/variant checks and descriptive recovery responses when the Online Store publication is missing
- update the front-end flow to reuse existing products, expose retry/skip toasts, and extend the toast component for secondary actions

## Testing
- npm test
- npm --prefix mgm-front run build

------
https://chatgpt.com/codex/tasks/task_e_68d58d65555c8327b3588adf780089fb