### PR TITLE
Auto-open store cart after product creation

### DIFF
--- a/mgm-front/src/lib/cart.ts
+++ b/mgm-front/src/lib/cart.ts
@@ -66,7 +66,7 @@ function submitCartForm(url: URL, target: string, popup?: Window | null, focus =
   return popupRef !== null || targetName === '_self';
 }
 
-export function openCartUrl(rawUrl: string, options?: OpenCartOptions) {
+export function openCartUrl(rawUrl: string, options?: OpenCartOptions): boolean {
   const target = options?.target ?? '_blank';
   const popup = options?.popup && !options.popup.closed ? options.popup : null;
   const focus = options?.focus !== false;
@@ -74,12 +74,12 @@ export function openCartUrl(rawUrl: string, options?: OpenCartOptions) {
     const parsed = new URL(rawUrl);
     if (normalizePathname(parsed.pathname) === CART_ADD_PATH) {
       const submitted = submitCartForm(parsed, target, popup, focus);
-      if (submitted) return;
+      if (submitted) return true;
     } else if (popup) {
       try {
         popup.location.href = rawUrl;
         if (focus && typeof popup.focus === 'function') popup.focus();
-        return;
+        return true;
       } catch (err) {
         // fall through to window.open
       }
@@ -88,5 +88,6 @@ export function openCartUrl(rawUrl: string, options?: OpenCartOptions) {
     console.error('[openCartUrl] invalid url', err);
   }
   const features = target === '_blank' ? 'noopener' : undefined;
-  window.open(rawUrl, target, features);
+  const win = window.open(rawUrl, target, features);
+  return !!win;
 }

--- a/mgm-front/src/pages/Confirm.jsx
+++ b/mgm-front/src/pages/Confirm.jsx
@@ -8,6 +8,7 @@ export default function Confirm() {
   const [sp] = useSearchParams();
   const jobId = sp.get('job_id');
   const [data, setData] = useState(null);
+  const [autoOpened, setAutoOpened] = useState(false);
   const [err, setErr] = useState('');
 
   useEffect(() => {
@@ -28,6 +29,16 @@ export default function Confirm() {
     if (jobId) tick();
     return () => clearTimeout(t);
   }, [jobId]);
+
+  useEffect(() => {
+    if (!autoOpened && data?.cart_url) {
+      try {
+        openCartUrl(data.cart_url);
+      } finally {
+        setAutoOpened(true);
+      }
+    }
+  }, [autoOpened, data?.cart_url]);
 
   if (!jobId) return <p>Falta job_id.</p>;
   if (!data) return <p>Cargando…</p>;

--- a/mgm-front/src/pages/Result.jsx
+++ b/mgm-front/src/pages/Result.jsx
@@ -17,6 +17,7 @@ export default function Result() {
   const [added, setAdded] = useState(
     () => localStorage.getItem(`MGM_jobAdded:${jobId}`) === "true",
   );
+  const [autoOpened, setAutoOpened] = useState(false);
 
   useEffect(() => {
     async function fetchJob() {
@@ -58,6 +59,21 @@ export default function Result() {
       ensureUrls();
     }
   }, [urls, jobId]);
+
+  useEffect(() => {
+    if (!autoOpened && !added && urls.cart_url_follow) {
+      const opened = openCartUrl(urls.cart_url_follow);
+      setAutoOpened(true);
+      if (opened) {
+        try {
+          localStorage.setItem(`MGM_jobAdded:${jobId}`, "true");
+        } catch (err) {
+          console.warn("[result] persist added flag failed", err);
+        }
+        setAdded(true);
+      }
+    }
+  }, [added, autoOpened, jobId, urls.cart_url_follow]);
 
   if (!urls.cart_url_follow || !urls.checkout_url_now) {
     return <p>Preparando tu carrito…</p>;


### PR DESCRIPTION
## Summary
- automatically open the Shopify cart in a new tab once the confirmation and result pages receive the cart link
- return whether opening the cart URL succeeded so the result page only marks the cart as added when the popup is created

## Testing
- npm run lint *(fails: existing unused-variable errors in Mockup.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d60685cc388327870aa541adaa9354