### PR TITLE
Add retries for Shopify product creation failures

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -10,6 +10,10 @@ const ONLINE_STORE_MISSING_MESSAGE = [
 ].join('\n');
 const ONLINE_STORE_DISABLED_MESSAGE = 'Tu tienda no tiene el canal Online Store habilitado. Instalalo o bien omití la publicación y usa Storefront para el carrito.';
 
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
+}
+
 function ensureBody(body) {
   if (body && typeof body === 'object') return body;
   if (typeof body === 'string') {
@@ -117,6 +121,60 @@ function logRequestId(event, resp, extra = {}) {
     } catch {}
   }
   return requestId;
+}
+
+const RETRYABLE_SHOPIFY_STATUS = new Set([500, 502, 503, 504]);
+
+async function executeProductCreate({ input, filename, maxAttempts = 3 }) {
+  const attempts = [];
+  let lastError = null;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      const resp = await shopifyAdminGraphQL(PRODUCT_CREATE_MUTATION, { input });
+      const requestId = logRequestId('product_create_request', resp, { filename, attempt: attempt + 1 });
+      const json = await resp.json().catch(() => null);
+      const attemptInfo = { resp, json, requestId };
+      attempts.push(attemptInfo);
+
+      if (resp.ok) {
+        return { ...attemptInfo, attempts };
+      }
+
+      if (!RETRYABLE_SHOPIFY_STATUS.has(resp.status) || attempt === maxAttempts - 1) {
+        return { ...attemptInfo, attempts };
+      }
+
+      try {
+        console.warn('product_create_retry', {
+          attempt: attempt + 1,
+          status: resp.status,
+          requestId: requestId || null,
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    } catch (err) {
+      lastError = err;
+      attempts.push({ error: err });
+
+      if (attempt === maxAttempts - 1) {
+        throw err;
+      }
+
+      try {
+        console.warn('product_create_retry_error', {
+          attempt: attempt + 1,
+          message: err?.message || String(err),
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    }
+  }
+
+  if (lastError) throw lastError;
+  return attempts[attempts.length - 1];
 }
 
 function parseDataUrlMeta(dataUrl) {
@@ -599,9 +657,12 @@ export async function publishProduct(req, res) {
       ...(seoInput ? { seo: seoInput } : {}),
     };
 
-    const productResp = await shopifyAdminGraphQL(PRODUCT_CREATE_MUTATION, { input: productInput });
-    const productRequestId = logRequestId('product_create_request', productResp, { filename });
-    const productJson = await productResp.json().catch(() => null);
+    const {
+      resp: productResp,
+      json: productJson,
+      requestId: productRequestId,
+      attempts: productAttempts,
+    } = await executeProductCreate({ input: productInput, filename });
     const productPayload = productJson?.data?.productCreate;
     if (!productResp.ok) {
       return res.status(502).json({
@@ -610,6 +671,9 @@ export async function publishProduct(req, res) {
         status: productResp.status,
         body: productJson,
         requestId: productRequestId || null,
+        ...(Array.isArray(productAttempts)
+          ? { requestIds: productAttempts.map((entry) => entry?.requestId).filter(Boolean) }
+          : {}),
         message: 'Shopify devolvió un error al crear el producto.',
       });
     }


### PR DESCRIPTION
## Summary
- add a reusable helper that retries Shopify product creation when the Admin API returns transient 5xx errors
- log retry attempts and include collected request ids when a failure persists

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5a2fc89688327ad775bb9b52b9d81