### PR TITLE
Fix publish mutation arguments for Shopify

### DIFF
--- a/lib/shopify/publication.js
+++ b/lib/shopify/publication.js
@@ -446,8 +446,8 @@ export async function publishToOnlineStore(productGid, publicationIdOverride, op
     return { ok: false, reason: 'publication_missing', attempt: 0 };
   }
 
-  const mutation = `mutation PublishProduct($publishableId: ID!, $publicationId: ID!) {
-    publishablePublish(publishableId: $publishableId, input: [{ publicationId: $publicationId }]) {
+  const mutation = `mutation PublishProduct($id: ID!, $publicationId: ID!) {
+    publishablePublish(id: $id, input: [{ publicationId: $publicationId }]) {
       userErrors { field message }
     }
   }`;
@@ -471,7 +471,7 @@ export async function publishToOnlineStore(productGid, publicationIdOverride, op
 
     try {
       const resp = await shopifyAdminGraphQL(mutation, {
-        publishableId,
+        id: publishableId,
         publicationId,
       });
       const json = await resp.json().catch(() => null);


### PR DESCRIPTION
## Summary
- update the publishablePublish GraphQL mutation to use the correct argument names expected by Shopify
- ensure the mutation variables align with the new signature so publication attempts no longer return GraphQL errors

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d602784280832792d823f538e60e48