### PR TITLE
Adjust Shopify user error handling for Admin API changes

### DIFF
--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -194,7 +194,6 @@ const CART_CREATE_MUTATION = `
         checkoutUrl
       }
       userErrors {
-        code
         field
         message
       }

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -166,6 +166,53 @@ function collectGraphQLErrorMessages(errors) {
     .filter((msg) => Boolean(msg));
 }
 
+function formatGraphQLErrors(errors) {
+  if (!Array.isArray(errors)) return [];
+  return errors
+    .map((err) => {
+      if (!err || typeof err !== 'object') return null;
+      const message = typeof err.message === 'string' ? err.message.trim() : '';
+      const extensionsCode = typeof err?.extensions?.code === 'string'
+        ? err.extensions.code.trim()
+        : '';
+      if (!message && !extensionsCode) return null;
+      return {
+        ...(message ? { message } : {}),
+        ...(extensionsCode ? { extensionsCode } : {}),
+      };
+    })
+    .filter(Boolean);
+}
+
+function sanitizeUserErrorField(field) {
+  if (Array.isArray(field)) {
+    const segments = field
+      .map((segment) => (typeof segment === 'string' ? segment.trim() : ''))
+      .filter(Boolean);
+    return segments.length ? segments : undefined;
+  }
+  if (typeof field === 'string' && field.trim()) {
+    return [field.trim()];
+  }
+  return undefined;
+}
+
+function sanitizeUserErrors(errors) {
+  if (!Array.isArray(errors)) return [];
+  return errors
+    .map((err) => {
+      if (!err || typeof err !== 'object') return null;
+      const message = typeof err.message === 'string' ? err.message.trim() : '';
+      const field = sanitizeUserErrorField(err.field);
+      if (!message && !field) return null;
+      return {
+        ...(field ? { field } : {}),
+        ...(message ? { message } : {}),
+      };
+    })
+    .filter(Boolean);
+}
+
 async function ensureShopifyEnvironmentReady() {
   const domain = pickEnvValue(['SHOPIFY_STORE_DOMAIN', 'SHOPIFY_SHOP']);
   const token = pickEnvValue(['SHOPIFY_ADMIN_TOKEN']);
@@ -343,7 +390,6 @@ const STAGED_UPLOADS_CREATE_MUTATION = `mutation StagedUploads($input: [StagedUp
     userErrors {
       field
       message
-      code
     }
   }
 }`;
@@ -366,7 +412,6 @@ const PRODUCT_CREATE_MUTATION = `mutation ProductCreate($input: ProductInput!) {
     userErrors {
       field
       message
-      code
     }
   }
 }`;
@@ -394,16 +439,27 @@ async function stagedUploadImage({ filename, buffer, mimeType, maxUploadAttempts
   }
   const errors = Array.isArray(json?.errors) ? json.errors : [];
   if (errors.length) {
+    const formattedErrors = formatGraphQLErrors(errors);
+    try {
+      console.error('staged_upload_graphql_errors', {
+        requestId: requestId || null,
+        errors: formattedErrors,
+      });
+    } catch {}
     const err = new Error('staged_upload_graphql_errors');
-    err.errors = errors;
+    err.errors = formattedErrors;
     err.requestId = requestId;
     throw err;
   }
   const payload = json?.data?.stagedUploadsCreate;
-  const userErrors = Array.isArray(payload?.userErrors)
-    ? payload.userErrors.filter((error) => error && (error.code || error.message))
-    : [];
+  const userErrors = sanitizeUserErrors(payload?.userErrors);
   if (userErrors.length) {
+    try {
+      console.error('staged_upload_user_errors', {
+        requestId: requestId || null,
+        userErrors,
+      });
+    } catch {}
     const err = new Error('staged_upload_user_errors');
     err.userErrors = userErrors;
     err.requestId = requestId;
@@ -599,7 +655,8 @@ function detectMissingScope(errorDetail) {
   return list.some((err) => {
     const code = typeof err?.code === 'string' ? err.code.toUpperCase()
       : typeof err?.extensions?.code === 'string' ? err.extensions.code.toUpperCase()
-        : '';
+        : typeof err?.extensionsCode === 'string' ? err.extensionsCode.toUpperCase()
+          : '';
     if (code.includes('ACCESS') || code.includes('PERMISSION')) return true;
     const message = typeof err?.message === 'string' ? err.message.toLowerCase() : '';
     if (!message) return false;
@@ -623,6 +680,7 @@ function collectMissingScopes(detail) {
       typeof entry.message === 'string' ? entry.message : '',
       typeof entry.code === 'string' ? entry.code : '',
       typeof entry?.extensions?.code === 'string' ? entry.extensions.code : '',
+      typeof entry?.extensionsCode === 'string' ? entry.extensionsCode : '',
     ];
     if (Array.isArray(entry?.extensions?.requiredAccess)) {
       for (const access of entry.extensions.requiredAccess) {
@@ -660,6 +718,7 @@ function detectMissingFilesScope(detail) {
     if (isMissingFilesScopeMessage(entry?.message)) return true;
     if (isMissingFilesScopeMessage(entry?.code)) return true;
     if (isMissingFilesScopeMessage(entry?.extensions?.code)) return true;
+    if (isMissingFilesScopeMessage(entry?.extensionsCode)) return true;
   }
   return false;
 }
@@ -769,12 +828,16 @@ export async function publishProduct(req, res) {
       stagedImage = await stagedUploadImage({ filename, buffer: imageBuffer, mimeType });
     } catch (err) {
       const status = typeof err?.status === 'number' ? err.status : 502;
-      const errorArrays = [
-        Array.isArray(err?.errors) ? err.errors : [],
-        Array.isArray(err?.userErrors) ? err.userErrors : [],
-        Array.isArray(err?.body?.errors) ? err.body.errors : [],
+      const formattedErrors = Array.isArray(err?.errors) && err.errors.length
+        ? err.errors
+        : formatGraphQLErrors(err?.body?.errors);
+      const stagedUserErrors = Array.isArray(err?.userErrors) && err.userErrors.length
+        ? err.userErrors
+        : sanitizeUserErrors(err?.body?.userErrors);
+      const combined = [
+        ...(Array.isArray(formattedErrors) ? formattedErrors : []),
+        ...(Array.isArray(stagedUserErrors) ? stagedUserErrors : []),
       ];
-      const combined = errorArrays.flat();
       const extraMessages = [
         typeof err?.message === 'string' ? err.message : '',
         typeof err?.body === 'string' ? err.body : '',
@@ -791,7 +854,12 @@ export async function publishProduct(req, res) {
         status,
         requestId: stageRequestId,
         uploadRequestId,
-        detail: err?.body || err?.errors || err?.userErrors || null,
+        detail: formattedErrors?.length || stagedUserErrors?.length
+          ? {
+            ...(formattedErrors?.length ? { errors: formattedErrors } : {}),
+            ...(stagedUserErrors?.length ? { userErrors: stagedUserErrors } : {}),
+          }
+          : err?.body || null,
       };
 
       const message = missingFilesScope
@@ -814,8 +882,8 @@ export async function publishProduct(req, res) {
           uploadRequestId,
           missingFilesScope,
           attempt: typeof err?.attempt === 'number' ? err.attempt : null,
-          errors: Array.isArray(err?.errors) ? err.errors : undefined,
-          userErrors: Array.isArray(err?.userErrors) ? err.userErrors : undefined,
+          errors: Array.isArray(formattedErrors) && formattedErrors.length ? formattedErrors : undefined,
+          userErrors: Array.isArray(stagedUserErrors) && stagedUserErrors.length ? stagedUserErrors : undefined,
         });
       } catch {}
 
@@ -940,6 +1008,7 @@ export async function publishProduct(req, res) {
       });
     }
     const productErrors = Array.isArray(productJson?.errors) ? productJson.errors : [];
+    const formattedProductErrors = formatGraphQLErrors(productErrors);
     const hasProductPayload = productPayload && typeof productPayload === 'object' && productPayload.product;
     if (productErrors.length) {
       if (!hasProductPayload) {
@@ -952,7 +1021,7 @@ export async function publishProduct(req, res) {
           return res.status(400).json({
             ok: false,
             reason: 'shopify_scope_missing',
-            errors: productErrors,
+            errors: formattedProductErrors,
             requestId: productRequestId || null,
             missing,
             message: friendlyMessage,
@@ -966,12 +1035,13 @@ export async function publishProduct(req, res) {
           console.error('product_create_graphql_errors', {
             requestId: productRequestId || null,
             messages: graphQLErrorMessages,
+            errors: formattedProductErrors,
           });
         } catch {}
         return res.status(502).json({
           ok: false,
           reason: 'shopify_graphql_errors',
-          errors: productErrors,
+          errors: formattedProductErrors,
           requestId: productRequestId || null,
           message: graphQLErrorMessage,
           ...(graphQLErrorMessages.length ? { messages: graphQLErrorMessages } : {}),
@@ -985,7 +1055,7 @@ export async function publishProduct(req, res) {
       const warningPayload = {
         code: 'shopify_graphql_warning',
         message: warningMessage,
-        detail: productErrors,
+        detail: formattedProductErrors,
         requestId: productRequestId || null,
         ...(errorMessages.length ? { messages: errorMessages } : {}),
       };
@@ -994,6 +1064,7 @@ export async function publishProduct(req, res) {
         console.warn('product_create_graphql_warning', {
           requestId: productRequestId || null,
           messages: errorMessages,
+          errors: formattedProductErrors,
         });
       } catch {}
     }
@@ -1006,9 +1077,7 @@ export async function publishProduct(req, res) {
         message: 'Shopify devolvió un error al crear el producto.',
       });
     }
-    const userErrors = Array.isArray(productPayload.userErrors)
-      ? productPayload.userErrors.filter((error) => error && (error.message || error.code))
-      : [];
+    const userErrors = sanitizeUserErrors(productPayload.userErrors);
     if (userErrors.length) {
       const userErrorMessages = userErrors
         .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
@@ -1019,14 +1088,9 @@ export async function publishProduct(req, res) {
       try {
         console.error('product_create_user_errors', {
           requestId: productRequestId || null,
-          errors: userErrors.map((error) => ({
-            field: Array.isArray(error?.field)
-              ? error.field.filter((segment) => typeof segment === 'string' && segment.trim()).join('.')
-              : typeof error?.field === 'string'
-                ? error.field
-                : null,
+          userErrors: userErrors.map((error) => ({
+            field: Array.isArray(error?.field) ? error.field.join('.') : undefined,
             message: typeof error?.message === 'string' ? error.message : '',
-            code: typeof error?.code === 'string' ? error.code : '',
           })),
         });
       } catch {}

--- a/lib/shopify/publication.js
+++ b/lib/shopify/publication.js
@@ -236,6 +236,82 @@ function isTransientUserErrorCode(code) {
     .includes(normalized);
 }
 
+function isTransientUserErrorMessage(message) {
+  if (!message || typeof message !== 'string') return false;
+  const normalized = message.toLowerCase();
+  return normalized.includes('throttle')
+    || normalized.includes('rate limit')
+    || normalized.includes('temporarily unavailable')
+    || normalized.includes('try again later');
+}
+
+function sanitizeUserErrorField(field) {
+  if (Array.isArray(field)) {
+    const segments = field
+      .map((segment) => (typeof segment === 'string' ? segment.trim() : ''))
+      .filter(Boolean);
+    return segments.length ? segments : undefined;
+  }
+  if (typeof field === 'string' && field.trim()) {
+    return [field.trim()];
+  }
+  return undefined;
+}
+
+function sanitizeUserErrors(errors) {
+  if (!Array.isArray(errors)) return [];
+  return errors
+    .map((err) => {
+      if (!err || typeof err !== 'object') return null;
+      const message = typeof err.message === 'string' ? err.message.trim() : '';
+      const field = sanitizeUserErrorField(err.field);
+      if (!message && !field) return null;
+      return {
+        ...(field ? { field } : {}),
+        ...(message ? { message } : {}),
+      };
+    })
+    .filter(Boolean);
+}
+
+function formatGraphQLErrors(errors) {
+  if (!Array.isArray(errors)) return [];
+  return errors
+    .map((err) => {
+      if (!err || typeof err !== 'object') return null;
+      const message = typeof err.message === 'string' ? err.message.trim() : '';
+      const extensionsCode = typeof err?.extensions?.code === 'string'
+        ? err.extensions.code.trim()
+        : '';
+      if (!message && !extensionsCode) return null;
+      return {
+        ...(message ? { message } : {}),
+        ...(extensionsCode ? { extensionsCode } : {}),
+      };
+    })
+    .filter(Boolean);
+}
+
+function isPublicationMissingUserError(err) {
+  if (!err || typeof err !== 'object') return false;
+  if (isPublicationMissingMessage(err.message)) return true;
+  const fields = Array.isArray(err.field) ? err.field : [];
+  return fields.some((segment) => typeof segment === 'string' && segment.toLowerCase().includes('publication'));
+}
+
+function isTransientUserError(err) {
+  if (!err || typeof err !== 'object') return false;
+  if (isTransientUserErrorMessage(err.message)) return true;
+  const fields = Array.isArray(err.field) ? err.field : [];
+  return fields.some((segment) => typeof segment === 'string' && segment.toLowerCase().includes('throttle'));
+}
+
+function isTransientGraphQLError(err) {
+  if (!err || typeof err !== 'object') return false;
+  if (isTransientUserErrorCode(err?.extensions?.code)) return true;
+  return isTransientUserErrorMessage(err?.message);
+}
+
 function isTransientStatus(status) {
   return status === 429 || status >= 500;
 }
@@ -258,7 +334,7 @@ export async function publishToOnlineStore(productGid, publicationIdOverride, op
 
   const mutation = `mutation PublishProduct($publishableId: ID!, $publicationId: ID!) {
     publishablePublish(publishableId: $publishableId, input: [{ publicationId: $publicationId }]) {
-      userErrors { code message field }
+      userErrors { field message }
     }
   }`;
 
@@ -313,6 +389,7 @@ export async function publishToOnlineStore(productGid, publicationIdOverride, op
       } else {
         const graphQLErrors = Array.isArray(json?.errors) ? json.errors : [];
         if (graphQLErrors.length) {
+          const formattedGraphQLErrors = formatGraphQLErrors(graphQLErrors);
           if (graphQLErrors.some((err) => isPublicationMissingMessage(err?.message)
             || isPublicationMissingCode(err?.extensions?.code))) {
             try {
@@ -321,19 +398,20 @@ export async function publishToOnlineStore(productGid, publicationIdOverride, op
                 publicationId,
                 requestId: requestId || null,
                 reason: 'publication_missing',
+                errors: formattedGraphQLErrors,
               });
             } catch {}
             return {
               ok: false,
               reason: 'publication_missing',
-              errors: graphQLErrors,
+              errors: formattedGraphQLErrors,
               attempt,
               requestId: requestId || null,
               requestIds,
             };
           }
-          lastError = { reason: 'graphql_errors', errors: graphQLErrors };
-          if (graphQLErrors.some((err) => isTransientUserErrorCode(err?.extensions?.code)) && attempt < maxAttempts) {
+          lastError = { reason: 'graphql_errors', errors: formattedGraphQLErrors };
+          if (graphQLErrors.some((err) => isTransientGraphQLError(err)) && attempt < maxAttempts) {
             retry = true;
           } else {
             try {
@@ -342,30 +420,32 @@ export async function publishToOnlineStore(productGid, publicationIdOverride, op
                 publicationId,
                 requestId: requestId || null,
                 reason: 'graphql_errors',
+                errors: formattedGraphQLErrors,
               });
             } catch {}
             return {
               ok: false,
               reason: 'graphql_errors',
-              errors: graphQLErrors,
+              errors: formattedGraphQLErrors,
               attempt,
               requestId: requestId || null,
               requestIds,
             };
           }
         } else {
-          const userErrors = Array.isArray(json?.data?.publishablePublish?.userErrors)
-            ? json.data.publishablePublish.userErrors.filter((err) => err && (err.message || err.code))
-            : [];
+          const userErrors = sanitizeUserErrors(json?.data?.publishablePublish?.userErrors);
           if (userErrors.length) {
-            if (userErrors.some((err) => isPublicationMissingMessage(err?.message)
-              || isPublicationMissingCode(err?.code))) {
+            if (userErrors.some((err) => isPublicationMissingUserError(err))) {
               try {
                 console.error('publish_to_online_store_error', {
                   attempt,
                   publicationId,
                   requestId: requestId || null,
                   reason: 'publication_missing',
+                  userErrors: userErrors.map((err) => ({
+                    field: Array.isArray(err.field) ? err.field.join('.') : undefined,
+                    message: err.message || '',
+                  })),
                 });
               } catch {}
               return {
@@ -377,7 +457,7 @@ export async function publishToOnlineStore(productGid, publicationIdOverride, op
                 requestIds,
               };
             }
-            if (userErrors.some((err) => isTransientUserErrorCode(err?.code)) && attempt < maxAttempts) {
+            if (userErrors.some((err) => isTransientUserError(err)) && attempt < maxAttempts) {
               lastError = { reason: 'user_errors', userErrors };
               retry = true;
             } else {
@@ -387,6 +467,10 @@ export async function publishToOnlineStore(productGid, publicationIdOverride, op
                   publicationId,
                   requestId: requestId || null,
                   reason: 'user_errors',
+                  userErrors: userErrors.map((err) => ({
+                    field: Array.isArray(err.field) ? err.field.join('.') : undefined,
+                    message: err.message || '',
+                  })),
                 });
               } catch {}
               return {


### PR DESCRIPTION
## Summary
- stop selecting the deprecated `code` field from Admin and Storefront userErrors selections
- normalize Shopify user error payloads and GraphQL error logging in publish-product so responses only depend on `message`/`field`
- update publish-to-online-store retries and logging to use sanitized errors and message-based throttling detection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d5ab8bc83883279cda9e60d52f5c78