### PR TITLE
Implement GraphQL publication flow with private pricing

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1,4 +1,4 @@
-import { shopifyAdmin } from '../shopify.js';
+import { shopifyAdminGraphQL } from '../shopify.js';
 import { buildProductUrl } from '../publicStorefront.js';
 import { publishToOnlineStore, resolveOnlineStorePublicationId } from '../shopify/publication.js';
 
@@ -23,10 +23,32 @@ function toNumber(value) {
   return Number.isFinite(n) ? n : null;
 }
 
-function formatPrice(value) {
+const BANKERS_EPSILON = 1e-9;
+
+function bankersRound(value, decimals = 2) {
   if (!Number.isFinite(value)) return null;
-  const normalized = Math.round(value * 100) / 100;
-  return normalized.toFixed(2);
+  const factor = 10 ** decimals;
+  const scaled = value * factor;
+  if (!Number.isFinite(scaled)) return null;
+  const floor = Math.floor(scaled);
+  const diff = scaled - floor;
+  if (diff > 0.5 + BANKERS_EPSILON) {
+    return (floor + 1) / factor;
+  }
+  if (diff < 0.5 - BANKERS_EPSILON) {
+    return floor / factor;
+  }
+  if (floor % 2 === 0) {
+    return floor / factor;
+  }
+  return (floor + 1) / factor;
+}
+
+function formatMoney(value) {
+  if (!Number.isFinite(value)) return null;
+  const rounded = bankersRound(value, 2);
+  if (!Number.isFinite(rounded)) return null;
+  return rounded.toFixed(2);
 }
 
 function pickProductType(raw) {
@@ -82,13 +104,179 @@ function buildMetaDescription({ productTypeLabel, designName, widthCm, heightCm,
   return `${sections.join('. ')}.`;
 }
 
+function extractRequestId(resp) {
+  if (!resp || typeof resp !== 'object' || typeof resp.headers?.get !== 'function') return '';
+  return resp.headers.get('x-request-id') || resp.headers.get('X-Request-ID') || '';
+}
+
+function logRequestId(event, resp, extra = {}) {
+  const requestId = extractRequestId(resp);
+  if (requestId) {
+    try {
+      console.info(event, { requestId, ...extra });
+    } catch {}
+  }
+  return requestId;
+}
+
+function parseDataUrlMeta(dataUrl) {
+  if (typeof dataUrl !== 'string') {
+    return { mimeType: 'image/png' };
+  }
+  const match = /^data:([^;,]+)(;base64)?,/.exec(dataUrl);
+  if (!match) {
+    return { mimeType: 'image/png' };
+  }
+  const mimeType = match[1] ? match[1].trim() : 'image/png';
+  return { mimeType: mimeType || 'image/png' };
+}
+
+function normalizeTags(value) {
+  const list = Array.isArray(value) ? value : [];
+  const result = [];
+  const seen = new Set();
+  for (const entry of list) {
+    if (typeof entry !== 'string') continue;
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    const normalized = trimmed.slice(0, 60);
+    const dedupe = normalized.toLowerCase();
+    if (seen.has(dedupe)) continue;
+    seen.add(dedupe);
+    result.push(normalized);
+    if (result.length >= 45) break;
+  }
+  return result;
+}
+
+const STAGED_UPLOADS_CREATE_MUTATION = `mutation StagedUploads($input: [StagedUploadInput!]!) {
+  stagedUploadsCreate(input: $input) {
+    stagedTargets {
+      url
+      resourceUrl
+      parameters {
+        name
+        value
+      }
+    }
+    userErrors {
+      field
+      message
+      code
+    }
+  }
+}`;
+
+const PRODUCT_CREATE_MUTATION = `mutation ProductCreate($input: ProductInput!) {
+  productCreate(input: $input) {
+    product {
+      id
+      legacyResourceId
+      handle
+      status
+      variants(first: 5) {
+        nodes {
+          id
+          legacyResourceId
+          title
+        }
+      }
+    }
+    userErrors {
+      field
+      message
+      code
+    }
+  }
+}`;
+
+async function stagedUploadImage({ filename, buffer, mimeType }) {
+  if (!buffer || !(buffer instanceof Buffer) || buffer.length === 0) {
+    throw new Error('staged_upload_empty_buffer');
+  }
+  const input = [{
+    resource: 'IMAGE',
+    filename,
+    mimeType: mimeType || 'image/png',
+    fileSize: buffer.length,
+    httpMethod: 'POST',
+  }];
+  const resp = await shopifyAdminGraphQL(STAGED_UPLOADS_CREATE_MUTATION, { input });
+  const requestId = logRequestId('staged_upload_request', resp, { filename });
+  const json = await resp.json().catch(() => null);
+  if (!resp.ok) {
+    const err = new Error('staged_upload_request_failed');
+    err.status = resp.status;
+    err.body = json;
+    err.requestId = requestId;
+    throw err;
+  }
+  const errors = Array.isArray(json?.errors) ? json.errors : [];
+  if (errors.length) {
+    const err = new Error('staged_upload_graphql_errors');
+    err.errors = errors;
+    err.requestId = requestId;
+    throw err;
+  }
+  const payload = json?.data?.stagedUploadsCreate;
+  const userErrors = Array.isArray(payload?.userErrors)
+    ? payload.userErrors.filter((error) => error && (error.code || error.message))
+    : [];
+  if (userErrors.length) {
+    const err = new Error('staged_upload_user_errors');
+    err.userErrors = userErrors;
+    err.requestId = requestId;
+    throw err;
+  }
+  const target = Array.isArray(payload?.stagedTargets) ? payload.stagedTargets[0] : null;
+  if (!target?.url || !target?.resourceUrl) {
+    const err = new Error('staged_upload_target_missing');
+    err.requestId = requestId;
+    throw err;
+  }
+  const form = new FormData();
+  const parameters = Array.isArray(target.parameters) ? target.parameters : [];
+  for (const param of parameters) {
+    if (!param || typeof param !== 'object') continue;
+    const name = typeof param.name === 'string' ? param.name : '';
+    if (!name) continue;
+    const value = typeof param.value === 'string' ? param.value : '';
+    form.append(name, value);
+  }
+  const blob = new Blob([buffer], { type: mimeType || 'image/png' });
+  form.append('file', blob, filename);
+  const uploadResp = await fetch(target.url, { method: 'POST', body: form });
+  if (!uploadResp.ok) {
+    const text = await uploadResp.text().catch(() => '');
+    const err = new Error('staged_upload_failed');
+    err.status = uploadResp.status;
+    err.body = text.slice(0, 2000);
+    err.requestId = requestId;
+    throw err;
+  }
+  try {
+    console.info('staged_upload_success', { requestId, filename });
+  } catch {}
+  return { originalSource: target.resourceUrl, requestId };
+}
+
 function buildProductMeta(product, variant) {
   const handle = typeof product?.handle === 'string' ? product.handle : undefined;
   const productUrl = handle ? buildProductUrl(handle) : undefined;
-  const productId = product?.id ? String(product.id) : undefined;
-  const variantId = variant?.id ? String(variant.id) : undefined;
-  const variantAdminId = variant?.admin_graphql_api_id || undefined;
-  const productAdminId = product?.admin_graphql_api_id || undefined;
+  const productAdminId = typeof product?.admin_graphql_api_id === 'string'
+    ? product.admin_graphql_api_id
+    : typeof product?.id === 'string'
+      ? product.id
+      : undefined;
+  const variantAdminId = typeof variant?.admin_graphql_api_id === 'string'
+    ? variant.admin_graphql_api_id
+    : typeof variant?.id === 'string'
+      ? variant.id
+      : undefined;
+  const productLegacyId = product?.legacyResourceId ?? product?.legacy_resource_id ?? product?.id;
+  const variantLegacyId = variant?.legacyResourceId ?? variant?.legacy_resource_id ?? variant?.id;
+  const productId = productLegacyId != null ? String(productLegacyId) : productAdminId;
+  const variantId = variantLegacyId != null ? String(variantLegacyId) : variantAdminId;
   return {
     productId,
     productHandle: handle,
@@ -140,8 +328,13 @@ function isActiveStatus(product) {
 }
 
 function hasVariant(product) {
-  const variants = Array.isArray(product?.variants) ? product.variants : [];
-  return variants.length > 0 && variants[0] && typeof variants[0] === 'object';
+  if (!product || typeof product !== 'object') return false;
+  if (Array.isArray(product?.variants)) {
+    const legacyVariants = product.variants;
+    return legacyVariants.length > 0 && legacyVariants[0] && typeof legacyVariants[0] === 'object';
+  }
+  const nodes = Array.isArray(product?.variants?.nodes) ? product.variants.nodes : [];
+  return nodes.length > 0 && nodes[0] && typeof nodes[0] === 'object';
 }
 
 function detectMissingScope(errorDetail) {
@@ -195,7 +388,6 @@ export async function publishProduct(req, res) {
     const title = (baseTitle || fallbackTitle).slice(0, 254);
 
     const priceTransfer = toNumber(body.priceTransfer ?? body.price);
-    const priceNormal = toNumber(body.priceNormal ?? body.compareAtPrice ?? body.priceNormalAmount);
     const priceCurrency = typeof body.priceCurrency === 'string' && body.priceCurrency.trim()
       ? body.priceCurrency.trim().toUpperCase()
       : 'ARS';
@@ -213,31 +405,36 @@ export async function publishProduct(req, res) {
     const metaDescription = (metaDescriptionRaw || generatedMeta || '').trim().slice(0, 320);
 
     const visibilityRaw = typeof body.visibility === 'string' ? body.visibility.trim().toLowerCase() : '';
-    const visibility = visibilityRaw === 'private' || visibilityRaw === 'draft' ? 'private' : 'public';
-    const publishStatus = visibility === 'private' ? 'draft' : 'active';
-    const publishedScope = visibility === 'private' ? 'global' : 'web';
-
-    const priceValue = Number.isFinite(priceTransfer) && priceTransfer > 0 ? formatPrice(priceTransfer) : '0.00';
-    const compareAt = Number.isFinite(priceNormal) && priceNormal > (priceTransfer || 0)
-      ? formatPrice(priceNormal)
-      : null;
+    const isPrivateExplicit = typeof body.isPrivate === 'boolean' ? body.isPrivate : null;
+    const visibility = isPrivateExplicit === true || visibilityRaw === 'private' || visibilityRaw === 'draft'
+      ? 'private'
+      : 'public';
+    const isPrivate = visibility === 'private';
 
     const imageAlt = typeof body.imageAlt === 'string' && body.imageAlt.trim()
       ? body.imageAlt.trim().slice(0, 254)
       : title;
 
-    const variant = {
-      price: priceValue,
-      ...(compareAt ? { compare_at_price: compareAt } : {}),
-      requires_shipping: true,
-      taxable: true,
-      inventory_management: 'shopify',
-      inventory_policy: 'continue',
-      inventory_quantity: 9999,
-      option1: 'Default Title',
-    };
-    if (body.sku) {
-      variant.sku = String(body.sku).slice(0, 64);
+    const { mimeType } = parseDataUrlMeta(mockupDataUrl);
+    const imageBuffer = Buffer.from(b64, 'base64');
+    if (!imageBuffer.length) {
+      return res.status(400).json({ ok: false, reason: 'invalid_mockup_dataurl' });
+    }
+
+    let stagedImage;
+    try {
+      stagedImage = await stagedUploadImage({ filename, buffer: imageBuffer, mimeType });
+    } catch (err) {
+      const status = typeof err?.status === 'number' ? err.status : 502;
+      const payload = {
+        ok: false,
+        reason: err?.message || 'staged_upload_failed',
+        status,
+        detail: err?.body || err?.errors || err?.userErrors || null,
+        requestId: err?.requestId || null,
+        message: 'No se pudo subir la imagen del producto a Shopify.',
+      };
+      return res.status(status >= 400 && status < 600 ? status : 502).json(payload);
     }
 
     const templateSuffix = typeof process.env.SHOPIFY_TEMPLATE_SUFFIX === 'string'
@@ -245,62 +442,127 @@ export async function publishProduct(req, res) {
       ? process.env.SHOPIFY_TEMPLATE_SUFFIX.trim()
       : 'mousepads';
 
-    const payload = {
-      product: {
-        title,
-        body_html: description,
-        product_type: productTypeLabel,
-        status: publishStatus,
-        published_scope: publishedScope,
-        tags: '',
-        vendor: DEFAULT_VENDOR,
-        template_suffix: templateSuffix,
-        metafields_global_title_tag: title,
-        ...(metaDescription ? { metafields_global_description_tag: metaDescription } : {}),
-        variants: [variant],
-        images: [
-          {
-            attachment: b64,
-            filename,
-            alt: imageAlt,
-          },
-        ],
-        metafields: [
-          ...(designNameRaw
-            ? [{ key: 'design_name', value: designNameRaw.slice(0, 250), type: 'single_line_text_field', namespace: 'custom' }]
-            : []),
-          ...(Number.isFinite(widthCm) && widthCm > 0
-            ? [{ key: 'width_cm', value: String(widthCm), type: 'single_line_text_field', namespace: 'custom' }]
-            : []),
-          ...(Number.isFinite(heightCm) && heightCm > 0
-            ? [{ key: 'height_cm', value: String(heightCm), type: 'single_line_text_field', namespace: 'custom' }]
-            : []),
-          ...(materialLabel
-            ? [{ key: 'material', value: materialLabel.slice(0, 60), type: 'single_line_text_field', namespace: 'custom' }]
-            : []),
-          ...(Number.isFinite(approxDpi) && approxDpi > 0
-            ? [{ key: 'approx_dpi', value: String(Math.round(approxDpi)), type: 'single_line_text_field', namespace: 'custom' }]
-            : []),
-          ...(priceCurrency
-            ? [{ key: 'price_currency', value: priceCurrency, type: 'single_line_text_field', namespace: 'custom' }]
-            : []),
-        ],
-      },
+    const tags = normalizeTags(body.tags);
+
+    const basePrice = Number.isFinite(priceTransfer) ? Math.max(priceTransfer, 0) : 0;
+    const computedPrice = isPrivate ? basePrice * 1.25 : basePrice;
+    const priceValue = formatMoney(computedPrice) || '0.00';
+
+    const variantInput = {
+      price: priceValue,
+      requiresShipping: true,
+      taxable: true,
+      inventoryPolicy: 'CONTINUE',
+      inventoryManagement: 'NOT_MANAGED',
+      options: ['Default Title'],
+    };
+    if (body.sku) {
+      variantInput.sku = String(body.sku).slice(0, 64);
+    }
+
+    const productMetafields = [
+      ...(designNameRaw
+        ? [{ key: 'design_name', value: designNameRaw.slice(0, 250), type: 'single_line_text_field', namespace: 'custom' }]
+        : []),
+      ...(Number.isFinite(widthCm) && widthCm > 0
+        ? [{ key: 'width_cm', value: String(widthCm), type: 'single_line_text_field', namespace: 'custom' }]
+        : []),
+      ...(Number.isFinite(heightCm) && heightCm > 0
+        ? [{ key: 'height_cm', value: String(heightCm), type: 'single_line_text_field', namespace: 'custom' }]
+        : []),
+      ...(materialLabel
+        ? [{ key: 'material', value: materialLabel.slice(0, 60), type: 'single_line_text_field', namespace: 'custom' }]
+        : []),
+      ...(Number.isFinite(approxDpi) && approxDpi > 0
+        ? [{ key: 'approx_dpi', value: String(Math.round(approxDpi)), type: 'single_line_text_field', namespace: 'custom' }]
+        : []),
+      ...(priceCurrency
+        ? [{ key: 'price_currency', value: priceCurrency, type: 'single_line_text_field', namespace: 'custom' }]
+        : []),
+      { key: 'price_source', value: 'transferencia', type: 'single_line_text_field', namespace: 'mgm' },
+      { key: 'is_private', value: isPrivate ? 'true' : 'false', type: 'boolean', namespace: 'mgm' },
+    ];
+
+    const mediaEntries = stagedImage?.originalSource
+      ? [{ mediaContentType: 'IMAGE', originalSource: stagedImage.originalSource, alt: imageAlt }]
+      : [];
+
+    const seoInput = {
+      title,
+      ...(metaDescription ? { description: metaDescription } : {}),
     };
 
-    const resp = await shopifyAdmin('products.json', {
-      method: 'POST',
-      body: JSON.stringify(payload),
-    });
+    const productInput = {
+      title,
+      descriptionHtml: description,
+      productType: productTypeLabel,
+      status: 'ACTIVE',
+      vendor: DEFAULT_VENDOR,
+      templateSuffix,
+      options: ['Title'],
+      variants: [variantInput],
+      ...(mediaEntries.length ? { media: mediaEntries } : {}),
+      ...(productMetafields.length ? { metafields: productMetafields } : {}),
+      ...(tags.length ? { tags } : {}),
+      ...(seoInput ? { seo: seoInput } : {}),
+    };
 
-    if (!resp.ok) {
-      const text = await resp.text().catch(() => '');
-      return res.status(502).json({ ok: false, reason: 'shopify_error', status: resp.status, body: text.slice(0, 2000) });
+    const productResp = await shopifyAdminGraphQL(PRODUCT_CREATE_MUTATION, { input: productInput });
+    const productRequestId = logRequestId('product_create_request', productResp, { filename });
+    const productJson = await productResp.json().catch(() => null);
+    if (!productResp.ok) {
+      return res.status(502).json({
+        ok: false,
+        reason: 'shopify_error',
+        status: productResp.status,
+        body: productJson,
+        requestId: productRequestId || null,
+        message: 'Shopify devolvió un error al crear el producto.',
+      });
     }
-    const data = await resp.json().catch(() => ({}));
-    const product = data?.product || {};
-    const variantResp = Array.isArray(product?.variants) ? product.variants[0] || {} : {};
+    const productErrors = Array.isArray(productJson?.errors) ? productJson.errors : [];
+    if (productErrors.length) {
+      return res.status(502).json({
+        ok: false,
+        reason: 'shopify_graphql_errors',
+        errors: productErrors,
+        requestId: productRequestId || null,
+        message: 'Shopify devolvió un error al crear el producto.',
+      });
+    }
+    const productPayload = productJson?.data?.productCreate;
+    if (!productPayload) {
+      return res.status(502).json({
+        ok: false,
+        reason: 'product_create_failed',
+        detail: productJson,
+        requestId: productRequestId || null,
+        message: 'Shopify devolvió un error al crear el producto.',
+      });
+    }
+    const userErrors = Array.isArray(productPayload.userErrors)
+      ? productPayload.userErrors.filter((error) => error && (error.message || error.code))
+      : [];
+    if (userErrors.length) {
+      return res.status(400).json({
+        ok: false,
+        reason: 'product_create_user_errors',
+        message: 'Shopify rechazó la creación del producto.',
+        detail: userErrors,
+        requestId: productRequestId || null,
+      });
+    }
+    const product = productPayload.product || {};
+    const variantsList = Array.isArray(product?.variants?.nodes)
+      ? product.variants.nodes
+      : Array.isArray(product?.variants)
+        ? product.variants
+        : [];
+    const variantResp = variantsList[0] || {};
     const meta = buildProductMeta(product, variantResp);
+    try {
+      console.info('product_create_success', { requestId: productRequestId || null, productId: meta.productAdminId || null });
+    } catch {}
 
     if (!isActiveStatus(product)) {
       return res.status(400).json({
@@ -351,7 +613,7 @@ export async function publishProduct(req, res) {
       throw err;
     }
 
-    const publishResult = await publishToOnlineStore(product?.admin_graphql_api_id, publicationInfo?.id, {
+    const publishResult = await publishToOnlineStore(meta.productAdminId, publicationInfo?.id, {
       maxAttempts: 5,
       initialDelayMs: 200,
       maxDelayMs: 3200,
@@ -390,6 +652,7 @@ export async function publishProduct(req, res) {
         detail: publishResult,
         ...meta,
         visibility,
+        publishAttempts: typeof publishResult.attempt === 'number' ? publishResult.attempt : undefined,
       });
     }
 
@@ -401,6 +664,7 @@ export async function publishProduct(req, res) {
       publicationId: publishResult.publicationId,
       publicationSource: publicationInfo?.source || null,
       requestIds: publishResult.requestIds || null,
+      publishAttempts: typeof publishResult.attempt === 'number' ? publishResult.attempt : undefined,
     });
   } catch (e) {
     if (e?.message === 'SHOPIFY_ENV_MISSING') {

--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -130,7 +130,6 @@ export async function createJobAndProduct(
   let heightCm = safeNumber((flow.editorState as any)?.size_cm?.h);
   let approxDpi = safeNumber(flow.approxDpi);
   let priceTransferRaw = safeNumber(flow.priceTransfer);
-  let priceNormalRaw = safeNumber(flow.priceNormal);
   const priceCurrencyRaw = typeof flow.priceCurrency === 'string' ? flow.priceCurrency : 'ARS';
   let priceCurrency = priceCurrencyRaw.trim() || 'ARS';
   let measurementLabel = formatMeasurement(widthCm, heightCm);
@@ -151,19 +150,6 @@ export async function createJobAndProduct(
   if (!canReuse) {
     if (!flow.mockupBlob) throw new Error('missing_mockup');
     mockupDataUrl = await blobToBase64(flow.mockupBlob);
-
-    let priceTransfer = priceTransferRaw;
-    let priceNormal = priceNormalRaw;
-
-    if (isPrivate) {
-      const markupFactor = 1.25;
-      const applyMarkup = (value?: number) => {
-        if (typeof value !== 'number') return value;
-        return Math.round(value * markupFactor * 100) / 100;
-      };
-      priceTransfer = applyMarkup(priceTransferRaw);
-      priceNormal = applyMarkup(priceNormalRaw);
-    }
 
     if (isPrivate) {
       const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -186,8 +172,7 @@ export async function createJobAndProduct(
         widthCm,
         heightCm,
         approxDpi,
-        priceTransfer,
-        priceNormal,
+        priceTransfer: priceTransferRaw,
         priceCurrency,
         lowQualityAck: Boolean(flow.lowQualityAck),
         imageAlt,
@@ -196,6 +181,7 @@ export async function createJobAndProduct(
         description: '',
         seoDescription: metaDescription,
         visibility: requestedVisibility,
+        isPrivate,
       }),
     });
     const publishData = await publishResp.json().catch(() => null);

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -237,7 +237,7 @@ export default function Mockup() {
       }
 
       setCartStatus('waiting');
-      const waitResult = await waitForVariantAvailability(current.variantId, current.productId, { timeoutMs: 30_000 });
+      const waitResult = await waitForVariantAvailability(current.variantId, current.productId);
       if (!waitResult.ready) {
         setCartStatus('idle');
         setBusy(false);


### PR DESCRIPTION
## Summary
- publish custom products through the Admin GraphQL API, including staged image uploads, banker rounding for transfer pricing with private markup, and mgm audit metafields
- keep Shopify publication robust by resolving the Online Store channel dynamically, retrying publishablePublish, and surfacing request ids when uploads or publishing fail
- update the editor flow to send the raw transfer price with a private flag and wait up to 45s for Storefront availability before redirecting with a cart permalink

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d595c291588327bb6f42e14ff551a0