### PR TITLE
Handle missing write_files scope for Shopify staged uploads

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -350,6 +350,31 @@ function detectMissingScope(errorDetail) {
   });
 }
 
+function isMissingFilesScopeMessage(raw) {
+  if (!raw || typeof raw !== 'string') return false;
+  const normalized = raw.toLowerCase();
+  if (!normalized.includes('scope') && !normalized.includes('permission') && !normalized.includes('access')) {
+    return normalized.includes('write_files');
+  }
+  return normalized.includes('write_files')
+    || normalized.includes('write files')
+    || normalized.includes('stagedupload')
+    || normalized.includes('staged uploads');
+}
+
+function detectMissingFilesScope(detail) {
+  if (!detail) return false;
+  if (detectMissingScope(detail)) return true;
+  const list = Array.isArray(detail) ? detail : [];
+  for (const entry of list) {
+    if (!entry || typeof entry !== 'object') continue;
+    if (isMissingFilesScopeMessage(entry?.message)) return true;
+    if (isMissingFilesScopeMessage(entry?.code)) return true;
+    if (isMissingFilesScopeMessage(entry?.extensions?.code)) return true;
+  }
+  return false;
+}
+
 export async function publishProduct(req, res) {
   if (req.method !== 'POST') {
     res.statusCode = 405;
@@ -426,6 +451,31 @@ export async function publishProduct(req, res) {
       stagedImage = await stagedUploadImage({ filename, buffer: imageBuffer, mimeType });
     } catch (err) {
       const status = typeof err?.status === 'number' ? err.status : 502;
+      const errorArrays = [
+        Array.isArray(err?.errors) ? err.errors : [],
+        Array.isArray(err?.userErrors) ? err.userErrors : [],
+        Array.isArray(err?.body?.errors) ? err.body.errors : [],
+      ];
+      const combined = errorArrays.flat();
+      const extraMessages = [
+        typeof err?.message === 'string' ? err.message : '',
+        typeof err?.body === 'string' ? err.body : '',
+        typeof err?.body?.message === 'string' ? err.body.message : '',
+      ];
+      const missingFilesScope = detectMissingFilesScope(combined)
+        || extraMessages.some((msg) => isMissingFilesScopeMessage(msg));
+
+      if (missingFilesScope) {
+        return res.status(403).json({
+          ok: false,
+          reason: 'shopify_missing_scope',
+          status: 403,
+          missing: ['write_files'],
+          requestId: err?.requestId || null,
+          message: 'La app de Shopify no tiene el scope write_files habilitado. Actualizá los permisos y reintentá.',
+        });
+      }
+
       const payload = {
         ok: false,
         reason: err?.message || 'staged_upload_failed',


### PR DESCRIPTION
## Summary
- detect and surface missing write_files scope errors when staging Shopify uploads fails
- add helpers that recognize permission-related responses from staged upload endpoints and return actionable guidance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d59ae980f48327b7a19774421db394