### PR TITLE
Reset mockup page state when mockup data changes

### DIFF
--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -51,6 +51,15 @@ export default function Mockup() {
   const buyPromptDescriptionId = 'buy-choice-description';
 
   useEffect(() => {
+    setToast(null);
+    setPendingCart(null);
+    setCartStatus('idle');
+    setBusy(false);
+    setBuyPromptOpen(false);
+    wasModalOpenedRef.current = false;
+  }, [flow.mockupUrl]);
+
+  useEffect(() => {
     if (!isBuyPromptOpen) return;
     wasModalOpenedRef.current = true;
     const timer = setTimeout(() => {


### PR DESCRIPTION
## Summary
- clear transient mockup state (toast, pending cart, modal) whenever a new mockup image is loaded so stale errors disappear on load

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5aed2c2648327a9a20cc24e9c30aa