### PR TITLE
Adjust Shopify publish flow to reuse default variant

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -4,7 +4,6 @@ import { publishToOnlineStore, resolveOnlineStorePublicationId } from '../shopif
 
 const DEFAULT_VENDOR = 'MgMGamers';
 const INVENTORY_TARGET_QUANTITY = 9999;
-const DEFAULT_VARIANT_TITLE = 'Default';
 const ONLINE_STORE_MISSING_MESSAGE = [
   'No pudimos encontrar el canal Online Store para publicar este producto.',
   'Revisá: 1) que el canal esté instalado, 2) que la app tenga el scope write_publications.',
@@ -394,19 +393,76 @@ async function executeProductCreate({ input, filename, maxAttempts = 3 }) {
   return attempts[attempts.length - 1];
 }
 
-async function executeProductVariantsBulkCreate({ productId, variants, strategy, maxAttempts = 3 }) {
+async function executeProductVariantUpdate({ input, maxAttempts = 3 }) {
+  const attempts = [];
+  let lastError = null;
+  const variables = { input };
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      const resp = await shopifyAdminGraphQL(PRODUCT_VARIANT_UPDATE_MUTATION, variables);
+      const requestId = logRequestId('product_variant_update_request', resp, {
+        attempt: attempt + 1,
+        variantId: typeof input?.id === 'string' ? input.id : undefined,
+      });
+      const json = await resp.json().catch(() => null);
+      const attemptInfo = { resp, json, requestId };
+      attempts.push(attemptInfo);
+
+      if (resp.ok) {
+        return { ...attemptInfo, attempts };
+      }
+
+      if (!RETRYABLE_SHOPIFY_STATUS.has(resp.status) || attempt === maxAttempts - 1) {
+        return { ...attemptInfo, attempts };
+      }
+
+      try {
+        console.warn('product_variant_update_retry', {
+          attempt: attempt + 1,
+          status: resp.status,
+          requestId: requestId || null,
+          variantId: typeof input?.id === 'string' ? input.id : undefined,
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    } catch (err) {
+      lastError = err;
+      attempts.push({ error: err });
+
+      if (attempt === maxAttempts - 1) {
+        throw err;
+      }
+
+      try {
+        console.warn('product_variant_update_retry_error', {
+          attempt: attempt + 1,
+          message: err?.message || String(err),
+          variantId: typeof input?.id === 'string' ? input.id : undefined,
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    }
+  }
+
+  if (lastError) throw lastError;
+  return attempts[attempts.length - 1];
+}
+
+async function executeProductVariantQuery({ productId, first = 1, maxAttempts = 3 }) {
   const attempts = [];
   let lastError = null;
   const variables = {
-    productId,
-    variants,
-    strategy: strategy || 'APPEND',
+    id: productId,
+    first: Math.max(1, Number.isFinite(first) ? Number(first) : 1),
   };
 
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     try {
-      const resp = await shopifyAdminGraphQL(PRODUCT_VARIANTS_BULK_CREATE_MUTATION, variables);
-      const requestId = logRequestId('product_variants_bulk_create_request', resp, {
+      const resp = await shopifyAdminGraphQL(PRODUCT_VARIANT_QUERY, variables);
+      const requestId = logRequestId('product_variant_query_request', resp, {
         productId,
         attempt: attempt + 1,
       });
@@ -423,7 +479,7 @@ async function executeProductVariantsBulkCreate({ productId, variants, strategy,
       }
 
       try {
-        console.warn('product_variants_bulk_create_retry', {
+        console.warn('product_variant_query_retry', {
           attempt: attempt + 1,
           status: resp.status,
           requestId: requestId || null,
@@ -441,7 +497,7 @@ async function executeProductVariantsBulkCreate({ productId, variants, strategy,
       }
 
       try {
-        console.warn('product_variants_bulk_create_retry_error', {
+        console.warn('product_variant_query_retry_error', {
           attempt: attempt + 1,
           message: err?.message || String(err),
           productId,
@@ -678,6 +734,9 @@ const PRODUCT_CREATE_MUTATION = `mutation ProductCreate($input: ProductInput!) {
           id
           legacyResourceId
           title
+          inventoryItem {
+            id
+          }
         }
       }
     }
@@ -688,19 +747,14 @@ const PRODUCT_CREATE_MUTATION = `mutation ProductCreate($input: ProductInput!) {
   }
 }`;
 
-const PRODUCT_VARIANTS_BULK_CREATE_MUTATION = `mutation ProductVariantsBulkCreate($productId: ID!, $variants: [ProductVariantsBulkInput!]!, $strategy: ProductVariantsBulkCreateStrategy!) {
-  productVariantsBulkCreate(productId: $productId, variants: $variants, strategy: $strategy) {
-    product {
-      id
-      legacyResourceId
-      handle
-      status
-    }
-    productVariants {
+const PRODUCT_VARIANT_UPDATE_MUTATION = `mutation ProductVariantUpdate($input: ProductVariantInput!) {
+  productVariantUpdate(input: $input) {
+    productVariant {
       id
       legacyResourceId
       title
       price
+      sku
       inventoryItem {
         id
       }
@@ -708,6 +762,23 @@ const PRODUCT_VARIANTS_BULK_CREATE_MUTATION = `mutation ProductVariantsBulkCreat
     userErrors {
       field
       message
+    }
+  }
+}`;
+
+const PRODUCT_VARIANT_QUERY = `query ProductDefaultVariant($id: ID!, $first: Int!) {
+  product(id: $id) {
+    id
+    variants(first: $first) {
+      nodes {
+        id
+        legacyResourceId
+        title
+        sku
+        inventoryItem {
+          id
+        }
+      }
     }
   }
 }`;
@@ -1268,13 +1339,13 @@ export async function publishProduct(req, res) {
     });
     const finalSku = providedSku || fallbackSku;
 
-    const variantInput = {
+    const variantUpdateInputBase = {
       price: priceValue,
       taxable: true,
     };
 
-    if (DEFAULT_VARIANT_TITLE) {
-      variantInput.selectedOptions = [{ name: 'Title', value: DEFAULT_VARIANT_TITLE }];
+    if (finalSku) {
+      variantUpdateInputBase.sku = finalSku;
     }
 
     let primaryLocationId = null;
@@ -1402,13 +1473,6 @@ export async function publishProduct(req, res) {
         reason: 'locations_query_failed',
         message: 'No se pudo obtener la ubicación principal de la tienda en Shopify.',
       });
-    }
-
-    if (primaryLocationId) {
-      variantInput.inventoryQuantities = [{
-        locationId: primaryLocationId,
-        availableQuantity: INVENTORY_TARGET_QUANTITY,
-      }];
     }
 
     const productMetafields = [
@@ -1621,327 +1685,352 @@ export async function publishProduct(req, res) {
       });
     }
 
-    let inventoryAdjustFallbackRequired = false;
 
-    try {
-      const variantInputLog = JSON.parse(JSON.stringify(variantInput));
-      console.info('product_variants_bulk_create_input', {
-        productId: productIdForVariants,
-        variants: [variantInputLog],
-        ...(finalSku ? { sku: finalSku } : {}),
-      });
-    } catch {}
+    const extractVariantNodes = (productData) => {
+      if (!productData || typeof productData !== 'object') return [];
+      const variants = productData.variants;
+      if (Array.isArray(variants?.nodes)) {
+        return variants.nodes.filter((node) => node && typeof node === 'object');
+      }
+      if (Array.isArray(variants?.edges)) {
+        return variants.edges
+          .map((edge) => edge?.node)
+          .filter((node) => node && typeof node === 'object');
+      }
+      if (Array.isArray(variants)) {
+        return variants.filter((node) => node && typeof node === 'object');
+      }
+      return [];
+    };
 
-    let variantInputCurrent;
-    try {
-      variantInputCurrent = JSON.parse(JSON.stringify(variantInput));
-    } catch {
-      variantInputCurrent = { ...variantInput };
-    }
+    const initialVariants = extractVariantNodes(product);
+    let defaultVariant = initialVariants.length ? initialVariants[0] : null;
 
-    let variantRespRaw;
-    let variantJson;
-    let variantRequestId;
-    let variantAttempts;
-    let variantPayload = null;
-    let variantErrors = [];
-    let formattedVariantErrors = [];
-    let variantCreationSucceeded = false;
+    let variantQueryRequestId = null;
+    let variantQueryRequestIds = [];
+    if (!defaultVariant?.id || !defaultVariant?.inventoryItem?.id) {
+      try {
+        console.info('product_variant_default_query', {
+          productId: productIdForVariants,
+          hasVariant: Boolean(defaultVariant?.id),
+        });
+      } catch {}
 
-    for (let variantFixAttempt = 0; variantFixAttempt < 2; variantFixAttempt += 1) {
-      ({
-        resp: variantRespRaw,
-        json: variantJson,
-        requestId: variantRequestId,
-        attempts: variantAttempts,
-      } = await executeProductVariantsBulkCreate({
-        productId: productIdForVariants,
-        variants: [variantInputCurrent],
-        strategy: 'REMOVE_STANDALONE_VARIANT',
-      }));
+      const {
+        resp: variantQueryResp,
+        json: variantQueryJson,
+        requestId: variantQueryId,
+        attempts: variantQueryAttempts,
+      } = await executeProductVariantQuery({ productId: productIdForVariants, first: 1 });
 
-      if (!variantRespRaw.ok) {
+      variantQueryRequestId = variantQueryId || null;
+      variantQueryRequestIds = Array.isArray(variantQueryAttempts)
+        ? variantQueryAttempts.map((entry) => entry?.requestId).filter(Boolean)
+        : [];
+
+      if (!variantQueryResp.ok) {
         return res.status(502).json({
           ok: false,
           reason: 'shopify_error',
-          status: variantRespRaw.status,
-          body: variantJson,
-          requestId: variantRequestId || null,
-          ...(Array.isArray(variantAttempts)
-            ? { requestIds: variantAttempts.map((entry) => entry?.requestId).filter(Boolean) }
-            : {}),
-          message: 'Shopify devolvió un error al crear la variante del producto.',
+          status: variantQueryResp.status,
+          body: variantQueryJson,
+          requestId: variantQueryRequestId,
+          ...(variantQueryRequestIds.length ? { requestIds: variantQueryRequestIds } : {}),
+          message: 'Shopify devolvió un error al obtener la variante por defecto del producto.',
           visibility,
           ...meta,
         });
       }
 
-      variantErrors = Array.isArray(variantJson?.errors) ? variantJson.errors : [];
-      formattedVariantErrors = formatGraphQLErrors(variantErrors);
-      variantPayload = variantJson?.data?.productVariantsBulkCreate;
-      const hasVariantPayload = variantPayload && typeof variantPayload === 'object';
+      const variantQueryErrors = Array.isArray(variantQueryJson?.errors) ? variantQueryJson.errors : [];
+      const formattedVariantQueryErrors = formatGraphQLErrors(variantQueryErrors);
+      const variantQueryProduct = variantQueryJson?.data?.product || null;
 
-      if (variantErrors.length) {
-        if (!hasVariantPayload) {
-          if (detectMissingScope(variantErrors)) {
-            const missingScopes = collectMissingScopes(variantErrors);
-            const missing = missingScopes.length ? missingScopes : ['write_products'];
-            const friendlyMessage = missing.length
-              ? `La app de Shopify no tiene permisos suficientes. Faltan los scopes: ${missing.join(', ')}.`
-              : 'La app de Shopify no tiene permisos suficientes para crear variantes.';
-            return res.status(400).json({
-              ok: false,
-              reason: 'shopify_scope_missing',
-              errors: formattedVariantErrors,
-              requestId: variantRequestId || null,
-              missing,
-              message: friendlyMessage,
-              visibility,
-              ...meta,
-            });
-          }
-          const variantErrorMessages = collectGraphQLErrorMessages(variantErrors);
-          const variantGraphQLErrorMessage = variantErrorMessages.length
-            ? `Shopify devolvió errores al crear la variante: ${variantErrorMessages.join(' | ')}`
-            : 'Shopify devolvió un error al crear la variante del producto.';
-          try {
-            console.error('product_variants_bulk_create_graphql_errors', {
-              requestId: variantRequestId || null,
-              messages: variantErrorMessages,
-              errors: formattedVariantErrors,
-            });
-          } catch {}
-          return res.status(502).json({
-            ok: false,
-            reason: 'shopify_variant_graphql_errors',
-            errors: formattedVariantErrors,
-            requestId: variantRequestId || null,
-            message: variantGraphQLErrorMessage,
-            ...(variantErrorMessages.length ? { messages: variantErrorMessages } : {}),
-            visibility,
-            ...meta,
-          });
-        }
-
-        const variantWarningMessages = collectGraphQLErrorMessages(variantErrors);
-        const variantWarningMessage = variantWarningMessages.length
-          ? `Shopify devolvió advertencias al crear la variante: ${variantWarningMessages.join(' | ')}`
-          : 'Shopify devolvió advertencias durante la creación de la variante del producto.';
-        const variantWarningPayload = {
-          code: 'shopify_variant_graphql_warning',
-          message: variantWarningMessage,
-          detail: formattedVariantErrors,
-          requestId: variantRequestId || null,
-          ...(variantWarningMessages.length ? { messages: variantWarningMessages } : {}),
-        };
-        warnings.push(variantWarningPayload);
-        try {
-          console.warn('product_variants_bulk_create_graphql_warning', {
-            requestId: variantRequestId || null,
-            messages: variantWarningMessages,
-            errors: formattedVariantErrors,
-          });
-        } catch {}
-      }
-
-      if (!variantPayload) {
-        return res.status(502).json({
-          ok: false,
-          reason: 'product_variants_bulk_create_failed',
-          detail: variantJson,
-          requestId: variantRequestId || null,
-          message: 'Shopify devolvió un error al crear la variante del producto.',
-          visibility,
-          ...meta,
-        });
-      }
-
-      const rawVariantUserErrors = Array.isArray(variantPayload?.userErrors) ? variantPayload.userErrors : [];
-      const variantUserErrors = sanitizeUserErrors(rawVariantUserErrors);
-
-      if (variantUserErrors.length) {
-        const variantUserErrorMessages = variantUserErrors
-          .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
-          .filter((msg) => Boolean(msg));
-        const friendlyVariantUserError = variantUserErrorMessages.length
-          ? variantUserErrorMessages[0]
-          : 'Shopify rechazó la creación de la variante del producto.';
-
-        if (detectMissingScope(rawVariantUserErrors)) {
-          const missingScopes = collectMissingScopes(rawVariantUserErrors);
-          const missing = missingScopes.length ? missingScopes : ['write_products'];
+      if (variantQueryErrors.length && !variantQueryProduct) {
+        if (detectMissingScope(variantQueryErrors)) {
+          const missingScopes = collectMissingScopes(variantQueryErrors);
+          const missing = missingScopes.length ? missingScopes : ['read_products'];
+        const friendlyMessage = missing.length
+          ? `La app de Shopify no tiene permisos suficientes. Faltan los scopes: ${missing.join(', ')}.`
+          : 'La app de Shopify no tiene permisos suficientes para leer variantes.';
           return res.status(400).json({
             ok: false,
             reason: 'shopify_scope_missing',
-            detail: variantUserErrors,
-            requestId: variantRequestId || null,
+            errors: formattedVariantQueryErrors,
+            requestId: variantQueryRequestId || null,
             missing,
-            message: friendlyVariantUserError,
+            message: friendlyMessage,
             visibility,
             ...meta,
-            ...(variantUserErrorMessages.length ? { messages: variantUserErrorMessages } : {}),
           });
         }
+        const variantQueryMessages = collectGraphQLErrorMessages(variantQueryErrors);
+        const friendlyVariantQueryMessage = variantQueryMessages.length
+          ? `Shopify devolvió errores: ${variantQueryMessages.join(' | ')}`
+          : 'Shopify devolvió un error al obtener la variante del producto.';
+        return res.status(502).json({
+          ok: false,
+          reason: 'shopify_graphql_errors',
+          errors: formattedVariantQueryErrors,
+          requestId: variantQueryRequestId || null,
+          message: friendlyVariantQueryMessage,
+          ...(variantQueryMessages.length ? { messages: variantQueryMessages } : {}),
+          visibility,
+          ...meta,
+        });
+      }
 
+      const variantNodesFromQuery = extractVariantNodes(variantQueryProduct || {});
+      if (variantNodesFromQuery.length) {
+        defaultVariant = variantNodesFromQuery[0];
+      }
+
+      if (!defaultVariant?.id) {
+        return res.status(502).json({
+          ok: false,
+          reason: 'product_missing_variant',
+          message: 'Shopify no devolvió la variante por defecto del producto.',
+          requestId: variantQueryRequestId || null,
+          visibility,
+          ...meta,
+        });
+      }
+
+      if (variantQueryErrors.length) {
+        const variantQueryMessages = collectGraphQLErrorMessages(variantQueryErrors);
+        const warningMessage = variantQueryMessages.length
+          ? `Shopify devolvió advertencias al leer la variante: ${variantQueryMessages.join(' | ')}`
+          : 'Shopify devolvió advertencias al leer la variante del producto.';
+        const warningPayload = {
+          code: 'shopify_graphql_warning',
+          message: warningMessage,
+          detail: formattedVariantQueryErrors,
+          requestId: variantQueryRequestId || null,
+          ...(variantQueryRequestIds.length ? { requestIds: variantQueryRequestIds } : {}),
+          ...(variantQueryMessages.length ? { messages: variantQueryMessages } : {}),
+        };
+        warnings.push(warningPayload);
         try {
-          console.error('product_variants_bulk_create_user_errors', {
-            requestId: variantRequestId || null,
-            userErrors: variantUserErrors.map((error) => ({
-              field: Array.isArray(error?.field) ? error.field.join('.') : undefined,
-              message: typeof error?.message === 'string' ? error.message : '',
-            })),
-          });
+          console.warn('product_variant_query_warning', warningPayload);
         } catch {}
+      }
+    }
 
-        if (variantFixAttempt === 0) {
-          let nextVariantInput;
-          try {
-            nextVariantInput = JSON.parse(JSON.stringify(variantInputCurrent));
-          } catch {
-            nextVariantInput = { ...variantInputCurrent };
-          }
-          const removedFields = [];
-          let modified = false;
+    if (!defaultVariant?.id) {
+      return res.status(502).json({
+        ok: false,
+        reason: 'product_missing_variant',
+        message: 'Shopify no devolvió variantes para el producto creado.',
+        requestId: productRequestId || null,
+        visibility,
+        ...meta,
+      });
+    }
 
-          const hasWeightError = variantUserErrors.some((error) => {
-            const fieldPath = Array.isArray(error?.field) ? error.field.join('.').toLowerCase() : '';
-            const message = typeof error?.message === 'string' ? error.message.toLowerCase() : '';
-            return fieldPath.includes('weight') || message.includes('weight');
-          });
-          if (hasWeightError) {
-            if (Object.prototype.hasOwnProperty.call(nextVariantInput, 'weight')) {
-              delete nextVariantInput.weight;
-              removedFields.push('weight');
-              modified = true;
-            }
-            if (Object.prototype.hasOwnProperty.call(nextVariantInput, 'weightUnit')) {
-              delete nextVariantInput.weightUnit;
-              removedFields.push('weightUnit');
-              modified = true;
-            }
-          }
+    const variantUpdateInput = { ...variantUpdateInputBase, id: defaultVariant.id };
 
-          const hasInventoryError = variantUserErrors.some((error) => {
-            const fieldPath = Array.isArray(error?.field) ? error.field.join('.').toLowerCase() : '';
-            const message = typeof error?.message === 'string' ? error.message.toLowerCase() : '';
-            return fieldPath.includes('inventoryquantities') || message.includes('inventory');
-          });
-          if (hasInventoryError && Object.prototype.hasOwnProperty.call(nextVariantInput, 'inventoryQuantities')) {
-            delete nextVariantInput.inventoryQuantities;
-            removedFields.push('inventoryQuantities');
-            modified = true;
-            inventoryAdjustFallbackRequired = true;
-          }
+    try {
+      const variantInputLog = JSON.parse(JSON.stringify(variantUpdateInput));
+      console.info('product_variant_update_input', {
+        productId: productIdForVariants,
+        input: variantInputLog,
+      });
+    } catch {}
 
-          if (modified) {
-            try {
-              console.warn('product_variants_bulk_create_retry_adjustment', {
-                productId: productIdForVariants,
-                requestId: variantRequestId || null,
-                removedFields,
-              });
-            } catch {}
-            try {
-              const retryInputLog = JSON.parse(JSON.stringify(nextVariantInput));
-              console.info('product_variants_bulk_create_retry_input', {
-                productId: productIdForVariants,
-                variants: [retryInputLog],
-                removedFields,
-                ...(finalSku ? { sku: finalSku } : {}),
-              });
-            } catch {}
-            variantInputCurrent = nextVariantInput;
-            continue;
-          }
-        }
+    const {
+      resp: variantResp,
+      json: variantJson,
+      requestId: variantRequestId,
+      attempts: variantAttempts,
+    } = await executeProductVariantUpdate({ input: variantUpdateInput });
 
+    const variantRequestIds = Array.isArray(variantAttempts)
+      ? variantAttempts.map((entry) => entry?.requestId).filter(Boolean)
+      : [];
+
+    if (!variantResp.ok) {
+      return res.status(502).json({
+        ok: false,
+        reason: 'shopify_error',
+        status: variantResp.status,
+        body: variantJson,
+        requestId: variantRequestId || null,
+        ...(variantRequestIds.length ? { requestIds: variantRequestIds } : {}),
+        message: 'Shopify devolvió un error al actualizar la variante del producto.',
+        visibility,
+        ...meta,
+      });
+    }
+
+    const variantErrors = Array.isArray(variantJson?.errors) ? variantJson.errors : [];
+    const formattedVariantErrors = formatGraphQLErrors(variantErrors);
+    const variantPayload = variantJson?.data?.productVariantUpdate;
+    const hasVariantPayload = variantPayload && typeof variantPayload === 'object';
+
+    if (variantErrors.length && !hasVariantPayload) {
+      if (detectMissingScope(variantErrors)) {
+        const missingScopes = collectMissingScopes(variantErrors);
+        const missing = missingScopes.length ? missingScopes : ['write_products'];
+        const friendlyMessage = missing.length
+          ? `La app de Shopify no tiene permisos suficientes. Faltan los scopes: ${missing.join(', ')}.`
+          : 'La app de Shopify no tiene permisos suficientes para actualizar la variante.';
         return res.status(400).json({
           ok: false,
-          reason: 'product_variant_user_errors',
-          message: friendlyVariantUserError,
+          reason: 'shopify_scope_missing',
+          errors: formattedVariantErrors,
+          requestId: variantRequestId || null,
+          missing,
+          message: friendlyMessage,
+          visibility,
+          ...meta,
+        });
+      }
+      const variantErrorMessages = collectGraphQLErrorMessages(variantErrors);
+      const friendlyVariantMessage = variantErrorMessages.length
+        ? `Shopify devolvió errores al actualizar la variante: ${variantErrorMessages.join(' | ')}`
+        : 'Shopify devolvió un error al actualizar la variante del producto.';
+      try {
+        console.error('product_variant_update_graphql_errors', {
+          requestId: variantRequestId || null,
+          messages: variantErrorMessages,
+          errors: formattedVariantErrors,
+        });
+      } catch {}
+      return res.status(502).json({
+        ok: false,
+        reason: 'shopify_graphql_errors',
+        errors: formattedVariantErrors,
+        requestId: variantRequestId || null,
+        message: friendlyVariantMessage,
+        ...(variantErrorMessages.length ? { messages: variantErrorMessages } : {}),
+        visibility,
+        ...meta,
+      });
+    }
+
+    if (variantErrors.length) {
+    const variantWarningMessages = collectGraphQLErrorMessages(variantErrors);
+    const variantWarningMessage = variantWarningMessages.length
+      ? `Shopify devolvió advertencias al actualizar la variante: ${variantWarningMessages.join(' | ')}`
+      : 'Shopify devolvió advertencias durante la actualización de la variante del producto.';
+      const variantWarningPayload = {
+        code: 'shopify_graphql_warning',
+        message: variantWarningMessage,
+        detail: formattedVariantErrors,
+        requestId: variantRequestId || null,
+        ...(variantRequestIds.length ? { requestIds: variantRequestIds } : {}),
+        ...(variantWarningMessages.length ? { messages: variantWarningMessages } : {}),
+      };
+      warnings.push(variantWarningPayload);
+      try {
+        console.warn('product_variant_update_graphql_warning', variantWarningPayload);
+      } catch {}
+    }
+
+    if (!variantPayload) {
+      return res.status(502).json({
+        ok: false,
+        reason: 'product_variant_update_failed',
+        detail: variantJson,
+        requestId: variantRequestId || null,
+        message: 'Shopify devolvió un error al actualizar la variante del producto.',
+        visibility,
+        ...meta,
+      });
+    }
+
+    const rawVariantUserErrors = Array.isArray(variantPayload?.userErrors) ? variantPayload.userErrors : [];
+    const variantUserErrors = sanitizeUserErrors(rawVariantUserErrors);
+    if (variantUserErrors.length) {
+      const variantUserErrorMessages = variantUserErrors
+        .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
+        .filter((msg) => Boolean(msg));
+      const friendlyVariantUserError = variantUserErrorMessages.length
+        ? variantUserErrorMessages[0]
+        : 'Shopify rechazó la actualización de la variante.';
+      if (detectMissingScope(rawVariantUserErrors)) {
+        const missingScopes = collectMissingScopes(rawVariantUserErrors);
+        const missing = missingScopes.length ? missingScopes : ['write_products'];
+        return res.status(400).json({
+          ok: false,
+          reason: 'shopify_scope_missing',
           detail: variantUserErrors,
           requestId: variantRequestId || null,
+          missing,
+          message: friendlyVariantUserError,
           visibility,
           ...meta,
           ...(variantUserErrorMessages.length ? { messages: variantUserErrorMessages } : {}),
         });
       }
 
-      variantCreationSucceeded = true;
-      break;
+      return res.status(400).json({
+        ok: false,
+        reason: 'product_variant_user_errors',
+        detail: variantUserErrors,
+        requestId: variantRequestId || null,
+        message: friendlyVariantUserError,
+        visibility,
+        ...meta,
+        ...(variantUserErrorMessages.length ? { messages: variantUserErrorMessages } : {}),
+      });
     }
 
-    if (!variantCreationSucceeded) {
-      return res.status(502).json({
-        ok: false,
-        reason: 'product_variants_bulk_create_failed',
-        detail: variantJson,
+    const updatedVariant = variantPayload?.productVariant && typeof variantPayload.productVariant === 'object'
+      ? variantPayload.productVariant
+      : defaultVariant || {};
+
+    product.variants = { nodes: [updatedVariant] };
+    meta = buildProductMeta(product, updatedVariant);
+
+    try {
+      console.info('product_variant_update_success', {
         requestId: variantRequestId || null,
-        message: 'Shopify devolvió un error al crear la variante del producto.',
+        productId: meta.productAdminId || null,
+        variantId: meta.variantAdminId || null,
+      });
+    } catch {}
+
+    const variantInventoryItemId = typeof updatedVariant?.inventoryItem?.id === 'string'
+      ? updatedVariant.inventoryItem.id
+      : typeof defaultVariant?.inventoryItem?.id === 'string'
+        ? defaultVariant.inventoryItem.id
+        : null;
+
+    if (!primaryLocationId) {
+      return res.status(400).json({
+        ok: false,
+        reason: 'inventory_adjust_location_missing',
+        message: 'No se pudo determinar la ubicación principal para ajustar el inventario en Shopify.',
+        requestId: variantRequestId || null,
         visibility,
         ...meta,
       });
     }
 
-    const createdVariants = Array.isArray(variantPayload?.productVariants?.nodes)
-      ? variantPayload.productVariants.nodes
-      : Array.isArray(variantPayload?.productVariants?.edges)
-        ? variantPayload.productVariants.edges.map((edge) => edge?.node).filter((node) => node && typeof node === 'object')
-        : Array.isArray(variantPayload?.productVariants)
-          ? variantPayload.productVariants
-          : [];
-
-    if (!createdVariants.length) {
+    if (!variantInventoryItemId) {
       return res.status(502).json({
         ok: false,
-        reason: 'product_variant_missing',
-        message: 'Shopify no devolvió la variante creada del producto.',
+        reason: 'inventory_item_missing',
+        message: 'Shopify no devolvió el inventoryItem de la variante para ajustar el stock.',
         requestId: variantRequestId || null,
         visibility,
         ...meta,
       });
     }
 
-    const variantResp = createdVariants[0] || {};
-    product.variants = { nodes: createdVariants };
-    meta = buildProductMeta(product, variantResp);
+    const inventoryAdjustInput = {
+      reason: 'CORRECTION',
+      inventoryItemAdjustments: [{
+        inventoryItemId: variantInventoryItemId,
+        locationId: primaryLocationId,
+        availableDelta: INVENTORY_TARGET_QUANTITY,
+      }],
+    };
 
-    const variantInventoryItemId = typeof variantResp?.inventoryItem?.id === 'string'
-      ? variantResp.inventoryItem.id
-      : null;
+    let inventoryWarningPayload = null;
 
-    if (inventoryAdjustFallbackRequired) {
-      if (!primaryLocationId) {
-        return res.status(400).json({
-          ok: false,
-          reason: 'inventory_adjust_location_missing',
-          message: 'No se pudo determinar la ubicación principal para ajustar el inventario en Shopify.',
-          requestId: variantRequestId || null,
-          visibility,
-          ...meta,
-        });
-      }
-
-      if (!variantInventoryItemId) {
-        return res.status(502).json({
-          ok: false,
-          reason: 'inventory_item_missing',
-          message: 'Shopify no devolvió el inventoryItem de la variante para ajustar el stock.',
-          requestId: variantRequestId || null,
-          visibility,
-          ...meta,
-        });
-      }
-
-      const inventoryAdjustInput = {
-        reason: 'CORRECTION',
-        inventoryItemAdjustments: [{
-          inventoryItemId: variantInventoryItemId,
-          locationId: primaryLocationId,
-          availableDelta: INVENTORY_TARGET_QUANTITY,
-        }],
-      };
-
+    try {
       const {
         resp: adjustResp,
         json: adjustJson,
@@ -1949,108 +2038,125 @@ export async function publishProduct(req, res) {
         attempts: adjustAttempts,
       } = await executeInventoryAdjustQuantities({ input: inventoryAdjustInput });
 
+      const adjustRequestIds = Array.isArray(adjustAttempts)
+        ? adjustAttempts.map((entry) => entry?.requestId).filter(Boolean)
+        : [];
+
+      const buildInventoryWarning = (payload = {}) => ({
+        code: 'inventory_adjust_warning',
+        message: 'No se pudo ajustar el stock en Shopify. Se continúa sin actualizar inventario.',
+        requestId: adjustRequestId || null,
+        ...(adjustRequestIds.length ? { requestIds: adjustRequestIds } : {}),
+        ...payload,
+      });
+
       if (!adjustResp.ok) {
-        return res.status(502).json({
-          ok: false,
-          reason: 'shopify_error',
-          status: adjustResp.status,
-          body: adjustJson,
-          requestId: adjustRequestId || null,
-          ...(Array.isArray(adjustAttempts)
-            ? { requestIds: adjustAttempts.map((entry) => entry?.requestId).filter(Boolean) }
-            : {}),
-          message: 'Shopify devolvió un error al ajustar el inventario de la variante.',
-          visibility,
-          ...meta,
-        });
-      }
-
-      const adjustErrors = Array.isArray(adjustJson?.errors) ? adjustJson.errors : [];
-      const formattedAdjustErrors = formatGraphQLErrors(adjustErrors);
-      const adjustPayload = adjustJson?.data?.inventoryAdjustQuantities;
-
-      if (adjustErrors.length && !adjustPayload) {
-        if (detectMissingScope(adjustErrors)) {
-          const missingScopes = collectMissingScopes(adjustErrors);
-          const missing = missingScopes.length ? missingScopes : ['write_inventory'];
-          const friendlyMessage = missing.length
-            ? `La app de Shopify no tiene permisos suficientes. Faltan los scopes: ${missing.join(', ')}.`
-            : 'La app de Shopify no tiene permisos suficientes para ajustar el inventario.';
-          return res.status(400).json({
+        if (adjustResp.status === 401 || adjustResp.status === 403) {
+          inventoryWarningPayload = buildInventoryWarning({ status: adjustResp.status, body: adjustJson });
+        } else {
+          return res.status(502).json({
             ok: false,
-            reason: 'shopify_scope_missing',
-            errors: formattedAdjustErrors,
+            reason: 'shopify_error',
+            status: adjustResp.status,
+            body: adjustJson,
             requestId: adjustRequestId || null,
-            missing,
-            message: friendlyMessage,
+            ...(adjustRequestIds.length ? { requestIds: adjustRequestIds } : {}),
+            message: 'Shopify devolvió un error al ajustar el inventario de la variante.',
             visibility,
             ...meta,
           });
         }
-        return res.status(502).json({
-          ok: false,
-          reason: 'inventory_adjust_graphql_errors',
-          errors: formattedAdjustErrors,
-          requestId: adjustRequestId || null,
-          message: 'Shopify devolvió errores al ajustar el inventario de la variante.',
-          visibility,
-          ...meta,
-        });
-      }
+      } else {
+        const adjustErrors = Array.isArray(adjustJson?.errors) ? adjustJson.errors : [];
+        const formattedAdjustErrors = formatGraphQLErrors(adjustErrors);
+        const adjustPayload = adjustJson?.data?.inventoryAdjustQuantities;
 
-      if (!adjustPayload) {
-        return res.status(502).json({
-          ok: false,
-          reason: 'inventory_adjust_failed',
-          detail: adjustJson,
-          requestId: adjustRequestId || null,
-          message: 'Shopify no confirmó el ajuste de inventario de la variante.',
-          visibility,
-          ...meta,
-        });
-      }
-
-      const rawAdjustUserErrors = Array.isArray(adjustPayload?.userErrors) ? adjustPayload.userErrors : [];
-      const adjustUserErrors = sanitizeUserErrors(rawAdjustUserErrors);
-      if (adjustUserErrors.length) {
-        const adjustUserErrorMessages = adjustUserErrors
-          .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
-          .filter((msg) => Boolean(msg));
-        const friendlyAdjustMessage = adjustUserErrorMessages.length
-          ? adjustUserErrorMessages[0]
-          : 'Shopify rechazó el ajuste de inventario de la variante.';
-
-        if (detectMissingScope(rawAdjustUserErrors)) {
-          const missingScopes = collectMissingScopes(rawAdjustUserErrors);
-          const missing = missingScopes.length ? missingScopes : ['write_inventory'];
-          return res.status(400).json({
+        if (adjustErrors.length && !adjustPayload) {
+          if (detectMissingScope(adjustErrors)) {
+            const missingScopes = collectMissingScopes(adjustErrors);
+            const missing = missingScopes.length ? missingScopes : ['write_inventory'];
+            inventoryWarningPayload = buildInventoryWarning({ detail: formattedAdjustErrors, missing });
+          } else {
+            return res.status(502).json({
+              ok: false,
+              reason: 'inventory_adjust_graphql_errors',
+              errors: formattedAdjustErrors,
+              requestId: adjustRequestId || null,
+              message: 'Shopify devolvió errores al ajustar el inventario de la variante.',
+              visibility,
+              ...meta,
+            });
+          }
+        } else if (!adjustPayload) {
+          return res.status(502).json({
             ok: false,
-            reason: 'shopify_scope_missing',
-            detail: adjustUserErrors,
+            reason: 'inventory_adjust_failed',
+            detail: adjustJson,
             requestId: adjustRequestId || null,
-            missing,
-            message: friendlyAdjustMessage,
+            message: 'Shopify no confirmó el ajuste de inventario de la variante.',
             visibility,
             ...meta,
-            ...(adjustUserErrorMessages.length ? { messages: adjustUserErrorMessages } : {}),
           });
+        } else {
+          const rawAdjustUserErrors = Array.isArray(adjustPayload?.userErrors) ? adjustPayload.userErrors : [];
+          const adjustUserErrors = sanitizeUserErrors(rawAdjustUserErrors);
+          if (adjustUserErrors.length) {
+            if (detectMissingScope(rawAdjustUserErrors)) {
+              const missingScopes = collectMissingScopes(rawAdjustUserErrors);
+              const missing = missingScopes.length ? missingScopes : ['write_inventory'];
+              inventoryWarningPayload = buildInventoryWarning({ detail: adjustUserErrors, missing });
+            } else {
+              const adjustUserErrorMessages = adjustUserErrors
+                .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
+                .filter((msg) => Boolean(msg));
+              const friendlyAdjustMessage = adjustUserErrorMessages.length
+                ? adjustUserErrorMessages[0]
+                : 'Shopify rechazó el ajuste de inventario de la variante.';
+              return res.status(400).json({
+                ok: false,
+                reason: 'inventory_adjust_user_errors',
+                detail: adjustUserErrors,
+                requestId: adjustRequestId || null,
+                message: friendlyAdjustMessage,
+                visibility,
+                ...meta,
+                ...(adjustUserErrorMessages.length ? { messages: adjustUserErrorMessages } : {}),
+              });
+            }
+          }
         }
 
-        return res.status(400).json({
-          ok: false,
-          reason: 'inventory_adjust_user_errors',
-          detail: adjustUserErrors,
-          requestId: adjustRequestId || null,
-          message: friendlyAdjustMessage,
-          visibility,
-          ...meta,
-          ...(adjustUserErrorMessages.length ? { messages: adjustUserErrorMessages } : {}),
-        });
+        if (!inventoryWarningPayload) {
+          try {
+            console.info('inventory_adjust_quantities_success', {
+              requestId: adjustRequestId || null,
+              productId: meta.productAdminId || null,
+              variantId: meta.variantAdminId || null,
+              locationId: primaryLocationId,
+              inventoryItemId: variantInventoryItemId,
+            });
+          } catch {}
+        }
       }
+    } catch (err) {
+      if (err?.message === 'SHOPIFY_ENV_MISSING') {
+        throw err;
+      }
+      return res.status(502).json({
+        ok: false,
+        reason: 'inventory_adjust_exception',
+        message: 'Ocurrió un error al ajustar el inventario de la variante.',
+        detail: { message: err?.message || String(err) },
+        visibility,
+        ...meta,
+      });
+    }
 
+    if (inventoryWarningPayload) {
+      warnings.push(inventoryWarningPayload);
       try {
-        console.info('inventory_adjust_quantities_success', {
-          requestId: adjustRequestId || null,
+        console.warn('inventory_adjust_quantities_warning', {
+          ...inventoryWarningPayload,
           productId: meta.productAdminId || null,
           variantId: meta.variantAdminId || null,
           locationId: primaryLocationId,
@@ -2058,14 +2164,6 @@ export async function publishProduct(req, res) {
         });
       } catch {}
     }
-
-    try {
-      console.info('product_variants_bulk_create_success', {
-        requestId: variantRequestId || null,
-        productId: meta.productAdminId || null,
-        variantId: meta.variantAdminId || null,
-      });
-    } catch {}
 
     if (productMediaInput.length) {
       const mediaWarningMessage = 'No se pudo asociar la imagen, seguimos sin mockup.';


### PR DESCRIPTION
## Summary
- fetch the default product variant after product creation and update it via `productVariantUpdate` instead of bulk-creating a new variant
- request the inventory item on product creation and adjust stock with warnings when permissions are missing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5bc95cf508327969b167639f8cb5b