### PR TITLE
Fix Shopify product flow for 2024-07 API

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1270,14 +1270,11 @@ export async function publishProduct(req, res) {
 
     const variantInput = {
       price: priceValue,
-      title: DEFAULT_VARIANT_TITLE,
       taxable: true,
-      weight: 0,
-      weightUnit: 'KILOGRAMS',
     };
 
-    if (finalSku) {
-      variantInput.sku = finalSku;
+    if (DEFAULT_VARIANT_TITLE) {
+      variantInput.selectedOptions = [{ name: 'Title', value: DEFAULT_VARIANT_TITLE }];
     }
 
     let primaryLocationId = null;
@@ -1631,6 +1628,7 @@ export async function publishProduct(req, res) {
       console.info('product_variants_bulk_create_input', {
         productId: productIdForVariants,
         variants: [variantInputLog],
+        ...(finalSku ? { sku: finalSku } : {}),
       });
     } catch {}
 
@@ -1849,6 +1847,7 @@ export async function publishProduct(req, res) {
                 productId: productIdForVariants,
                 variants: [retryInputLog],
                 removedFields,
+                ...(finalSku ? { sku: finalSku } : {}),
               });
             } catch {}
             variantInputCurrent = nextVariantInput;

--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -32,13 +32,17 @@ export async function shopifyAdminGraphQL(query, variables = {}, idemKey) {
     if (!ADMIN_TOKEN) e.missing.push('SHOPIFY_ADMIN_TOKEN');
     throw e;
   }
-  const base = `https://${STORE_DOMAIN}/admin/api/${API_VERSION}/graphql.json`;
+  const url = new URL(`https://${STORE_DOMAIN}/admin/api/graphql.json`);
+  const apiVersion = typeof API_VERSION === 'string' && API_VERSION.trim()
+    ? API_VERSION.trim()
+    : '2024-07';
+  url.searchParams.set('api_version', apiVersion);
   const headers = {
     'Content-Type': 'application/json',
     'X-Shopify-Access-Token': ADMIN_TOKEN,
     'X-Shopify-Idempotency-Key': idemKey || randomUUID(),
   };
-  return fetch(base, { method: 'POST', headers, body: JSON.stringify({ query, variables }) });
+  return fetch(url.toString(), { method: 'POST', headers, body: JSON.stringify({ query, variables }) });
 }
 
 function buildStorefrontEndpoint(domain, apiVersion) {


### PR DESCRIPTION
## Summary
- update the admin GraphQL helper to call `/admin/api/graphql.json` with the explicit `api_version` query parameter
- restrict the variant creation payload to the fields supported by `ProductVariantsBulkInput` while keeping logging of the generated SKU for observability

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5b9edf4148327a45c29317238c491