### PR TITLE
Require acknowledgement for low-quality images

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -193,7 +193,7 @@ export default function Home() {
       return;
     }
     setDesignNameError('');
-    if (level === 'bad' && !ackLow) {
+    if (ackLowMissing) {
       setErr('Confirmá que aceptás continuar con la calidad baja.');
       return;
     }
@@ -293,6 +293,8 @@ export default function Home() {
   const url = 'https://www.mgmgamers.store/';
   const hasImage = Boolean(uploaded);
   const isCanvasReady = Boolean(hasImage && imageUrl);
+  const requiresLowAck = hasImage && level === 'bad';
+  const ackLowMissing = requiresLowAck && !ackLow;
   const configTriggerClasses = [
     styles.configTrigger,
     configOpen ? styles.configTriggerActive : '',
@@ -813,13 +815,23 @@ export default function Home() {
                   </div>
                 )}
               </div>
-              {hasImage && level === 'bad' && (
-                <label className={`${styles.ackLabel} ${styles.canvasAck}`}>
+              {requiresLowAck && (
+                <label
+                  className={`${styles.ackLabel} ${styles.canvasAck} ${ackLowMissing ? styles.ackLabelInvalid : ''}`.trim()}
+                >
                   <input
                     className={styles.ackCheckbox}
                     type="checkbox"
                     checked={ackLow}
-                    onChange={e => setAckLow(e.target.checked)}
+                    onChange={e => {
+                      setAckLow(e.target.checked);
+                      if (e.target.checked && err === 'Confirmá que aceptás continuar con la calidad baja.') {
+                        setErr('');
+                      }
+                    }}
+                    required={requiresLowAck}
+                    aria-required={requiresLowAck}
+                    aria-invalid={ackLowMissing}
                   />
                   <span className={styles.ackIndicator} aria-hidden="true" />
                   <span className={styles.ackLabelText}>
@@ -830,7 +842,7 @@ export default function Home() {
               {hasImage && (
                 <button
                   className={`${styles.continueButton} ${styles.canvasContinue}`}
-                  disabled={busy}
+                  disabled={busy || ackLowMissing}
                   onClick={handleContinue}
                 >
                   Continuar

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -568,8 +568,9 @@
 
 .ackLabel {
   position: relative;
-  display: inline-flex;
+  display: flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
   min-height: 36px;
   padding: 4px 6px;
@@ -583,8 +584,9 @@
   letter-spacing: 0;
   line-height: 1.4;
   cursor: pointer;
-  text-align: left;
-  transition: color 0.18s ease;
+  text-align: center;
+  width: 100%;
+  transition: color 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
 }
 
 .ackLabel:hover {
@@ -614,6 +616,7 @@
   color: inherit;
   line-height: 1.4;
   white-space: normal;
+  text-align: inherit;
 }
 
 .ackCheckbox {
@@ -671,11 +674,21 @@
 .canvasAck {
   position: absolute;
   right: var(--canvas-floating-right);
-  bottom: calc(
-    var(--canvas-floating-bottom) + var(--canvas-continue-height) + var(--canvas-floating-gap)
-  );
+  bottom: calc(var(--canvas-floating-bottom) + var(--canvas-continue-height) + 6px);
   z-index: 60;
+  width: clamp(220px, 26vw, 320px);
   max-width: min(320px, calc(100% - var(--canvas-floating-right)));
+}
+
+.ackLabelInvalid {
+  color: rgba(252, 165, 165, 0.92);
+  background: rgba(64, 18, 24, 0.35);
+  box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.45);
+}
+
+.ackLabelInvalid .ackIndicator {
+  border-color: rgba(239, 68, 68, 0.65);
+  color: rgba(239, 68, 68, 0.85);
 }
 
 .canvasContinue {


### PR DESCRIPTION
## Summary
- require checking the low-quality acknowledgement before continuing and reset the message when it is accepted
- visually align the acknowledgement checkbox with the Continue button and highlight it in red while unchecked

## Testing
- npm run lint *(fails: pre-existing react-hooks/rules-of-hooks violations in src/pages/Mockup.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b200eef88327ae3d44ad1b401f99