### PR TITLE
Create Shopify variants via bulk mutation and improve staged uploads

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -347,6 +347,68 @@ async function executeProductCreate({ input, filename, maxAttempts = 3 }) {
   return attempts[attempts.length - 1];
 }
 
+async function executeProductVariantsBulkCreate({ productId, variants, strategy, maxAttempts = 3 }) {
+  const attempts = [];
+  let lastError = null;
+  const variables = {
+    productId,
+    variants,
+    strategy: strategy || 'APPEND',
+  };
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      const resp = await shopifyAdminGraphQL(PRODUCT_VARIANTS_BULK_CREATE_MUTATION, variables);
+      const requestId = logRequestId('product_variants_bulk_create_request', resp, {
+        productId,
+        attempt: attempt + 1,
+      });
+      const json = await resp.json().catch(() => null);
+      const attemptInfo = { resp, json, requestId };
+      attempts.push(attemptInfo);
+
+      if (resp.ok) {
+        return { ...attemptInfo, attempts };
+      }
+
+      if (!RETRYABLE_SHOPIFY_STATUS.has(resp.status) || attempt === maxAttempts - 1) {
+        return { ...attemptInfo, attempts };
+      }
+
+      try {
+        console.warn('product_variants_bulk_create_retry', {
+          attempt: attempt + 1,
+          status: resp.status,
+          requestId: requestId || null,
+          productId,
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    } catch (err) {
+      lastError = err;
+      attempts.push({ error: err });
+
+      if (attempt === maxAttempts - 1) {
+        throw err;
+      }
+
+      try {
+        console.warn('product_variants_bulk_create_retry_error', {
+          attempt: attempt + 1,
+          message: err?.message || String(err),
+          productId,
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    }
+  }
+
+  if (lastError) throw lastError;
+  return attempts[attempts.length - 1];
+}
+
 function parseDataUrlMeta(dataUrl) {
   if (typeof dataUrl !== 'string') {
     return { mimeType: 'image/png' };
@@ -416,6 +478,27 @@ const PRODUCT_CREATE_MUTATION = `mutation ProductCreate($input: ProductInput!) {
   }
 }`;
 
+const PRODUCT_VARIANTS_BULK_CREATE_MUTATION = `mutation ProductVariantsBulkCreate($productId: ID!, $variants: [ProductVariantsBulkInput!]!, $strategy: ProductVariantsBulkCreateStrategy!) {
+  productVariantsBulkCreate(productId: $productId, variants: $variants, strategy: $strategy) {
+    product {
+      id
+      legacyResourceId
+      handle
+      status
+    }
+    productVariants {
+      id
+      legacyResourceId
+      title
+      price
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}`;
+
 async function stagedUploadImage({ filename, buffer, mimeType, maxUploadAttempts = 3 }) {
   if (!buffer || !(buffer instanceof Buffer) || buffer.length === 0) {
     throw new Error('staged_upload_empty_buffer');
@@ -424,7 +507,7 @@ async function stagedUploadImage({ filename, buffer, mimeType, maxUploadAttempts
     resource: 'IMAGE',
     filename,
     mimeType: mimeType || 'image/png',
-    fileSize: buffer.length,
+    fileSize: String(buffer.length),
     httpMethod: 'POST',
   }];
   const resp = await shopifyAdminGraphQL(STAGED_UPLOADS_CREATE_MUTATION, { input });
@@ -542,7 +625,7 @@ async function stagedUploadImage({ filename, buffer, mimeType, maxUploadAttempts
     const text = await uploadResp.text().catch(() => '');
     lastBody = text.slice(0, 2000);
 
-    if (uploadResp.status === 502 && attempt < attempts - 1) {
+    if (uploadResp.status >= 500 && uploadResp.status < 600 && attempt < attempts - 1) {
       try {
         console.warn('staged_upload_post_retry', {
           attempt: attempt + 1,
@@ -944,7 +1027,6 @@ export async function publishProduct(req, res) {
     const productInput = {
       title,
       status: 'ACTIVE',
-      variants: [variantInput],
     };
 
     if (typeof description === 'string' && description.trim()) {
@@ -1104,15 +1186,217 @@ export async function publishProduct(req, res) {
       });
     }
     const product = productPayload.product || {};
-    const variantsList = Array.isArray(product?.variants?.nodes)
-      ? product.variants.nodes
-      : Array.isArray(product?.variants)
-        ? product.variants
-        : [];
-    const variantResp = variantsList[0] || {};
-    const meta = buildProductMeta(product, variantResp);
+    let meta = buildProductMeta(product, {});
     try {
       console.info('product_create_success', { requestId: productRequestId || null, productId: meta.productAdminId || null });
+    } catch {}
+
+    const productIdForVariants = typeof product?.id === 'string' && product.id
+      ? product.id
+      : meta.productAdminId;
+    if (!productIdForVariants) {
+      return res.status(502).json({
+        ok: false,
+        reason: 'product_missing_id',
+        message: 'Shopify no devolvió un ID válido para el producto creado.',
+        requestId: productRequestId || null,
+        visibility,
+        ...meta,
+      });
+    }
+
+    try {
+      const variantInputLog = JSON.parse(JSON.stringify(variantInput));
+      console.info('product_variants_bulk_create_input', {
+        productId: productIdForVariants,
+        variants: [variantInputLog],
+      });
+    } catch {}
+
+    const {
+      resp: variantRespRaw,
+      json: variantJson,
+      requestId: variantRequestId,
+      attempts: variantAttempts,
+    } = await executeProductVariantsBulkCreate({
+      productId: productIdForVariants,
+      variants: [variantInput],
+      strategy: 'REMOVE_STANDALONE_VARIANT',
+    });
+
+    if (!variantRespRaw.ok) {
+      return res.status(502).json({
+        ok: false,
+        reason: 'shopify_error',
+        status: variantRespRaw.status,
+        body: variantJson,
+        requestId: variantRequestId || null,
+        ...(Array.isArray(variantAttempts)
+          ? { requestIds: variantAttempts.map((entry) => entry?.requestId).filter(Boolean) }
+          : {}),
+        message: 'Shopify devolvió un error al crear la variante del producto.',
+        visibility,
+        ...meta,
+      });
+    }
+
+    const variantErrors = Array.isArray(variantJson?.errors) ? variantJson.errors : [];
+    const formattedVariantErrors = formatGraphQLErrors(variantErrors);
+    const variantPayload = variantJson?.data?.productVariantsBulkCreate;
+    const hasVariantPayload = variantPayload && typeof variantPayload === 'object';
+
+    if (variantErrors.length) {
+      if (!hasVariantPayload) {
+        if (detectMissingScope(variantErrors)) {
+          const missingScopes = collectMissingScopes(variantErrors);
+          const missing = missingScopes.length ? missingScopes : ['write_products'];
+          const friendlyMessage = missing.length
+            ? `La app de Shopify no tiene permisos suficientes. Faltan los scopes: ${missing.join(', ')}.`
+            : 'La app de Shopify no tiene permisos suficientes para crear variantes.';
+          return res.status(400).json({
+            ok: false,
+            reason: 'shopify_scope_missing',
+            errors: formattedVariantErrors,
+            requestId: variantRequestId || null,
+            missing,
+            message: friendlyMessage,
+            visibility,
+            ...meta,
+          });
+        }
+        const variantErrorMessages = collectGraphQLErrorMessages(variantErrors);
+        const variantGraphQLErrorMessage = variantErrorMessages.length
+          ? `Shopify devolvió errores al crear la variante: ${variantErrorMessages.join(' | ')}`
+          : 'Shopify devolvió un error al crear la variante del producto.';
+        try {
+          console.error('product_variants_bulk_create_graphql_errors', {
+            requestId: variantRequestId || null,
+            messages: variantErrorMessages,
+            errors: formattedVariantErrors,
+          });
+        } catch {}
+        return res.status(502).json({
+          ok: false,
+          reason: 'shopify_variant_graphql_errors',
+          errors: formattedVariantErrors,
+          requestId: variantRequestId || null,
+          message: variantGraphQLErrorMessage,
+          ...(variantErrorMessages.length ? { messages: variantErrorMessages } : {}),
+          visibility,
+          ...meta,
+        });
+      }
+
+      const variantWarningMessages = collectGraphQLErrorMessages(variantErrors);
+      const variantWarningMessage = variantWarningMessages.length
+        ? `Shopify devolvió advertencias al crear la variante: ${variantWarningMessages.join(' | ')}`
+        : 'Shopify devolvió advertencias durante la creación de la variante del producto.';
+      const variantWarningPayload = {
+        code: 'shopify_variant_graphql_warning',
+        message: variantWarningMessage,
+        detail: formattedVariantErrors,
+        requestId: variantRequestId || null,
+        ...(variantWarningMessages.length ? { messages: variantWarningMessages } : {}),
+      };
+      warnings.push(variantWarningPayload);
+      try {
+        console.warn('product_variants_bulk_create_graphql_warning', {
+          requestId: variantRequestId || null,
+          messages: variantWarningMessages,
+          errors: formattedVariantErrors,
+        });
+      } catch {}
+    }
+
+    if (!variantPayload) {
+      return res.status(502).json({
+        ok: false,
+        reason: 'product_variants_bulk_create_failed',
+        detail: variantJson,
+        requestId: variantRequestId || null,
+        message: 'Shopify devolvió un error al crear la variante del producto.',
+        visibility,
+        ...meta,
+      });
+    }
+
+    const rawVariantUserErrors = Array.isArray(variantPayload?.userErrors) ? variantPayload.userErrors : [];
+    const variantUserErrors = sanitizeUserErrors(rawVariantUserErrors);
+    if (variantUserErrors.length) {
+      const variantUserErrorMessages = variantUserErrors
+        .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
+        .filter((msg) => Boolean(msg));
+      const friendlyVariantUserError = variantUserErrorMessages.length
+        ? variantUserErrorMessages[0]
+        : 'Shopify rechazó la creación de la variante del producto.';
+
+      if (detectMissingScope(rawVariantUserErrors)) {
+        const missingScopes = collectMissingScopes(rawVariantUserErrors);
+        const missing = missingScopes.length ? missingScopes : ['write_products'];
+        return res.status(400).json({
+          ok: false,
+          reason: 'shopify_scope_missing',
+          detail: variantUserErrors,
+          requestId: variantRequestId || null,
+          missing,
+          message: friendlyVariantUserError,
+          visibility,
+          ...meta,
+          ...(variantUserErrorMessages.length ? { messages: variantUserErrorMessages } : {}),
+        });
+      }
+
+      try {
+        console.error('product_variants_bulk_create_user_errors', {
+          requestId: variantRequestId || null,
+          userErrors: variantUserErrors.map((error) => ({
+            field: Array.isArray(error?.field) ? error.field.join('.') : undefined,
+            message: typeof error?.message === 'string' ? error.message : '',
+          })),
+        });
+      } catch {}
+
+      return res.status(400).json({
+        ok: false,
+        reason: 'product_variant_user_errors',
+        message: friendlyVariantUserError,
+        detail: variantUserErrors,
+        requestId: variantRequestId || null,
+        visibility,
+        ...meta,
+        ...(variantUserErrorMessages.length ? { messages: variantUserErrorMessages } : {}),
+      });
+    }
+
+    const createdVariants = Array.isArray(variantPayload?.productVariants?.nodes)
+      ? variantPayload.productVariants.nodes
+      : Array.isArray(variantPayload?.productVariants?.edges)
+        ? variantPayload.productVariants.edges.map((edge) => edge?.node).filter((node) => node && typeof node === 'object')
+        : Array.isArray(variantPayload?.productVariants)
+          ? variantPayload.productVariants
+          : [];
+
+    if (!createdVariants.length) {
+      return res.status(502).json({
+        ok: false,
+        reason: 'product_variant_missing',
+        message: 'Shopify no devolvió la variante creada del producto.',
+        requestId: variantRequestId || null,
+        visibility,
+        ...meta,
+      });
+    }
+
+    const variantResp = createdVariants[0] || {};
+    product.variants = { nodes: createdVariants };
+    meta = buildProductMeta(product, variantResp);
+
+    try {
+      console.info('product_variants_bulk_create_success', {
+        requestId: variantRequestId || null,
+        productId: meta.productAdminId || null,
+        variantId: meta.variantAdminId || null,
+      });
     } catch {}
 
     if (!isActiveStatus(product)) {


### PR DESCRIPTION
## Summary
- add a helper and mutation for productVariantsBulkCreate and invoke it after productCreate
- stop sending variants in productCreate, replace the standalone variant, and surface detailed errors and warnings
- send staged upload fileSize as a string and retry 5xx multipart responses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5aeda57888327891c2e8b72194334