### PR TITLE
Improve Shopify product publishing robustness

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -10,10 +10,19 @@ export function getEnv(name, { required = true } = {}) {
 }
 
 export function getShopifyConfig() {
+  const rawDomain = [process.env.SHOPIFY_STORE_DOMAIN, process.env.SHOPIFY_SHOP]
+    .map((value) => (typeof value === 'string' ? value.trim() : ''))
+    .find((value) => value) || '';
+  if (!process.env.SHOPIFY_STORE_DOMAIN && rawDomain) {
+    process.env.SHOPIFY_STORE_DOMAIN = rawDomain;
+  }
+  const apiVersion = typeof process.env.SHOPIFY_API_VERSION === 'string'
+    ? process.env.SHOPIFY_API_VERSION.trim() || '2024-07'
+    : '2024-07';
   return {
-    STORE_DOMAIN: process.env.SHOPIFY_STORE_DOMAIN || '',
+    STORE_DOMAIN: rawDomain,
     ADMIN_TOKEN: process.env.SHOPIFY_ADMIN_TOKEN || '',
-    API_VERSION: process.env.SHOPIFY_API_VERSION || '2024-07',
+    API_VERSION: apiVersion,
     STOREFRONT_TOKEN: process.env.SHOPIFY_STOREFRONT_TOKEN || '',
     STOREFRONT_DOMAIN: process.env.SHOPIFY_STOREFRONT_DOMAIN || '',
   };

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -125,6 +125,129 @@ function logRequestId(event, resp, extra = {}) {
 
 const RETRYABLE_SHOPIFY_STATUS = new Set([500, 502, 503, 504]);
 
+const DEFAULT_SHOPIFY_API_VERSION = '2024-07';
+const SHOP_SANITY_QUERY = `query ShopSanity {
+  shop {
+    name
+    myshopifyDomain
+  }
+}`;
+
+function pickEnvValue(names) {
+  for (const name of names) {
+    if (!name) continue;
+    const raw = typeof process.env[name] === 'string' ? process.env[name].trim() : '';
+    if (raw) return raw;
+  }
+  return '';
+}
+
+function isValidMyShopifyDomain(domain) {
+  if (typeof domain !== 'string') return false;
+  const trimmed = domain.trim();
+  if (!trimmed) return false;
+  if (!/\.myshopify\.com$/i.test(trimmed)) return false;
+  const withoutSuffix = trimmed.replace(/\.myshopify\.com$/i, '');
+  return /^[a-z0-9][a-z0-9-]*$/i.test(withoutSuffix);
+}
+
+function collectGraphQLErrorMessages(errors) {
+  if (!Array.isArray(errors)) return [];
+  return errors
+    .map((err) => {
+      if (!err || typeof err !== 'object') return '';
+      if (typeof err.message === 'string' && err.message.trim()) return err.message.trim();
+      if (typeof err.code === 'string' && err.code.trim()) return err.code.trim();
+      if (typeof err?.extensions?.code === 'string' && err.extensions.code.trim()) {
+        return err.extensions.code.trim();
+      }
+      return '';
+    })
+    .filter((msg) => Boolean(msg));
+}
+
+async function ensureShopifyEnvironmentReady() {
+  const domain = pickEnvValue(['SHOPIFY_STORE_DOMAIN', 'SHOPIFY_SHOP']);
+  const token = pickEnvValue(['SHOPIFY_ADMIN_TOKEN']);
+  const rawApiVersion = typeof process.env.SHOPIFY_API_VERSION === 'string'
+    ? process.env.SHOPIFY_API_VERSION.trim()
+    : '';
+
+  const missing = [];
+  if (!domain) missing.push('SHOPIFY_SHOP');
+  if (!token) missing.push('SHOPIFY_ADMIN_TOKEN');
+  if (!rawApiVersion) missing.push('SHOPIFY_API_VERSION');
+
+  if (missing.length) {
+    return { ok: false, reason: 'missing_env', missing };
+  }
+
+  if (!isValidMyShopifyDomain(domain)) {
+    return { ok: false, reason: 'invalid_shop_domain', domain };
+  }
+
+  if (!process.env.SHOPIFY_STORE_DOMAIN) {
+    process.env.SHOPIFY_STORE_DOMAIN = domain;
+  }
+  if (!process.env.SHOPIFY_API_VERSION) {
+    process.env.SHOPIFY_API_VERSION = rawApiVersion;
+  }
+
+  if (rawApiVersion !== DEFAULT_SHOPIFY_API_VERSION) {
+    return { ok: false, reason: 'invalid_api_version', apiVersion: rawApiVersion };
+  }
+
+  let resp;
+  try {
+    resp = await shopifyAdminGraphQL(SHOP_SANITY_QUERY, {});
+  } catch (err) {
+    if (err?.message === 'SHOPIFY_ENV_MISSING') {
+      const errMissing = Array.isArray(err?.missing) && err.missing.length ? err.missing : missing;
+      return { ok: false, reason: 'missing_env', missing: errMissing };
+    }
+    return { ok: false, reason: 'sanity_request_failed', error: err };
+  }
+
+  const requestId = logRequestId('shop_sanity_check', resp, { domain });
+  const json = await resp.json().catch(() => null);
+
+  if (!resp.ok) {
+    const errors = Array.isArray(json?.errors) ? json.errors : [];
+    return {
+      ok: false,
+      reason: 'sanity_http_error',
+      status: resp.status,
+      errors,
+      json,
+      requestId,
+    };
+  }
+
+  const graphQLErrors = Array.isArray(json?.errors) ? json.errors : [];
+  if (graphQLErrors.length) {
+    return {
+      ok: false,
+      reason: 'sanity_graphql_errors',
+      errors: graphQLErrors,
+      requestId,
+      messages: collectGraphQLErrorMessages(graphQLErrors),
+    };
+  }
+
+  const shopName = typeof json?.data?.shop?.name === 'string' ? json.data.shop.name : '';
+  if (!shopName) {
+    return { ok: false, reason: 'sanity_no_shop', requestId };
+  }
+
+  return {
+    ok: true,
+    shopName,
+    domain,
+    apiVersion: rawApiVersion,
+    requestId,
+  };
+}
+
 async function executeProductCreate({ input, filename, maxAttempts = 3 }) {
   const attempts = [];
   let lastError = null;
@@ -248,7 +371,7 @@ const PRODUCT_CREATE_MUTATION = `mutation ProductCreate($input: ProductInput!) {
   }
 }`;
 
-async function stagedUploadImage({ filename, buffer, mimeType }) {
+async function stagedUploadImage({ filename, buffer, mimeType, maxUploadAttempts = 3 }) {
   if (!buffer || !(buffer instanceof Buffer) || buffer.length === 0) {
     throw new Error('staged_upload_empty_buffer');
   }
@@ -292,30 +415,106 @@ async function stagedUploadImage({ filename, buffer, mimeType }) {
     err.requestId = requestId;
     throw err;
   }
-  const form = new FormData();
+
   const parameters = Array.isArray(target.parameters) ? target.parameters : [];
-  for (const param of parameters) {
-    if (!param || typeof param !== 'object') continue;
-    const name = typeof param.name === 'string' ? param.name : '';
-    if (!name) continue;
-    const value = typeof param.value === 'string' ? param.value : '';
-    form.append(name, value);
-  }
   const blob = new Blob([buffer], { type: mimeType || 'image/png' });
-  form.append('file', blob, filename);
-  const uploadResp = await fetch(target.url, { method: 'POST', body: form });
-  if (!uploadResp.ok) {
+  const buildFormData = () => {
+    const formData = new FormData();
+    for (const param of parameters) {
+      if (!param || typeof param !== 'object') continue;
+      const name = typeof param.name === 'string' ? param.name : '';
+      if (!name) continue;
+      const value = typeof param.value === 'string' ? param.value : '';
+      formData.append(name, value);
+    }
+    formData.append('file', blob, filename);
+    return formData;
+  };
+
+  const attempts = Math.max(1, Number.isFinite(maxUploadAttempts) ? Number(maxUploadAttempts) : 3);
+  let uploadRequestId = '';
+  let lastStatus = 0;
+  let lastBody = '';
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const form = buildFormData();
+    let uploadResp;
+    try {
+      uploadResp = await fetch(target.url, { method: 'POST', body: form });
+    } catch (err) {
+      lastStatus = 0;
+      lastBody = err?.message || '';
+      if (attempt < attempts - 1) {
+        try {
+          console.warn('staged_upload_post_retry', {
+            attempt: attempt + 1,
+            status: 0,
+            requestId: requestId || null,
+            uploadRequestId: uploadRequestId || null,
+            reason: err?.message || 'exception',
+          });
+        } catch {}
+        await sleep(200 * 2 ** attempt);
+        continue;
+      }
+      const finalErr = new Error('staged_upload_failed');
+      finalErr.status = 0;
+      finalErr.body = lastBody;
+      finalErr.requestId = requestId;
+      finalErr.attempt = attempt + 1;
+      throw finalErr;
+    }
+
+    const attemptUploadRequestId = extractRequestId(uploadResp);
+    if (attemptUploadRequestId) {
+      uploadRequestId = attemptUploadRequestId;
+    }
+
+    if (uploadResp.ok) {
+      try {
+        console.info('staged_upload_success', {
+          requestId,
+          uploadRequestId: uploadRequestId || null,
+          filename,
+          attempts: attempt + 1,
+        });
+      } catch {}
+      return { originalSource: target.resourceUrl, requestId, uploadRequestId: uploadRequestId || null };
+    }
+
+    lastStatus = uploadResp.status;
     const text = await uploadResp.text().catch(() => '');
+    lastBody = text.slice(0, 2000);
+
+    if (uploadResp.status === 502 && attempt < attempts - 1) {
+      try {
+        console.warn('staged_upload_post_retry', {
+          attempt: attempt + 1,
+          status: uploadResp.status,
+          requestId: requestId || null,
+          uploadRequestId: uploadRequestId || null,
+        });
+      } catch {}
+      await sleep(200 * 2 ** attempt);
+      continue;
+    }
+
     const err = new Error('staged_upload_failed');
     err.status = uploadResp.status;
-    err.body = text.slice(0, 2000);
+    err.body = lastBody;
     err.requestId = requestId;
+    if (uploadRequestId) err.uploadRequestId = uploadRequestId;
+    err.attempt = attempt + 1;
     throw err;
   }
-  try {
-    console.info('staged_upload_success', { requestId, filename });
-  } catch {}
-  return { originalSource: target.resourceUrl, requestId };
+
+  const err = new Error('staged_upload_failed');
+  err.status = lastStatus || 502;
+  err.body = lastBody;
+  err.requestId = requestId;
+  if (uploadRequestId) err.uploadRequestId = uploadRequestId;
+  err.attempt = attempts;
+  throw err;
 }
 
 function buildProductMeta(product, variant) {
@@ -471,6 +670,34 @@ export async function publishProduct(req, res) {
     return res.json({ ok: false, error: 'method_not_allowed' });
   }
   try {
+    const envStatus = await ensureShopifyEnvironmentReady();
+    if (!envStatus.ok) {
+      const reason = envStatus.reason || 'shopify_env_invalid';
+      let message = 'Token/Admin API inválido o dominio incorrecto';
+      if (reason === 'invalid_api_version') {
+        message = `La versión de la API de Shopify debe ser ${DEFAULT_SHOPIFY_API_VERSION}.`;
+      }
+      try {
+        console.error('shopify_env_check_failed', {
+          reason,
+          requestId: envStatus.requestId || null,
+          missing: Array.isArray(envStatus.missing) ? envStatus.missing : undefined,
+          status: typeof envStatus.status === 'number' ? envStatus.status : undefined,
+          messages: Array.isArray(envStatus.messages) ? envStatus.messages : undefined,
+        });
+      } catch {}
+      return res.status(400).json({
+        ok: false,
+        reason,
+        message,
+        ...(envStatus.requestId ? { requestId: envStatus.requestId } : {}),
+        ...(typeof envStatus.status === 'number' ? { status: envStatus.status } : {}),
+        ...(Array.isArray(envStatus.missing) && envStatus.missing.length ? { missing: envStatus.missing } : {}),
+        ...(Array.isArray(envStatus.errors) && envStatus.errors.length ? { errors: envStatus.errors } : {}),
+        ...(Array.isArray(envStatus.messages) && envStatus.messages.length ? { messages: envStatus.messages } : {}),
+      });
+    }
+
     const body = ensureBody(req.body);
 
     const mockupDataUrl = typeof body.mockupDataUrl === 'string' ? body.mockupDataUrl : '';
@@ -556,16 +783,20 @@ export async function publishProduct(req, res) {
       const missingFilesScope = detectMissingFilesScope(combined)
         || extraMessages.some((msg) => isMissingFilesScopeMessage(msg));
 
+      const stageRequestId = err?.requestId || null;
+      const uploadRequestId = err?.uploadRequestId || null;
+
       const warningBase = {
         code: missingFilesScope ? 'missing_write_files_scope' : 'image_upload_failed',
         status,
-        requestId: err?.requestId || null,
+        requestId: stageRequestId,
+        uploadRequestId,
         detail: err?.body || err?.errors || err?.userErrors || null,
       };
 
       const message = missingFilesScope
-        ? 'No se pudo subir la imagen porque falta el scope write_files. El producto se creó sin mockup.'
-        : 'No se pudo subir la imagen del producto. El producto se creó sin mockup.';
+        ? 'No se pudo subir la imagen porque falta el scope write_files. Se seguirá sin mockup.'
+        : 'No se pudo subir la imagen, se seguirá sin mockup.';
 
       const warningPayload = {
         ...warningBase,
@@ -579,8 +810,12 @@ export async function publishProduct(req, res) {
         console.warn('product_image_upload_warning', {
           message,
           status,
-          requestId: warningPayload.requestId || null,
+          requestId: stageRequestId,
+          uploadRequestId,
           missingFilesScope,
+          attempt: typeof err?.attempt === 'number' ? err.attempt : null,
+          errors: Array.isArray(err?.errors) ? err.errors : undefined,
+          userErrors: Array.isArray(err?.userErrors) ? err.userErrors : undefined,
         });
       } catch {}
 
@@ -601,10 +836,6 @@ export async function publishProduct(req, res) {
     const variantInput = {
       price: priceValue,
       requiresShipping: true,
-      taxable: true,
-      inventoryPolicy: 'CONTINUE',
-      inventoryManagement: 'NOT_MANAGED',
-      options: ['Default Title'],
     };
     if (body.sku) {
       variantInput.sku = String(body.sku).slice(0, 64);
@@ -644,18 +875,49 @@ export async function publishProduct(req, res) {
 
     const productInput = {
       title,
-      descriptionHtml: description,
-      productType: productTypeLabel,
       status: 'ACTIVE',
-      vendor: DEFAULT_VENDOR,
-      templateSuffix,
-      options: ['Title'],
       variants: [variantInput],
-      ...(mediaEntries.length ? { media: mediaEntries } : {}),
-      ...(productMetafields.length ? { metafields: productMetafields } : {}),
-      ...(tags.length ? { tags } : {}),
-      ...(seoInput ? { seo: seoInput } : {}),
     };
+
+    if (typeof description === 'string' && description.trim()) {
+      productInput.descriptionHtml = description;
+    }
+    if (productTypeLabel) {
+      productInput.productType = productTypeLabel;
+    }
+    if (DEFAULT_VENDOR) {
+      productInput.vendor = DEFAULT_VENDOR;
+    }
+    if (templateSuffix) {
+      productInput.templateSuffix = templateSuffix;
+    }
+    if (mediaEntries.length) {
+      productInput.media = mediaEntries;
+    }
+    if (productMetafields.length) {
+      productInput.metafields = productMetafields;
+    }
+    if (tags.length) {
+      productInput.tags = tags;
+    }
+    if (seoInput && (seoInput.description || seoInput.title)) {
+      productInput.seo = seoInput;
+    }
+
+    try {
+      const productInputLog = JSON.parse(JSON.stringify(productInput));
+      console.info('product_create_input', {
+        input: productInputLog,
+        hasMedia: mediaEntries.length > 0,
+        metafields: productMetafields.length,
+      });
+    } catch (logErr) {
+      try {
+        console.warn('product_create_input_log_failed', {
+          message: logErr?.message || String(logErr),
+        });
+      } catch {}
+    }
 
     const {
       resp: productResp,
@@ -696,26 +958,36 @@ export async function publishProduct(req, res) {
             message: friendlyMessage,
           });
         }
+        const graphQLErrorMessages = collectGraphQLErrorMessages(productErrors);
+        const graphQLErrorMessage = graphQLErrorMessages.length
+          ? `Shopify devolvió errores: ${graphQLErrorMessages.join(' | ')}`
+          : 'Shopify devolvió un error al crear el producto.';
+        try {
+          console.error('product_create_graphql_errors', {
+            requestId: productRequestId || null,
+            messages: graphQLErrorMessages,
+          });
+        } catch {}
         return res.status(502).json({
           ok: false,
           reason: 'shopify_graphql_errors',
           errors: productErrors,
           requestId: productRequestId || null,
-          message: 'Shopify devolvió un error al crear el producto.',
+          message: graphQLErrorMessage,
+          ...(graphQLErrorMessages.length ? { messages: graphQLErrorMessages } : {}),
         });
       }
 
-      const errorMessages = productErrors
-        .map((err) => (typeof err?.message === 'string' ? err.message.trim() : ''))
-        .filter((msg) => Boolean(msg));
+      const errorMessages = collectGraphQLErrorMessages(productErrors);
       const warningMessage = errorMessages.length
-        ? `Shopify devolvió advertencias: ${errorMessages.join(' ')}`
+        ? `Shopify devolvió advertencias: ${errorMessages.join(' | ')}`
         : 'Shopify devolvió advertencias durante la creación del producto.';
       const warningPayload = {
         code: 'shopify_graphql_warning',
         message: warningMessage,
         detail: productErrors,
         requestId: productRequestId || null,
+        ...(errorMessages.length ? { messages: errorMessages } : {}),
       };
       warnings.push(warningPayload);
       try {
@@ -738,12 +1010,33 @@ export async function publishProduct(req, res) {
       ? productPayload.userErrors.filter((error) => error && (error.message || error.code))
       : [];
     if (userErrors.length) {
+      const userErrorMessages = userErrors
+        .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
+        .filter((msg) => Boolean(msg));
+      const friendlyUserError = userErrorMessages.length
+        ? userErrorMessages[0]
+        : 'Shopify rechazó la creación del producto.';
+      try {
+        console.error('product_create_user_errors', {
+          requestId: productRequestId || null,
+          errors: userErrors.map((error) => ({
+            field: Array.isArray(error?.field)
+              ? error.field.filter((segment) => typeof segment === 'string' && segment.trim()).join('.')
+              : typeof error?.field === 'string'
+                ? error.field
+                : null,
+            message: typeof error?.message === 'string' ? error.message : '',
+            code: typeof error?.code === 'string' ? error.code : '',
+          })),
+        });
+      } catch {}
       return res.status(400).json({
         ok: false,
         reason: 'product_create_user_errors',
-        message: 'Shopify rechazó la creación del producto.',
+        message: friendlyUserError,
         detail: userErrors,
         requestId: productRequestId || null,
+        ...(userErrorMessages.length ? { messages: userErrorMessages } : {}),
       });
     }
     const product = productPayload.product || {};


### PR DESCRIPTION
## Summary
- validate Shopify environment variables and run a shop sanity query before creating products, failing fast with actionable errors
- harden staged image uploads with retry/backoff and continue product creation with warnings when media fails
- send a minimal, filtered productCreate payload and surface precise GraphQL/user error messages for easier troubleshooting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5a5c8f7e4832794c00f633fde2c2a