### PR TITLE
Associate product media after product creation

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -409,6 +409,61 @@ async function executeProductVariantsBulkCreate({ productId, variants, strategy,
   return attempts[attempts.length - 1];
 }
 
+async function executeProductCreateMedia({ productId, media, maxAttempts = 3 }) {
+  const attempts = [];
+  let lastError = null;
+  const variables = { productId, media };
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      const resp = await shopifyAdminGraphQL(PRODUCT_CREATE_MEDIA_MUTATION, variables);
+      const requestId = logRequestId('product_create_media_request', resp, { productId, attempt: attempt + 1 });
+      const json = await resp.json().catch(() => null);
+      const attemptInfo = { resp, json, requestId };
+      attempts.push(attemptInfo);
+
+      if (resp.ok) {
+        return { ...attemptInfo, attempts };
+      }
+
+      if (!RETRYABLE_SHOPIFY_STATUS.has(resp.status) || attempt === maxAttempts - 1) {
+        return { ...attemptInfo, attempts };
+      }
+
+      try {
+        console.warn('product_create_media_retry', {
+          attempt: attempt + 1,
+          status: resp.status,
+          requestId: requestId || null,
+          productId,
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    } catch (err) {
+      lastError = err;
+      attempts.push({ error: err });
+
+      if (attempt === maxAttempts - 1) {
+        throw err;
+      }
+
+      try {
+        console.warn('product_create_media_retry_error', {
+          attempt: attempt + 1,
+          message: err?.message || String(err),
+          productId,
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    }
+  }
+
+  if (lastError) throw lastError;
+  return attempts[attempts.length - 1];
+}
+
 function parseDataUrlMeta(dataUrl) {
   if (typeof dataUrl !== 'string') {
     return { mimeType: 'image/png' };
@@ -495,6 +550,26 @@ const PRODUCT_VARIANTS_BULK_CREATE_MUTATION = `mutation ProductVariantsBulkCreat
     userErrors {
       field
       message
+    }
+  }
+}`;
+
+const PRODUCT_CREATE_MEDIA_MUTATION = `mutation ProductCreateMedia($productId: ID!, $media: [CreateMediaInput!]!) {
+  productCreateMedia(productId: $productId, media: $media) {
+    media {
+      id
+      status
+      alt
+      mediaErrors {
+        code
+        message
+        details
+      }
+    }
+    mediaUserErrors {
+      field
+      message
+      code
     }
   }
 }`;
@@ -1015,7 +1090,7 @@ export async function publishProduct(req, res) {
       { key: 'is_private', value: isPrivate ? 'true' : 'false', type: 'boolean', namespace: 'mgm' },
     ];
 
-    const mediaEntries = stagedImage?.originalSource
+    const productMediaInput = stagedImage?.originalSource
       ? [{ mediaContentType: 'IMAGE', originalSource: stagedImage.originalSource, alt: imageAlt }]
       : [];
 
@@ -1041,9 +1116,6 @@ export async function publishProduct(req, res) {
     if (templateSuffix) {
       productInput.templateSuffix = templateSuffix;
     }
-    if (mediaEntries.length) {
-      productInput.media = mediaEntries;
-    }
     if (productMetafields.length) {
       productInput.metafields = productMetafields;
     }
@@ -1058,7 +1130,7 @@ export async function publishProduct(req, res) {
       const productInputLog = JSON.parse(JSON.stringify(productInput));
       console.info('product_create_input', {
         input: productInputLog,
-        hasMedia: mediaEntries.length > 0,
+        hasMedia: productMediaInput.length > 0,
         metafields: productMetafields.length,
       });
     } catch (logErr) {
@@ -1398,6 +1470,112 @@ export async function publishProduct(req, res) {
         variantId: meta.variantAdminId || null,
       });
     } catch {}
+
+    if (productMediaInput.length) {
+      const mediaWarningMessage = 'No se pudo asociar la imagen, seguimos sin mockup.';
+      try {
+        const mediaInputLog = JSON.parse(JSON.stringify(productMediaInput));
+        console.info('product_create_media_input', {
+          productId: productIdForVariants,
+          media: mediaInputLog,
+        });
+      } catch {}
+
+      let mediaAssociationOk = false;
+      let mediaWarningPayload = null;
+
+      try {
+        const {
+          resp: mediaResp,
+          json: mediaJson,
+          requestId: mediaRequestId,
+          attempts: mediaAttempts,
+        } = await executeProductCreateMedia({ productId: productIdForVariants, media: productMediaInput });
+
+        const mediaRequestIds = Array.isArray(mediaAttempts)
+          ? mediaAttempts.map((entry) => entry?.requestId).filter(Boolean)
+          : [];
+        const mediaErrors = Array.isArray(mediaJson?.errors) ? mediaJson.errors : [];
+        const formattedMediaErrors = formatGraphQLErrors(mediaErrors);
+        const mediaPayload = mediaJson?.data?.productCreateMedia;
+
+        const buildWarning = (detail = null, extra = {}) => {
+          const payload = {
+            code: 'product_create_media_failed',
+            message: mediaWarningMessage,
+            requestId: mediaRequestId || null,
+            ...(mediaRequestIds.length ? { requestIds: mediaRequestIds } : {}),
+            ...(detail ? { detail } : {}),
+          };
+          if (Array.isArray(extra.missing) && extra.missing.length) {
+            payload.missing = extra.missing;
+          }
+          return payload;
+        };
+
+        if (!mediaResp.ok) {
+          mediaWarningPayload = buildWarning({
+            status: mediaResp.status,
+            body: mediaJson,
+          });
+        } else if (mediaErrors.length && !mediaPayload) {
+          const missing = detectMissingScope(mediaErrors) ? collectMissingScopes(mediaErrors) : [];
+          mediaWarningPayload = buildWarning({ errors: formattedMediaErrors }, { missing });
+        } else if (!mediaPayload) {
+          mediaWarningPayload = buildWarning({ body: mediaJson });
+        } else {
+          const rawMediaUserErrors = Array.isArray(mediaPayload?.mediaUserErrors) ? mediaPayload.mediaUserErrors : [];
+          const mediaUserErrors = sanitizeUserErrors(rawMediaUserErrors);
+          const createdMedia = Array.isArray(mediaPayload?.media) ? mediaPayload.media : [];
+          const mediaWithErrors = createdMedia.filter((entry) => Array.isArray(entry?.mediaErrors) && entry.mediaErrors.length);
+          const firstMedia = createdMedia.length ? createdMedia[0] : null;
+
+          if (mediaErrors.length) {
+            const missing = detectMissingScope(mediaErrors) ? collectMissingScopes(mediaErrors) : [];
+            mediaWarningPayload = buildWarning({ errors: formattedMediaErrors }, { missing });
+          } else if (mediaUserErrors.length) {
+            const missing = detectMissingScope(rawMediaUserErrors) ? collectMissingScopes(rawMediaUserErrors) : [];
+            mediaWarningPayload = buildWarning({ userErrors: mediaUserErrors }, { missing });
+          } else if (mediaWithErrors.length) {
+            mediaWarningPayload = buildWarning({ mediaErrors: mediaWithErrors.map((entry) => entry.mediaErrors) });
+          } else if (!firstMedia) {
+            mediaWarningPayload = buildWarning({ body: mediaJson });
+          } else {
+            mediaAssociationOk = true;
+            try {
+              console.info('product_create_media_success', {
+                requestId: mediaRequestId || null,
+                productId: productIdForVariants,
+                mediaId: firstMedia?.id || null,
+                status: firstMedia?.status || null,
+              });
+            } catch {}
+          }
+        }
+      } catch (err) {
+        try {
+          console.warn('product_create_media_exception', {
+            message: err?.message || String(err),
+            productId: productIdForVariants,
+          });
+        } catch {}
+
+        mediaWarningPayload = {
+          code: 'product_create_media_failed',
+          message: mediaWarningMessage,
+          detail: {
+            message: err?.message || String(err),
+          },
+        };
+      }
+
+      if (!mediaAssociationOk && mediaWarningPayload) {
+        warnings.push(mediaWarningPayload);
+        try {
+          console.warn('product_create_media_warning', mediaWarningPayload);
+        } catch {}
+      }
+    }
 
     if (!isActiveStatus(product)) {
       return res.status(400).json({


### PR DESCRIPTION
## Summary
- add a ProductCreateMedia mutation and helper that retries Shopify media association requests
- omit media from the initial productCreate input and keep optional fields conditional
- call productCreateMedia after variants are created, logging warnings without blocking the flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d5b14b7e7c8327b27486c97e4a054b