### PR TITLE
Improve Shopify product publish error handling

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -350,6 +350,38 @@ function detectMissingScope(errorDetail) {
   });
 }
 
+function extractScopesFromString(raw) {
+  if (typeof raw !== 'string' || !raw) return [];
+  const matches = raw.toLowerCase().match(/\b(?:read|write)_[a-z0-9_]+\b/g);
+  if (!matches) return [];
+  return matches.map((scope) => scope.trim()).filter(Boolean);
+}
+
+function collectMissingScopes(detail) {
+  const list = Array.isArray(detail) ? detail : [];
+  const scopes = new Set();
+  for (const entry of list) {
+    if (!entry || typeof entry !== 'object') continue;
+    const candidates = [
+      typeof entry.message === 'string' ? entry.message : '',
+      typeof entry.code === 'string' ? entry.code : '',
+      typeof entry?.extensions?.code === 'string' ? entry.extensions.code : '',
+    ];
+    if (Array.isArray(entry?.extensions?.requiredAccess)) {
+      for (const access of entry.extensions.requiredAccess) {
+        if (typeof access === 'string') candidates.push(access);
+      }
+    }
+    for (const candidate of candidates) {
+      if (!candidate) continue;
+      for (const scope of extractScopesFromString(candidate)) {
+        scopes.add(scope);
+      }
+    }
+  }
+  return Array.from(scopes);
+}
+
 function isMissingFilesScopeMessage(raw) {
   if (!raw || typeof raw !== 'string') return false;
   const normalized = raw.toLowerCase();
@@ -570,6 +602,7 @@ export async function publishProduct(req, res) {
     const productResp = await shopifyAdminGraphQL(PRODUCT_CREATE_MUTATION, { input: productInput });
     const productRequestId = logRequestId('product_create_request', productResp, { filename });
     const productJson = await productResp.json().catch(() => null);
+    const productPayload = productJson?.data?.productCreate;
     if (!productResp.ok) {
       return res.status(502).json({
         ok: false,
@@ -581,16 +614,53 @@ export async function publishProduct(req, res) {
       });
     }
     const productErrors = Array.isArray(productJson?.errors) ? productJson.errors : [];
+    const hasProductPayload = productPayload && typeof productPayload === 'object' && productPayload.product;
     if (productErrors.length) {
-      return res.status(502).json({
-        ok: false,
-        reason: 'shopify_graphql_errors',
-        errors: productErrors,
+      if (!hasProductPayload) {
+        if (detectMissingScope(productErrors)) {
+          const missingScopes = collectMissingScopes(productErrors);
+          const missing = missingScopes.length ? missingScopes : ['write_products'];
+          const friendlyMessage = missing.length
+            ? `La app de Shopify no tiene permisos suficientes. Faltan los scopes: ${missing.join(', ')}.`
+            : 'La app de Shopify no tiene permisos suficientes para crear productos.';
+          return res.status(400).json({
+            ok: false,
+            reason: 'shopify_scope_missing',
+            errors: productErrors,
+            requestId: productRequestId || null,
+            missing,
+            message: friendlyMessage,
+          });
+        }
+        return res.status(502).json({
+          ok: false,
+          reason: 'shopify_graphql_errors',
+          errors: productErrors,
+          requestId: productRequestId || null,
+          message: 'Shopify devolvió un error al crear el producto.',
+        });
+      }
+
+      const errorMessages = productErrors
+        .map((err) => (typeof err?.message === 'string' ? err.message.trim() : ''))
+        .filter((msg) => Boolean(msg));
+      const warningMessage = errorMessages.length
+        ? `Shopify devolvió advertencias: ${errorMessages.join(' ')}`
+        : 'Shopify devolvió advertencias durante la creación del producto.';
+      const warningPayload = {
+        code: 'shopify_graphql_warning',
+        message: warningMessage,
+        detail: productErrors,
         requestId: productRequestId || null,
-        message: 'Shopify devolvió un error al crear el producto.',
-      });
+      };
+      warnings.push(warningPayload);
+      try {
+        console.warn('product_create_graphql_warning', {
+          requestId: productRequestId || null,
+          messages: errorMessages,
+        });
+      } catch {}
     }
-    const productPayload = productJson?.data?.productCreate;
     if (!productPayload) {
       return res.status(502).json({
         ok: false,

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -143,6 +143,11 @@ export default function Mockup() {
         ? error.missing.join(', ')
         : 'SHOPIFY_STORE_DOMAIN, SHOPIFY_ADMIN_TOKEN';
       friendly = `La integración con Shopify no está configurada. Faltan las variables: ${missing}.`;
+    } else if (reasonRaw === 'shopify_scope_missing') {
+      const missing = Array.isArray(error?.missing) && error.missing.length
+        ? error.missing.join(', ')
+        : 'write_products';
+      friendly = `La app de Shopify no tiene permisos suficientes. Reinstalá la app concediendo los scopes: ${missing}.`;
     } else if (reasonRaw === 'shopify_storefront_env_missing') {
       const missing = Array.isArray(error?.missing) && error.missing.length
         ? error.missing.join(', ')


### PR DESCRIPTION
## Summary
- detect missing Shopify scopes when GraphQL rejects product creation and surface a friendly message
- treat recoverable GraphQL errors as warnings so the product flow can proceed when Shopify still returns a product
- surface a front-end alert explaining the missing scope so the user can fix the Shopify app permissions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5a0bc76208327827659f6885f9ad0