### PR TITLE
Fix Shopify admin endpoint and add variant update REST fallback

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1,4 +1,4 @@
-import { shopifyAdminGraphQL } from '../shopify.js';
+import { shopifyAdmin, shopifyAdminGraphQL } from '../shopify.js';
 import { buildProductUrl } from '../publicStorefront.js';
 import { publishToOnlineStore, resolveOnlineStorePublicationId } from '../shopify/publication.js';
 
@@ -123,6 +123,31 @@ function buildGeneratedSku({ productTypeKey, measurement, materialLabel }) {
     .join('-')
     .replace(/-+/g, '-');
   return sku.slice(0, 64);
+}
+
+function extractLegacyId(raw, expectedType = '') {
+  if (raw == null) return '';
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return String(Math.trunc(raw));
+  }
+  if (typeof raw === 'bigint') {
+    return raw >= 0 ? raw.toString() : '';
+  }
+  if (typeof raw !== 'string') return '';
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  const gidMatch = trimmed.match(/^gid:\/\/shopify\/([A-Za-z0-9]+)\/(\d+)$/);
+  if (gidMatch) {
+    if (!expectedType) return gidMatch[2];
+    if (gidMatch[1].toLowerCase() === expectedType.toLowerCase()) return gidMatch[2];
+    return gidMatch[2];
+  }
+  return /^\d+$/.test(trimmed) ? trimmed : '';
+}
+
+function buildInventoryItemGid(raw) {
+  const legacy = extractLegacyId(raw, 'InventoryItem');
+  return legacy ? `gid://shopify/InventoryItem/${legacy}` : '';
 }
 
 function buildGlasspadTitle({ designName, measurement }) {
@@ -440,6 +465,116 @@ async function executeProductVariantUpdate({ input, maxAttempts = 3 }) {
           attempt: attempt + 1,
           message: err?.message || String(err),
           variantId: typeof input?.id === 'string' ? input.id : undefined,
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    }
+  }
+
+  if (lastError) throw lastError;
+  return attempts[attempts.length - 1];
+}
+
+function buildVariantFromRestVariant(defaultVariant, restVariant, updateInput) {
+  const base = defaultVariant && typeof defaultVariant === 'object' ? defaultVariant : {};
+  const rest = restVariant && typeof restVariant === 'object' ? restVariant : {};
+  const adminId = typeof rest.admin_graphql_api_id === 'string'
+    ? rest.admin_graphql_api_id
+    : typeof base.id === 'string'
+      ? base.id
+      : null;
+  const legacyId = extractLegacyId(rest.id ?? rest.legacyResourceId ?? base.legacyResourceId ?? base.id, 'ProductVariant');
+  const price = typeof rest.price === 'string' && rest.price
+    ? rest.price
+    : typeof updateInput?.price === 'string'
+      ? updateInput.price
+      : typeof base.price === 'string'
+        ? base.price
+        : null;
+  const sku = typeof rest.sku === 'string' && rest.sku
+    ? rest.sku
+    : typeof updateInput?.sku === 'string'
+      ? updateInput.sku
+      : typeof base.sku === 'string'
+        ? base.sku
+        : null;
+  const inventoryItemId = typeof base?.inventoryItem?.id === 'string'
+    ? base.inventoryItem.id
+    : buildInventoryItemGid(rest.inventory_item_id);
+
+  const variant = {
+    id: adminId,
+    legacyResourceId: legacyId || undefined,
+    title: typeof base.title === 'string' ? base.title : typeof rest.title === 'string' ? rest.title : null,
+    price: price || null,
+    sku: sku || null,
+  };
+  if (inventoryItemId) {
+    variant.inventoryItem = { id: inventoryItemId };
+  }
+  return variant;
+}
+
+async function executeProductVariantRestUpdate({ variantId, payload, maxAttempts = 3 }) {
+  const attempts = [];
+  let lastError = null;
+  const legacyId = extractLegacyId(variantId, 'ProductVariant');
+  if (!legacyId) {
+    throw new Error('variant_rest_id_invalid');
+  }
+  const variantPayload = {
+    id: Number.isFinite(Number(legacyId)) ? Number(legacyId) : legacyId,
+    price: payload?.price,
+    taxable: payload?.taxable === true,
+  };
+  if (typeof payload?.sku === 'string' && payload.sku) {
+    variantPayload.sku = payload.sku;
+  }
+  const body = JSON.stringify({ variant: variantPayload });
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      const resp = await shopifyAdmin(`variants/${legacyId}.json`, { method: 'PUT', body });
+      const requestId = logRequestId('product_variant_update_rest_request', resp, {
+        attempt: attempt + 1,
+        variantId: legacyId,
+      });
+      const json = await resp.json().catch(() => null);
+      const attemptInfo = { resp, json, requestId };
+      attempts.push(attemptInfo);
+
+      if (resp.ok) {
+        return { ...attemptInfo, attempts };
+      }
+
+      if (!RETRYABLE_SHOPIFY_STATUS.has(resp.status) || attempt === maxAttempts - 1) {
+        return { ...attemptInfo, attempts };
+      }
+
+      try {
+        console.warn('product_variant_update_rest_retry', {
+          attempt: attempt + 1,
+          status: resp.status,
+          requestId: requestId || null,
+          variantId: legacyId,
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    } catch (err) {
+      lastError = err;
+      attempts.push({ error: err });
+
+      if (attempt === maxAttempts - 1) {
+        throw err;
+      }
+
+      try {
+        console.warn('product_variant_update_rest_retry_error', {
+          attempt: attempt + 1,
+          message: err?.message || String(err),
+          variantId: legacyId,
         });
       } catch {}
 
@@ -1840,85 +1975,231 @@ export async function publishProduct(req, res) {
     const {
       resp: variantResp,
       json: variantJson,
-      requestId: variantRequestId,
+      requestId: variantGraphQLRequestIdRaw,
       attempts: variantAttempts,
     } = await executeProductVariantUpdate({ input: variantUpdateInput });
 
-    const variantRequestIds = Array.isArray(variantAttempts)
+    const variantGraphQLRequestId = variantGraphQLRequestIdRaw || null;
+    const variantGraphQLRequestIds = Array.isArray(variantAttempts)
       ? variantAttempts.map((entry) => entry?.requestId).filter(Boolean)
       : [];
 
-    if (!variantResp.ok) {
+    const variantErrors = Array.isArray(variantJson?.errors) ? variantJson.errors : [];
+    const formattedVariantErrors = formatGraphQLErrors(variantErrors);
+    const variantPayload = variantJson?.data?.productVariantUpdate;
+    const hasVariantPayload = variantPayload && typeof variantPayload === 'object';
+    const rawVariantUserErrors = Array.isArray(variantPayload?.userErrors) ? variantPayload.userErrors : [];
+    const variantUserErrors = sanitizeUserErrors(rawVariantUserErrors);
+    const variantGraphQLNode = hasVariantPayload && typeof variantPayload?.productVariant === 'object'
+      ? variantPayload.productVariant
+      : null;
+    const hasGraphQLMissingScope = detectMissingScope(variantErrors);
+    const hasGraphQLUserMissingScope = detectMissingScope(rawVariantUserErrors);
+    const variantRestIdCandidate = extractLegacyId(
+      defaultVariant?.legacyResourceId
+        ?? defaultVariant?.legacy_resource_id
+        ?? meta?.variantId
+        ?? defaultVariant?.id,
+      'ProductVariant',
+    );
+
+    let variantUpdateSource = 'graphql';
+    let variantRequestIdFinal = variantGraphQLRequestId;
+    let variantRequestIdsFinal = variantGraphQLRequestIds;
+    let updatedVariant = null;
+    let restFallbackDetail = null;
+
+    if (variantResp.ok && variantGraphQLNode && !variantUserErrors.length) {
+      updatedVariant = variantGraphQLNode;
+    } else if (!hasGraphQLMissingScope && !hasGraphQLUserMissingScope && variantRestIdCandidate) {
+      try {
+        const {
+          resp: variantRestResp,
+          json: variantRestJson,
+          requestId: variantRestRequestId,
+          attempts: variantRestAttempts,
+        } = await executeProductVariantRestUpdate({
+          variantId: variantRestIdCandidate,
+          payload: variantUpdateInputBase,
+        });
+
+        const variantRestRequestIds = Array.isArray(variantRestAttempts)
+          ? variantRestAttempts.map((entry) => entry?.requestId).filter(Boolean)
+          : [];
+
+        if (variantRestResp.ok && variantRestJson?.variant) {
+          variantUpdateSource = 'rest';
+          variantRequestIdFinal = variantRestRequestId || null;
+          variantRequestIdsFinal = variantRestRequestIds;
+          updatedVariant = buildVariantFromRestVariant(defaultVariant, variantRestJson.variant, variantUpdateInputBase);
+          if (!variantResp.ok || variantErrors.length || variantUserErrors.length) {
+            const fallbackWarning = {
+              code: 'product_variant_update_graphql_fallback',
+              message: 'Shopify GraphQL falló al actualizar la variante. Se utilizó REST como fallback.',
+              requestId: variantGraphQLRequestId,
+              ...(variantGraphQLRequestIds.length ? { requestIds: variantGraphQLRequestIds } : {}),
+              detail: {
+                status: typeof variantResp?.status === 'number' ? variantResp.status : undefined,
+                errors: formattedVariantErrors.length ? formattedVariantErrors : undefined,
+                userErrors: variantUserErrors.length ? variantUserErrors : undefined,
+              },
+            };
+            warnings.push(fallbackWarning);
+            try {
+              console.warn('product_variant_update_fallback', fallbackWarning);
+            } catch {}
+          }
+        } else {
+          restFallbackDetail = {
+            status: typeof variantRestResp?.status === 'number' ? variantRestResp.status : undefined,
+            body: variantRestJson,
+            requestId: variantRestRequestId || null,
+            ...(variantRestRequestIds.length ? { requestIds: variantRestRequestIds } : {}),
+          };
+        }
+      } catch (err) {
+        restFallbackDetail = { error: err?.message || String(err) };
+      }
+    }
+
+    if (!updatedVariant) {
+      if (!variantResp.ok) {
+        return res.status(502).json({
+          ok: false,
+          reason: 'shopify_error',
+          status: variantResp.status,
+          body: variantJson,
+          requestId: variantGraphQLRequestId,
+          ...(variantGraphQLRequestIds.length ? { requestIds: variantGraphQLRequestIds } : {}),
+          ...(restFallbackDetail ? { restFallback: restFallbackDetail } : {}),
+          message: 'Shopify devolvió un error al actualizar la variante del producto.',
+          visibility,
+          ...meta,
+        });
+      }
+
+      if (variantErrors.length && !hasVariantPayload) {
+        if (hasGraphQLMissingScope) {
+          const missingScopes = collectMissingScopes(variantErrors);
+          const missing = missingScopes.length ? missingScopes : ['write_products'];
+          const friendlyMessage = missing.length
+            ? `La app de Shopify no tiene permisos suficientes. Faltan los scopes: ${missing.join(', ')}.`
+            : 'La app de Shopify no tiene permisos suficientes para actualizar la variante.';
+          return res.status(400).json({
+            ok: false,
+            reason: 'shopify_scope_missing',
+            errors: formattedVariantErrors,
+            requestId: variantGraphQLRequestId,
+            ...(variantGraphQLRequestIds.length ? { requestIds: variantGraphQLRequestIds } : {}),
+            ...(restFallbackDetail ? { restFallback: restFallbackDetail } : {}),
+            missing,
+            message: friendlyMessage,
+            visibility,
+            ...meta,
+          });
+        }
+        const variantErrorMessages = collectGraphQLErrorMessages(variantErrors);
+        const friendlyVariantMessage = variantErrorMessages.length
+          ? `Shopify devolvió errores al actualizar la variante: ${variantErrorMessages.join(' | ')}`
+          : 'Shopify devolvió un error al actualizar la variante del producto.';
+        try {
+          console.error('product_variant_update_graphql_errors', {
+            requestId: variantGraphQLRequestId || null,
+            messages: variantErrorMessages,
+            errors: formattedVariantErrors,
+          });
+        } catch {}
+        return res.status(502).json({
+          ok: false,
+          reason: 'shopify_graphql_errors',
+          errors: formattedVariantErrors,
+          requestId: variantGraphQLRequestId,
+          ...(variantGraphQLRequestIds.length ? { requestIds: variantGraphQLRequestIds } : {}),
+          ...(variantErrorMessages.length ? { messages: variantErrorMessages } : {}),
+          ...(restFallbackDetail ? { restFallback: restFallbackDetail } : {}),
+          message: friendlyVariantMessage,
+          visibility,
+          ...meta,
+        });
+      }
+
+      if (!hasVariantPayload) {
+        return res.status(502).json({
+          ok: false,
+          reason: 'product_variant_update_failed',
+          detail: variantJson,
+          requestId: variantGraphQLRequestId,
+          ...(variantGraphQLRequestIds.length ? { requestIds: variantGraphQLRequestIds } : {}),
+          ...(restFallbackDetail ? { restFallback: restFallbackDetail } : {}),
+          message: 'Shopify devolvió un error al actualizar la variante del producto.',
+          visibility,
+          ...meta,
+        });
+      }
+
+      if (variantUserErrors.length) {
+        const variantUserErrorMessages = variantUserErrors
+          .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
+          .filter((msg) => Boolean(msg));
+        const friendlyVariantUserError = variantUserErrorMessages.length
+          ? variantUserErrorMessages[0]
+          : 'Shopify rechazó la actualización de la variante.';
+        if (hasGraphQLUserMissingScope) {
+          const missingScopes = collectMissingScopes(rawVariantUserErrors);
+          const missing = missingScopes.length ? missingScopes : ['write_products'];
+          return res.status(400).json({
+            ok: false,
+            reason: 'shopify_scope_missing',
+            detail: variantUserErrors,
+            requestId: variantGraphQLRequestId,
+            ...(variantGraphQLRequestIds.length ? { requestIds: variantGraphQLRequestIds } : {}),
+            ...(restFallbackDetail ? { restFallback: restFallbackDetail } : {}),
+            missing,
+            message: friendlyVariantUserError,
+            visibility,
+            ...meta,
+            ...(variantUserErrorMessages.length ? { messages: variantUserErrorMessages } : {}),
+          });
+        }
+
+        return res.status(400).json({
+          ok: false,
+          reason: 'product_variant_user_errors',
+          detail: variantUserErrors,
+          requestId: variantGraphQLRequestId,
+          ...(variantGraphQLRequestIds.length ? { requestIds: variantGraphQLRequestIds } : {}),
+          ...(restFallbackDetail ? { restFallback: restFallbackDetail } : {}),
+          message: friendlyVariantUserError,
+          visibility,
+          ...meta,
+          ...(variantUserErrorMessages.length ? { messages: variantUserErrorMessages } : {}),
+        });
+      }
+
       return res.status(502).json({
         ok: false,
-        reason: 'shopify_error',
-        status: variantResp.status,
-        body: variantJson,
-        requestId: variantRequestId || null,
-        ...(variantRequestIds.length ? { requestIds: variantRequestIds } : {}),
+        reason: 'product_variant_update_failed',
+        detail: variantJson,
+        requestId: variantGraphQLRequestId,
+        ...(variantGraphQLRequestIds.length ? { requestIds: variantGraphQLRequestIds } : {}),
+        ...(restFallbackDetail ? { restFallback: restFallbackDetail } : {}),
         message: 'Shopify devolvió un error al actualizar la variante del producto.',
         visibility,
         ...meta,
       });
     }
 
-    const variantErrors = Array.isArray(variantJson?.errors) ? variantJson.errors : [];
-    const formattedVariantErrors = formatGraphQLErrors(variantErrors);
-    const variantPayload = variantJson?.data?.productVariantUpdate;
-    const hasVariantPayload = variantPayload && typeof variantPayload === 'object';
-
-    if (variantErrors.length && !hasVariantPayload) {
-      if (detectMissingScope(variantErrors)) {
-        const missingScopes = collectMissingScopes(variantErrors);
-        const missing = missingScopes.length ? missingScopes : ['write_products'];
-        const friendlyMessage = missing.length
-          ? `La app de Shopify no tiene permisos suficientes. Faltan los scopes: ${missing.join(', ')}.`
-          : 'La app de Shopify no tiene permisos suficientes para actualizar la variante.';
-        return res.status(400).json({
-          ok: false,
-          reason: 'shopify_scope_missing',
-          errors: formattedVariantErrors,
-          requestId: variantRequestId || null,
-          missing,
-          message: friendlyMessage,
-          visibility,
-          ...meta,
-        });
-      }
-      const variantErrorMessages = collectGraphQLErrorMessages(variantErrors);
-      const friendlyVariantMessage = variantErrorMessages.length
-        ? `Shopify devolvió errores al actualizar la variante: ${variantErrorMessages.join(' | ')}`
-        : 'Shopify devolvió un error al actualizar la variante del producto.';
-      try {
-        console.error('product_variant_update_graphql_errors', {
-          requestId: variantRequestId || null,
-          messages: variantErrorMessages,
-          errors: formattedVariantErrors,
-        });
-      } catch {}
-      return res.status(502).json({
-        ok: false,
-        reason: 'shopify_graphql_errors',
-        errors: formattedVariantErrors,
-        requestId: variantRequestId || null,
-        message: friendlyVariantMessage,
-        ...(variantErrorMessages.length ? { messages: variantErrorMessages } : {}),
-        visibility,
-        ...meta,
-      });
-    }
-
-    if (variantErrors.length) {
-    const variantWarningMessages = collectGraphQLErrorMessages(variantErrors);
-    const variantWarningMessage = variantWarningMessages.length
-      ? `Shopify devolvió advertencias al actualizar la variante: ${variantWarningMessages.join(' | ')}`
-      : 'Shopify devolvió advertencias durante la actualización de la variante del producto.';
+    if (variantUpdateSource === 'graphql' && variantErrors.length) {
+      const variantWarningMessages = collectGraphQLErrorMessages(variantErrors);
+      const variantWarningMessage = variantWarningMessages.length
+        ? `Shopify devolvió advertencias al actualizar la variante: ${variantWarningMessages.join(' | ')}`
+        : 'Shopify devolvió advertencias durante la actualización de la variante del producto.';
       const variantWarningPayload = {
         code: 'shopify_graphql_warning',
         message: variantWarningMessage,
         detail: formattedVariantErrors,
-        requestId: variantRequestId || null,
-        ...(variantRequestIds.length ? { requestIds: variantRequestIds } : {}),
+        requestId: variantGraphQLRequestId,
+        ...(variantGraphQLRequestIds.length ? { requestIds: variantGraphQLRequestIds } : {}),
         ...(variantWarningMessages.length ? { messages: variantWarningMessages } : {}),
       };
       warnings.push(variantWarningPayload);
@@ -1927,68 +2208,19 @@ export async function publishProduct(req, res) {
       } catch {}
     }
 
-    if (!variantPayload) {
-      return res.status(502).json({
-        ok: false,
-        reason: 'product_variant_update_failed',
-        detail: variantJson,
-        requestId: variantRequestId || null,
-        message: 'Shopify devolvió un error al actualizar la variante del producto.',
-        visibility,
-        ...meta,
-      });
-    }
-
-    const rawVariantUserErrors = Array.isArray(variantPayload?.userErrors) ? variantPayload.userErrors : [];
-    const variantUserErrors = sanitizeUserErrors(rawVariantUserErrors);
-    if (variantUserErrors.length) {
-      const variantUserErrorMessages = variantUserErrors
-        .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
-        .filter((msg) => Boolean(msg));
-      const friendlyVariantUserError = variantUserErrorMessages.length
-        ? variantUserErrorMessages[0]
-        : 'Shopify rechazó la actualización de la variante.';
-      if (detectMissingScope(rawVariantUserErrors)) {
-        const missingScopes = collectMissingScopes(rawVariantUserErrors);
-        const missing = missingScopes.length ? missingScopes : ['write_products'];
-        return res.status(400).json({
-          ok: false,
-          reason: 'shopify_scope_missing',
-          detail: variantUserErrors,
-          requestId: variantRequestId || null,
-          missing,
-          message: friendlyVariantUserError,
-          visibility,
-          ...meta,
-          ...(variantUserErrorMessages.length ? { messages: variantUserErrorMessages } : {}),
-        });
-      }
-
-      return res.status(400).json({
-        ok: false,
-        reason: 'product_variant_user_errors',
-        detail: variantUserErrors,
-        requestId: variantRequestId || null,
-        message: friendlyVariantUserError,
-        visibility,
-        ...meta,
-        ...(variantUserErrorMessages.length ? { messages: variantUserErrorMessages } : {}),
-      });
-    }
-
-    const updatedVariant = variantPayload?.productVariant && typeof variantPayload.productVariant === 'object'
-      ? variantPayload.productVariant
-      : defaultVariant || {};
-
     product.variants = { nodes: [updatedVariant] };
     meta = buildProductMeta(product, updatedVariant);
 
     try {
-      console.info('product_variant_update_success', {
-        requestId: variantRequestId || null,
+      const variantSuccessLog = {
+        requestId: variantRequestIdFinal || null,
         productId: meta.productAdminId || null,
         variantId: meta.variantAdminId || null,
-      });
+      };
+      if (Array.isArray(variantRequestIdsFinal) && variantRequestIdsFinal.length) {
+        variantSuccessLog.requestIds = variantRequestIdsFinal;
+      }
+      console.info('product_variant_update_success', variantSuccessLog);
     } catch {}
 
     const variantInventoryItemId = typeof updatedVariant?.inventoryItem?.id === 'string'
@@ -2002,7 +2234,7 @@ export async function publishProduct(req, res) {
         ok: false,
         reason: 'inventory_adjust_location_missing',
         message: 'No se pudo determinar la ubicación principal para ajustar el inventario en Shopify.',
-        requestId: variantRequestId || null,
+        requestId: variantRequestIdFinal || null,
         visibility,
         ...meta,
       });
@@ -2013,7 +2245,7 @@ export async function publishProduct(req, res) {
         ok: false,
         reason: 'inventory_item_missing',
         message: 'Shopify no devolvió el inventoryItem de la variante para ajustar el stock.',
-        requestId: variantRequestId || null,
+        requestId: variantRequestIdFinal || null,
         visibility,
         ...meta,
       });

--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -32,17 +32,16 @@ export async function shopifyAdminGraphQL(query, variables = {}, idemKey) {
     if (!ADMIN_TOKEN) e.missing.push('SHOPIFY_ADMIN_TOKEN');
     throw e;
   }
-  const url = new URL(`https://${STORE_DOMAIN}/admin/api/graphql.json`);
   const apiVersion = typeof API_VERSION === 'string' && API_VERSION.trim()
     ? API_VERSION.trim()
     : '2024-07';
-  url.searchParams.set('api_version', apiVersion);
+  const url = `https://${STORE_DOMAIN}/admin/api/${apiVersion}/graphql.json`;
   const headers = {
     'Content-Type': 'application/json',
     'X-Shopify-Access-Token': ADMIN_TOKEN,
     'X-Shopify-Idempotency-Key': idemKey || randomUUID(),
   };
-  return fetch(url.toString(), { method: 'POST', headers, body: JSON.stringify({ query, variables }) });
+  return fetch(url, { method: 'POST', headers, body: JSON.stringify({ query, variables }) });
 }
 
 function buildStorefrontEndpoint(domain, apiVersion) {


### PR DESCRIPTION
## Summary
- point all Admin GraphQL calls to the versioned /admin/api/<version>/graphql.json endpoint
- add helpers to extract legacy IDs and reuse the default variant when falling back to REST updates
- fall back to a REST Admin variant update with detailed logging when the GraphQL mutation fails and keep downstream inventory handling working

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5c10c4908832793ec7bf8ccb9cc3f