### PR TITLE
Update Shopify variant creation flow for 2024-07

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -3,6 +3,8 @@ import { buildProductUrl } from '../publicStorefront.js';
 import { publishToOnlineStore, resolveOnlineStorePublicationId } from '../shopify/publication.js';
 
 const DEFAULT_VENDOR = 'MgMGamers';
+const INVENTORY_TARGET_QUANTITY = 9999;
+const DEFAULT_VARIANT_TITLE = 'Default';
 const ONLINE_STORE_MISSING_MESSAGE = [
   'No pudimos encontrar el canal Online Store para publicar este producto.',
   'Revisá: 1) que el canal esté instalado, 2) que la app tenga el scope write_publications.',
@@ -77,6 +79,51 @@ function buildMeasurement(widthCm, heightCm) {
   const h = formatDimension(heightCm);
   if (!w || !h) return null;
   return `${w}x${h}`;
+}
+
+function normalizeSkuSegment(raw, { allowX = false } = {}) {
+  if (typeof raw !== 'string') return '';
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  const normalized = trimmed
+    .normalize('NFD')
+    .replace(/[^\p{ASCII}]/gu, '')
+    .toUpperCase();
+  if (!normalized) return '';
+  const pattern = allowX ? /[^A-Z0-9X]+/g : /[^A-Z0-9]+/g;
+  return normalized.replace(pattern, allowX ? 'X' : '-').replace(/^-+|-+$/g, '');
+}
+
+function buildMeasurementSku(measurement) {
+  if (typeof measurement !== 'string') return '';
+  const trimmed = measurement.trim();
+  if (!trimmed) return '';
+  const sanitized = trimmed.toLowerCase().replace(/[^0-9x]+/g, 'x').replace(/x+/g, 'x').replace(/^x+|x+$/g, '');
+  if (!sanitized) return '';
+  return sanitized;
+}
+
+function buildGeneratedSku({ productTypeKey, measurement, materialLabel }) {
+  const segments = ['MGM'];
+  if (productTypeKey === 'glasspad') {
+    segments.push('GLS');
+  }
+  const measurementSegment = buildMeasurementSku(measurement);
+  if (measurementSegment) {
+    segments.push(measurementSegment.toUpperCase());
+  }
+  const materialSegment = normalizeSkuSegment(materialLabel || '');
+  if (materialSegment) {
+    segments.push(materialSegment);
+  }
+  if (segments.length === 1) {
+    segments.push('CUSTOM');
+  }
+  const sku = segments
+    .filter((segment) => Boolean(segment))
+    .join('-')
+    .replace(/-+/g, '-');
+  return sku.slice(0, 64);
 }
 
 function buildGlasspadTitle({ designName, measurement }) {
@@ -464,6 +511,114 @@ async function executeProductCreateMedia({ productId, media, maxAttempts = 3 }) 
   return attempts[attempts.length - 1];
 }
 
+async function executeLocationsQuery({ first = 5, maxAttempts = 3 } = {}) {
+  const attempts = [];
+  let lastError = null;
+  const variables = { first: Math.max(1, Number.isFinite(first) ? Number(first) : 5) };
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      const resp = await shopifyAdminGraphQL(LOCATIONS_QUERY, variables);
+      const requestId = logRequestId('locations_query_request', resp, { attempt: attempt + 1 });
+      const json = await resp.json().catch(() => null);
+      const attemptInfo = { resp, json, requestId };
+      attempts.push(attemptInfo);
+
+      if (resp.ok) {
+        return { ...attemptInfo, attempts };
+      }
+
+      if (!RETRYABLE_SHOPIFY_STATUS.has(resp.status) || attempt === maxAttempts - 1) {
+        return { ...attemptInfo, attempts };
+      }
+
+      try {
+        console.warn('locations_query_retry', {
+          attempt: attempt + 1,
+          status: resp.status,
+          requestId: requestId || null,
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    } catch (err) {
+      lastError = err;
+      attempts.push({ error: err });
+
+      if (attempt === maxAttempts - 1) {
+        throw err;
+      }
+
+      try {
+        console.warn('locations_query_retry_error', {
+          attempt: attempt + 1,
+          message: err?.message || String(err),
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    }
+  }
+
+  if (lastError) throw lastError;
+  return attempts[attempts.length - 1];
+}
+
+async function executeInventoryAdjustQuantities({ input, maxAttempts = 3 }) {
+  const attempts = [];
+  let lastError = null;
+  const variables = { input };
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      const resp = await shopifyAdminGraphQL(INVENTORY_ADJUST_QUANTITIES_MUTATION, variables);
+      const requestId = logRequestId('inventory_adjust_quantities_request', resp, {
+        attempt: attempt + 1,
+      });
+      const json = await resp.json().catch(() => null);
+      const attemptInfo = { resp, json, requestId };
+      attempts.push(attemptInfo);
+
+      if (resp.ok) {
+        return { ...attemptInfo, attempts };
+      }
+
+      if (!RETRYABLE_SHOPIFY_STATUS.has(resp.status) || attempt === maxAttempts - 1) {
+        return { ...attemptInfo, attempts };
+      }
+
+      try {
+        console.warn('inventory_adjust_quantities_retry', {
+          attempt: attempt + 1,
+          status: resp.status,
+          requestId: requestId || null,
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    } catch (err) {
+      lastError = err;
+      attempts.push({ error: err });
+
+      if (attempt === maxAttempts - 1) {
+        throw err;
+      }
+
+      try {
+        console.warn('inventory_adjust_quantities_retry_error', {
+          attempt: attempt + 1,
+          message: err?.message || String(err),
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    }
+  }
+
+  if (lastError) throw lastError;
+  return attempts[attempts.length - 1];
+}
+
 function parseDataUrlMeta(dataUrl) {
   if (typeof dataUrl !== 'string') {
     return { mimeType: 'image/png' };
@@ -546,6 +701,9 @@ const PRODUCT_VARIANTS_BULK_CREATE_MUTATION = `mutation ProductVariantsBulkCreat
       legacyResourceId
       title
       price
+      inventoryItem {
+        id
+      }
     }
     userErrors {
       field
@@ -567,6 +725,32 @@ const PRODUCT_CREATE_MEDIA_MUTATION = `mutation ProductCreateMedia($productId: I
       }
     }
     mediaUserErrors {
+      field
+      message
+      code
+    }
+  }
+}`;
+
+const LOCATIONS_QUERY = `query PrimaryLocations($first: Int!) {
+  locations(first: $first) {
+    nodes {
+      id
+      name
+      isActive
+      isPrimary
+    }
+  }
+}`;
+
+const INVENTORY_ADJUST_QUANTITIES_MUTATION = `mutation InventoryAdjustQuantities($input: InventoryAdjustQuantitiesInput!) {
+  inventoryAdjustQuantities(input: $input) {
+    inventoryAdjustmentGroup {
+      id
+      reason
+      createdAt
+    }
+    userErrors {
       field
       message
       code
@@ -756,6 +940,22 @@ function buildProductMeta(product, variant) {
     variantId,
     variantAdminId,
   };
+}
+
+function pickPrimaryLocation(locations) {
+  if (!Array.isArray(locations)) return null;
+  const nodes = locations
+    .map((loc) => (loc && typeof loc === 'object' ? loc : null))
+    .filter(Boolean);
+  if (!nodes.length) return null;
+  const activeNodes = nodes.filter((loc) => loc.isActive !== false);
+  if (activeNodes.length) {
+    const primary = activeNodes.find((loc) => loc.isPrimary === true);
+    if (primary) return primary;
+    return activeNodes[0];
+  }
+  const primaryInactive = nodes.find((loc) => loc.isPrimary === true);
+  return primaryInactive || nodes[0];
 }
 
 function respondWithPublicationIssue(res, meta, reason, message, options = {}) {
@@ -1059,12 +1259,159 @@ export async function publishProduct(req, res) {
     const computedPrice = isPrivate ? basePrice * 1.25 : basePrice;
     const priceValue = formatMoney(computedPrice) || '0.00';
 
+    const providedSkuRaw = typeof body.sku === 'string' ? body.sku.trim() : '';
+    const providedSku = providedSkuRaw ? providedSkuRaw.slice(0, 64) : '';
+    const fallbackSku = buildGeneratedSku({
+      productTypeKey,
+      measurement: measurementLabel,
+      materialLabel,
+    });
+    const finalSku = providedSku || fallbackSku;
+
     const variantInput = {
       price: priceValue,
-      requiresShipping: true,
+      title: DEFAULT_VARIANT_TITLE,
+      taxable: true,
+      weight: 0,
+      weightUnit: 'KILOGRAMS',
     };
-    if (body.sku) {
-      variantInput.sku = String(body.sku).slice(0, 64);
+
+    if (finalSku) {
+      variantInput.sku = finalSku;
+    }
+
+    let primaryLocationId = null;
+    let primaryLocationName = '';
+    let locationRequestIds = [];
+    let lastLocationRequestId = null;
+
+    try {
+      const {
+        resp: locationResp,
+        json: locationJson,
+        requestId: locationRequestId,
+        attempts: locationAttempts,
+      } = await executeLocationsQuery({ first: 5 });
+
+      lastLocationRequestId = locationRequestId || null;
+      locationRequestIds = Array.isArray(locationAttempts)
+        ? locationAttempts.map((entry) => entry?.requestId).filter(Boolean)
+        : [];
+
+      if (!locationResp.ok) {
+        return res.status(502).json({
+          ok: false,
+          reason: 'shopify_error',
+          status: locationResp.status,
+          body: locationJson,
+          requestId: lastLocationRequestId,
+          ...(locationRequestIds.length ? { requestIds: locationRequestIds } : {}),
+          message: 'Shopify devolvió un error al obtener las ubicaciones de la tienda.',
+        });
+      }
+
+      const locationErrors = Array.isArray(locationJson?.errors) ? locationJson.errors : [];
+      const formattedLocationErrors = formatGraphQLErrors(locationErrors);
+      const locationNodes = Array.isArray(locationJson?.data?.locations?.nodes)
+        ? locationJson.data.locations.nodes
+        : [];
+      const primaryLocation = pickPrimaryLocation(locationNodes);
+
+      if (locationErrors.length && !primaryLocation) {
+        if (detectMissingScope(locationErrors)) {
+          const missingScopes = collectMissingScopes(locationErrors);
+          const missing = missingScopes.length ? missingScopes : ['read_locations'];
+          const friendlyMessage = missing.length
+            ? `La app de Shopify no tiene permisos suficientes. Faltan los scopes: ${missing.join(', ')}.`
+            : 'La app de Shopify no tiene permisos suficientes para leer ubicaciones.';
+          return res.status(400).json({
+            ok: false,
+            reason: 'shopify_scope_missing',
+            errors: formattedLocationErrors,
+            requestId: lastLocationRequestId,
+            missing,
+            message: friendlyMessage,
+          });
+        }
+        try {
+          console.error('locations_query_graphql_errors', {
+            requestId: lastLocationRequestId || null,
+            errors: formattedLocationErrors,
+          });
+        } catch {}
+        return res.status(502).json({
+          ok: false,
+          reason: 'shopify_graphql_errors',
+          errors: formattedLocationErrors,
+          requestId: lastLocationRequestId || null,
+          message: 'Shopify devolvió errores al obtener las ubicaciones de la tienda.',
+        });
+      }
+
+      if (!primaryLocation?.id) {
+        return res.status(400).json({
+          ok: false,
+          reason: 'shopify_location_missing',
+          requestId: lastLocationRequestId || null,
+          ...(formattedLocationErrors.length ? { errors: formattedLocationErrors } : {}),
+          message: 'No se encontró una ubicación activa en Shopify para asignar stock.',
+        });
+      }
+
+      if (primaryLocation.isActive === false) {
+        return res.status(400).json({
+          ok: false,
+          reason: 'shopify_location_inactive',
+          requestId: lastLocationRequestId || null,
+          message: 'La ubicación primaria encontrada no está activa en Shopify.',
+        });
+      }
+
+      if (locationErrors.length) {
+        const warningPayload = {
+          code: 'shopify_locations_warning',
+          message: 'Shopify devolvió advertencias al obtener las ubicaciones de la tienda.',
+          requestId: lastLocationRequestId || null,
+          detail: formattedLocationErrors,
+        };
+        warnings.push(warningPayload);
+        try {
+          console.warn('locations_query_warning', warningPayload);
+        } catch {}
+      }
+
+      primaryLocationId = primaryLocation.id;
+      primaryLocationName = typeof primaryLocation.name === 'string' ? primaryLocation.name : '';
+
+      try {
+        console.info('primary_location_resolved', {
+          locationId: primaryLocationId,
+          name: primaryLocationName || null,
+          isPrimary: primaryLocation?.isPrimary === true,
+          requestId: lastLocationRequestId || null,
+        });
+      } catch {}
+    } catch (err) {
+      if (err?.message === 'SHOPIFY_ENV_MISSING') {
+        throw err;
+      }
+      try {
+        console.error('locations_query_exception', {
+          message: err?.message || String(err),
+        });
+      } catch {}
+      return res.status(502).json({
+        ok: false,
+        reason: 'locations_query_failed',
+        message: 'No se pudo obtener la ubicación principal de la tienda en Shopify.',
+      });
+    }
+
+    if (primaryLocationId) {
+      variantInput.inventoryQuantities = [{
+        locationId: primaryLocationId,
+        availableQuantity: INVENTORY_TARGET_QUANTITY,
+      }];
     }
 
     const productMetafields = [
@@ -1277,6 +1624,8 @@ export async function publishProduct(req, res) {
       });
     }
 
+    let inventoryAdjustFallbackRequired = false;
+
     try {
       const variantInputLog = JSON.parse(JSON.stringify(variantInput));
       console.info('product_variants_bulk_create_input', {
@@ -1285,102 +1634,245 @@ export async function publishProduct(req, res) {
       });
     } catch {}
 
-    const {
-      resp: variantRespRaw,
-      json: variantJson,
-      requestId: variantRequestId,
-      attempts: variantAttempts,
-    } = await executeProductVariantsBulkCreate({
-      productId: productIdForVariants,
-      variants: [variantInput],
-      strategy: 'REMOVE_STANDALONE_VARIANT',
-    });
-
-    if (!variantRespRaw.ok) {
-      return res.status(502).json({
-        ok: false,
-        reason: 'shopify_error',
-        status: variantRespRaw.status,
-        body: variantJson,
-        requestId: variantRequestId || null,
-        ...(Array.isArray(variantAttempts)
-          ? { requestIds: variantAttempts.map((entry) => entry?.requestId).filter(Boolean) }
-          : {}),
-        message: 'Shopify devolvió un error al crear la variante del producto.',
-        visibility,
-        ...meta,
-      });
+    let variantInputCurrent;
+    try {
+      variantInputCurrent = JSON.parse(JSON.stringify(variantInput));
+    } catch {
+      variantInputCurrent = { ...variantInput };
     }
 
-    const variantErrors = Array.isArray(variantJson?.errors) ? variantJson.errors : [];
-    const formattedVariantErrors = formatGraphQLErrors(variantErrors);
-    const variantPayload = variantJson?.data?.productVariantsBulkCreate;
-    const hasVariantPayload = variantPayload && typeof variantPayload === 'object';
+    let variantRespRaw;
+    let variantJson;
+    let variantRequestId;
+    let variantAttempts;
+    let variantPayload = null;
+    let variantErrors = [];
+    let formattedVariantErrors = [];
+    let variantCreationSucceeded = false;
 
-    if (variantErrors.length) {
-      if (!hasVariantPayload) {
-        if (detectMissingScope(variantErrors)) {
-          const missingScopes = collectMissingScopes(variantErrors);
-          const missing = missingScopes.length ? missingScopes : ['write_products'];
-          const friendlyMessage = missing.length
-            ? `La app de Shopify no tiene permisos suficientes. Faltan los scopes: ${missing.join(', ')}.`
-            : 'La app de Shopify no tiene permisos suficientes para crear variantes.';
-          return res.status(400).json({
-            ok: false,
-            reason: 'shopify_scope_missing',
-            errors: formattedVariantErrors,
-            requestId: variantRequestId || null,
-            missing,
-            message: friendlyMessage,
-            visibility,
-            ...meta,
-          });
-        }
-        const variantErrorMessages = collectGraphQLErrorMessages(variantErrors);
-        const variantGraphQLErrorMessage = variantErrorMessages.length
-          ? `Shopify devolvió errores al crear la variante: ${variantErrorMessages.join(' | ')}`
-          : 'Shopify devolvió un error al crear la variante del producto.';
-        try {
-          console.error('product_variants_bulk_create_graphql_errors', {
-            requestId: variantRequestId || null,
-            messages: variantErrorMessages,
-            errors: formattedVariantErrors,
-          });
-        } catch {}
+    for (let variantFixAttempt = 0; variantFixAttempt < 2; variantFixAttempt += 1) {
+      ({
+        resp: variantRespRaw,
+        json: variantJson,
+        requestId: variantRequestId,
+        attempts: variantAttempts,
+      } = await executeProductVariantsBulkCreate({
+        productId: productIdForVariants,
+        variants: [variantInputCurrent],
+        strategy: 'REMOVE_STANDALONE_VARIANT',
+      }));
+
+      if (!variantRespRaw.ok) {
         return res.status(502).json({
           ok: false,
-          reason: 'shopify_variant_graphql_errors',
-          errors: formattedVariantErrors,
+          reason: 'shopify_error',
+          status: variantRespRaw.status,
+          body: variantJson,
           requestId: variantRequestId || null,
-          message: variantGraphQLErrorMessage,
-          ...(variantErrorMessages.length ? { messages: variantErrorMessages } : {}),
+          ...(Array.isArray(variantAttempts)
+            ? { requestIds: variantAttempts.map((entry) => entry?.requestId).filter(Boolean) }
+            : {}),
+          message: 'Shopify devolvió un error al crear la variante del producto.',
           visibility,
           ...meta,
         });
       }
 
-      const variantWarningMessages = collectGraphQLErrorMessages(variantErrors);
-      const variantWarningMessage = variantWarningMessages.length
-        ? `Shopify devolvió advertencias al crear la variante: ${variantWarningMessages.join(' | ')}`
-        : 'Shopify devolvió advertencias durante la creación de la variante del producto.';
-      const variantWarningPayload = {
-        code: 'shopify_variant_graphql_warning',
-        message: variantWarningMessage,
-        detail: formattedVariantErrors,
-        requestId: variantRequestId || null,
-        ...(variantWarningMessages.length ? { messages: variantWarningMessages } : {}),
-      };
-      warnings.push(variantWarningPayload);
-      try {
-        console.warn('product_variants_bulk_create_graphql_warning', {
+      variantErrors = Array.isArray(variantJson?.errors) ? variantJson.errors : [];
+      formattedVariantErrors = formatGraphQLErrors(variantErrors);
+      variantPayload = variantJson?.data?.productVariantsBulkCreate;
+      const hasVariantPayload = variantPayload && typeof variantPayload === 'object';
+
+      if (variantErrors.length) {
+        if (!hasVariantPayload) {
+          if (detectMissingScope(variantErrors)) {
+            const missingScopes = collectMissingScopes(variantErrors);
+            const missing = missingScopes.length ? missingScopes : ['write_products'];
+            const friendlyMessage = missing.length
+              ? `La app de Shopify no tiene permisos suficientes. Faltan los scopes: ${missing.join(', ')}.`
+              : 'La app de Shopify no tiene permisos suficientes para crear variantes.';
+            return res.status(400).json({
+              ok: false,
+              reason: 'shopify_scope_missing',
+              errors: formattedVariantErrors,
+              requestId: variantRequestId || null,
+              missing,
+              message: friendlyMessage,
+              visibility,
+              ...meta,
+            });
+          }
+          const variantErrorMessages = collectGraphQLErrorMessages(variantErrors);
+          const variantGraphQLErrorMessage = variantErrorMessages.length
+            ? `Shopify devolvió errores al crear la variante: ${variantErrorMessages.join(' | ')}`
+            : 'Shopify devolvió un error al crear la variante del producto.';
+          try {
+            console.error('product_variants_bulk_create_graphql_errors', {
+              requestId: variantRequestId || null,
+              messages: variantErrorMessages,
+              errors: formattedVariantErrors,
+            });
+          } catch {}
+          return res.status(502).json({
+            ok: false,
+            reason: 'shopify_variant_graphql_errors',
+            errors: formattedVariantErrors,
+            requestId: variantRequestId || null,
+            message: variantGraphQLErrorMessage,
+            ...(variantErrorMessages.length ? { messages: variantErrorMessages } : {}),
+            visibility,
+            ...meta,
+          });
+        }
+
+        const variantWarningMessages = collectGraphQLErrorMessages(variantErrors);
+        const variantWarningMessage = variantWarningMessages.length
+          ? `Shopify devolvió advertencias al crear la variante: ${variantWarningMessages.join(' | ')}`
+          : 'Shopify devolvió advertencias durante la creación de la variante del producto.';
+        const variantWarningPayload = {
+          code: 'shopify_variant_graphql_warning',
+          message: variantWarningMessage,
+          detail: formattedVariantErrors,
           requestId: variantRequestId || null,
-          messages: variantWarningMessages,
-          errors: formattedVariantErrors,
+          ...(variantWarningMessages.length ? { messages: variantWarningMessages } : {}),
+        };
+        warnings.push(variantWarningPayload);
+        try {
+          console.warn('product_variants_bulk_create_graphql_warning', {
+            requestId: variantRequestId || null,
+            messages: variantWarningMessages,
+            errors: formattedVariantErrors,
+          });
+        } catch {}
+      }
+
+      if (!variantPayload) {
+        return res.status(502).json({
+          ok: false,
+          reason: 'product_variants_bulk_create_failed',
+          detail: variantJson,
+          requestId: variantRequestId || null,
+          message: 'Shopify devolvió un error al crear la variante del producto.',
+          visibility,
+          ...meta,
         });
-      } catch {}
+      }
+
+      const rawVariantUserErrors = Array.isArray(variantPayload?.userErrors) ? variantPayload.userErrors : [];
+      const variantUserErrors = sanitizeUserErrors(rawVariantUserErrors);
+
+      if (variantUserErrors.length) {
+        const variantUserErrorMessages = variantUserErrors
+          .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
+          .filter((msg) => Boolean(msg));
+        const friendlyVariantUserError = variantUserErrorMessages.length
+          ? variantUserErrorMessages[0]
+          : 'Shopify rechazó la creación de la variante del producto.';
+
+        if (detectMissingScope(rawVariantUserErrors)) {
+          const missingScopes = collectMissingScopes(rawVariantUserErrors);
+          const missing = missingScopes.length ? missingScopes : ['write_products'];
+          return res.status(400).json({
+            ok: false,
+            reason: 'shopify_scope_missing',
+            detail: variantUserErrors,
+            requestId: variantRequestId || null,
+            missing,
+            message: friendlyVariantUserError,
+            visibility,
+            ...meta,
+            ...(variantUserErrorMessages.length ? { messages: variantUserErrorMessages } : {}),
+          });
+        }
+
+        try {
+          console.error('product_variants_bulk_create_user_errors', {
+            requestId: variantRequestId || null,
+            userErrors: variantUserErrors.map((error) => ({
+              field: Array.isArray(error?.field) ? error.field.join('.') : undefined,
+              message: typeof error?.message === 'string' ? error.message : '',
+            })),
+          });
+        } catch {}
+
+        if (variantFixAttempt === 0) {
+          let nextVariantInput;
+          try {
+            nextVariantInput = JSON.parse(JSON.stringify(variantInputCurrent));
+          } catch {
+            nextVariantInput = { ...variantInputCurrent };
+          }
+          const removedFields = [];
+          let modified = false;
+
+          const hasWeightError = variantUserErrors.some((error) => {
+            const fieldPath = Array.isArray(error?.field) ? error.field.join('.').toLowerCase() : '';
+            const message = typeof error?.message === 'string' ? error.message.toLowerCase() : '';
+            return fieldPath.includes('weight') || message.includes('weight');
+          });
+          if (hasWeightError) {
+            if (Object.prototype.hasOwnProperty.call(nextVariantInput, 'weight')) {
+              delete nextVariantInput.weight;
+              removedFields.push('weight');
+              modified = true;
+            }
+            if (Object.prototype.hasOwnProperty.call(nextVariantInput, 'weightUnit')) {
+              delete nextVariantInput.weightUnit;
+              removedFields.push('weightUnit');
+              modified = true;
+            }
+          }
+
+          const hasInventoryError = variantUserErrors.some((error) => {
+            const fieldPath = Array.isArray(error?.field) ? error.field.join('.').toLowerCase() : '';
+            const message = typeof error?.message === 'string' ? error.message.toLowerCase() : '';
+            return fieldPath.includes('inventoryquantities') || message.includes('inventory');
+          });
+          if (hasInventoryError && Object.prototype.hasOwnProperty.call(nextVariantInput, 'inventoryQuantities')) {
+            delete nextVariantInput.inventoryQuantities;
+            removedFields.push('inventoryQuantities');
+            modified = true;
+            inventoryAdjustFallbackRequired = true;
+          }
+
+          if (modified) {
+            try {
+              console.warn('product_variants_bulk_create_retry_adjustment', {
+                productId: productIdForVariants,
+                requestId: variantRequestId || null,
+                removedFields,
+              });
+            } catch {}
+            try {
+              const retryInputLog = JSON.parse(JSON.stringify(nextVariantInput));
+              console.info('product_variants_bulk_create_retry_input', {
+                productId: productIdForVariants,
+                variants: [retryInputLog],
+                removedFields,
+              });
+            } catch {}
+            variantInputCurrent = nextVariantInput;
+            continue;
+          }
+        }
+
+        return res.status(400).json({
+          ok: false,
+          reason: 'product_variant_user_errors',
+          message: friendlyVariantUserError,
+          detail: variantUserErrors,
+          requestId: variantRequestId || null,
+          visibility,
+          ...meta,
+          ...(variantUserErrorMessages.length ? { messages: variantUserErrorMessages } : {}),
+        });
+      }
+
+      variantCreationSucceeded = true;
+      break;
     }
 
-    if (!variantPayload) {
+    if (!variantCreationSucceeded) {
       return res.status(502).json({
         ok: false,
         reason: 'product_variants_bulk_create_failed',
@@ -1389,54 +1881,6 @@ export async function publishProduct(req, res) {
         message: 'Shopify devolvió un error al crear la variante del producto.',
         visibility,
         ...meta,
-      });
-    }
-
-    const rawVariantUserErrors = Array.isArray(variantPayload?.userErrors) ? variantPayload.userErrors : [];
-    const variantUserErrors = sanitizeUserErrors(rawVariantUserErrors);
-    if (variantUserErrors.length) {
-      const variantUserErrorMessages = variantUserErrors
-        .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
-        .filter((msg) => Boolean(msg));
-      const friendlyVariantUserError = variantUserErrorMessages.length
-        ? variantUserErrorMessages[0]
-        : 'Shopify rechazó la creación de la variante del producto.';
-
-      if (detectMissingScope(rawVariantUserErrors)) {
-        const missingScopes = collectMissingScopes(rawVariantUserErrors);
-        const missing = missingScopes.length ? missingScopes : ['write_products'];
-        return res.status(400).json({
-          ok: false,
-          reason: 'shopify_scope_missing',
-          detail: variantUserErrors,
-          requestId: variantRequestId || null,
-          missing,
-          message: friendlyVariantUserError,
-          visibility,
-          ...meta,
-          ...(variantUserErrorMessages.length ? { messages: variantUserErrorMessages } : {}),
-        });
-      }
-
-      try {
-        console.error('product_variants_bulk_create_user_errors', {
-          requestId: variantRequestId || null,
-          userErrors: variantUserErrors.map((error) => ({
-            field: Array.isArray(error?.field) ? error.field.join('.') : undefined,
-            message: typeof error?.message === 'string' ? error.message : '',
-          })),
-        });
-      } catch {}
-
-      return res.status(400).json({
-        ok: false,
-        reason: 'product_variant_user_errors',
-        message: friendlyVariantUserError,
-        detail: variantUserErrors,
-        requestId: variantRequestId || null,
-        visibility,
-        ...meta,
-        ...(variantUserErrorMessages.length ? { messages: variantUserErrorMessages } : {}),
       });
     }
 
@@ -1462,6 +1906,159 @@ export async function publishProduct(req, res) {
     const variantResp = createdVariants[0] || {};
     product.variants = { nodes: createdVariants };
     meta = buildProductMeta(product, variantResp);
+
+    const variantInventoryItemId = typeof variantResp?.inventoryItem?.id === 'string'
+      ? variantResp.inventoryItem.id
+      : null;
+
+    if (inventoryAdjustFallbackRequired) {
+      if (!primaryLocationId) {
+        return res.status(400).json({
+          ok: false,
+          reason: 'inventory_adjust_location_missing',
+          message: 'No se pudo determinar la ubicación principal para ajustar el inventario en Shopify.',
+          requestId: variantRequestId || null,
+          visibility,
+          ...meta,
+        });
+      }
+
+      if (!variantInventoryItemId) {
+        return res.status(502).json({
+          ok: false,
+          reason: 'inventory_item_missing',
+          message: 'Shopify no devolvió el inventoryItem de la variante para ajustar el stock.',
+          requestId: variantRequestId || null,
+          visibility,
+          ...meta,
+        });
+      }
+
+      const inventoryAdjustInput = {
+        reason: 'CORRECTION',
+        inventoryItemAdjustments: [{
+          inventoryItemId: variantInventoryItemId,
+          locationId: primaryLocationId,
+          availableDelta: INVENTORY_TARGET_QUANTITY,
+        }],
+      };
+
+      const {
+        resp: adjustResp,
+        json: adjustJson,
+        requestId: adjustRequestId,
+        attempts: adjustAttempts,
+      } = await executeInventoryAdjustQuantities({ input: inventoryAdjustInput });
+
+      if (!adjustResp.ok) {
+        return res.status(502).json({
+          ok: false,
+          reason: 'shopify_error',
+          status: adjustResp.status,
+          body: adjustJson,
+          requestId: adjustRequestId || null,
+          ...(Array.isArray(adjustAttempts)
+            ? { requestIds: adjustAttempts.map((entry) => entry?.requestId).filter(Boolean) }
+            : {}),
+          message: 'Shopify devolvió un error al ajustar el inventario de la variante.',
+          visibility,
+          ...meta,
+        });
+      }
+
+      const adjustErrors = Array.isArray(adjustJson?.errors) ? adjustJson.errors : [];
+      const formattedAdjustErrors = formatGraphQLErrors(adjustErrors);
+      const adjustPayload = adjustJson?.data?.inventoryAdjustQuantities;
+
+      if (adjustErrors.length && !adjustPayload) {
+        if (detectMissingScope(adjustErrors)) {
+          const missingScopes = collectMissingScopes(adjustErrors);
+          const missing = missingScopes.length ? missingScopes : ['write_inventory'];
+          const friendlyMessage = missing.length
+            ? `La app de Shopify no tiene permisos suficientes. Faltan los scopes: ${missing.join(', ')}.`
+            : 'La app de Shopify no tiene permisos suficientes para ajustar el inventario.';
+          return res.status(400).json({
+            ok: false,
+            reason: 'shopify_scope_missing',
+            errors: formattedAdjustErrors,
+            requestId: adjustRequestId || null,
+            missing,
+            message: friendlyMessage,
+            visibility,
+            ...meta,
+          });
+        }
+        return res.status(502).json({
+          ok: false,
+          reason: 'inventory_adjust_graphql_errors',
+          errors: formattedAdjustErrors,
+          requestId: adjustRequestId || null,
+          message: 'Shopify devolvió errores al ajustar el inventario de la variante.',
+          visibility,
+          ...meta,
+        });
+      }
+
+      if (!adjustPayload) {
+        return res.status(502).json({
+          ok: false,
+          reason: 'inventory_adjust_failed',
+          detail: adjustJson,
+          requestId: adjustRequestId || null,
+          message: 'Shopify no confirmó el ajuste de inventario de la variante.',
+          visibility,
+          ...meta,
+        });
+      }
+
+      const rawAdjustUserErrors = Array.isArray(adjustPayload?.userErrors) ? adjustPayload.userErrors : [];
+      const adjustUserErrors = sanitizeUserErrors(rawAdjustUserErrors);
+      if (adjustUserErrors.length) {
+        const adjustUserErrorMessages = adjustUserErrors
+          .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
+          .filter((msg) => Boolean(msg));
+        const friendlyAdjustMessage = adjustUserErrorMessages.length
+          ? adjustUserErrorMessages[0]
+          : 'Shopify rechazó el ajuste de inventario de la variante.';
+
+        if (detectMissingScope(rawAdjustUserErrors)) {
+          const missingScopes = collectMissingScopes(rawAdjustUserErrors);
+          const missing = missingScopes.length ? missingScopes : ['write_inventory'];
+          return res.status(400).json({
+            ok: false,
+            reason: 'shopify_scope_missing',
+            detail: adjustUserErrors,
+            requestId: adjustRequestId || null,
+            missing,
+            message: friendlyAdjustMessage,
+            visibility,
+            ...meta,
+            ...(adjustUserErrorMessages.length ? { messages: adjustUserErrorMessages } : {}),
+          });
+        }
+
+        return res.status(400).json({
+          ok: false,
+          reason: 'inventory_adjust_user_errors',
+          detail: adjustUserErrors,
+          requestId: adjustRequestId || null,
+          message: friendlyAdjustMessage,
+          visibility,
+          ...meta,
+          ...(adjustUserErrorMessages.length ? { messages: adjustUserErrorMessages } : {}),
+        });
+      }
+
+      try {
+        console.info('inventory_adjust_quantities_success', {
+          requestId: adjustRequestId || null,
+          productId: meta.productAdminId || null,
+          variantId: meta.variantAdminId || null,
+          locationId: primaryLocationId,
+          inventoryItemId: variantInventoryItemId,
+        });
+      } catch {}
+    }
 
     try {
       console.info('product_variants_bulk_create_success', {


### PR DESCRIPTION
## Summary
- generate variant SKUs, pricing and Shopify-ready variant payloads without `requiresShipping`
- resolve the shop's primary location to set inventory quantities during `productVariantsBulkCreate`
- retry variant creation without optional fields and fall back to `inventoryAdjustQuantities` when needed
- attach staged media after variant creation, publish to Online Store, and log inventory adjustments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5b469c65c832792e83d2e075dbf59