### PR TITLE
style: restyle config panel visuals

### DIFF
--- a/mgm-front/src/components/SizeControls.module.css
+++ b/mgm-front/src/components/SizeControls.module.css
@@ -1,75 +1,116 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 24px;
 }
 
 .containerDisabled {
-  opacity: 0.6;
+  opacity: 0.55;
+  pointer-events: none;
 }
 
 .section {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+}
+
+.section + .section {
+  margin-top: clamp(12px, 1.8vw, 18px);
 }
 
 .groupLabel {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 600;
-  color: #cbd5f5;
+  margin: 14px 0 8px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--muted);
+  letter-spacing: 0.01em;
+}
+
+.section:first-of-type .groupLabel {
+  margin-top: 0;
 }
 
 .dimensionsRow {
-  display: flex;
-  gap: 16px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
 }
 
 .inputLabel {
-  flex: 1;
-  display: block;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .inputControl {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 12px 16px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(18, 18, 22, 0.85);
-  box-shadow: 0 12px 22px rgba(8, 8, 12, 0.25);
+  justify-content: space-between;
+  height: 56px;
+  padding: 0 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--control-stroke);
+  background: var(--control-bg);
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.04);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.inputControl:hover {
+  border-color: #33373c;
+}
+
+.inputControl:focus-within {
+  border-color: #3a3f45;
+  box-shadow: 0 0 0 3px var(--control-focus);
 }
 
 .inputControlDisabled {
-  border-color: rgba(255, 255, 255, 0.08);
-  background: rgba(24, 24, 28, 0.6);
-  box-shadow: none;
+  border-color: var(--control-stroke);
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
-.input {
-  flex: 1;
-  font-size: 1rem;
+.inputControlDisabled:hover {
+  border-color: var(--control-stroke);
+}
+
+.inputAffix {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
   font-weight: 500;
-  border: none;
-  background: transparent;
-  color: #f4f5f7;
-  outline: none;
-  text-align: right;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+  text-transform: none;
 }
 
 .inputIcon {
   width: 24px;
   height: 24px;
   flex-shrink: 0;
+  order: -1;
+  opacity: 0.9;
 }
 
-.inputAffix {
-  font-size: 0.75rem;
+.input {
+  flex: 1;
+  margin-left: 12px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 16px;
   font-weight: 600;
-  color: #9ca3af;
+  letter-spacing: 0.02em;
+  text-align: right;
+  outline: none;
+}
+
+.input::placeholder {
+  color: var(--placeholder);
+}
+
+.input:disabled {
+  cursor: not-allowed;
 }
 
 .visuallyHidden {
@@ -84,67 +125,98 @@
   border: 0;
 }
 
-.input:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
 
 .presets {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  margin-top: 12px;
 }
 
 .presetButton {
   padding: 6px 14px;
   border-radius: 999px;
-  border: 1px solid #2d2d33;
-  background: rgba(20, 20, 24, 0.9);
-  color: #f4f4f5;
-  font-size: 0.75rem;
+  border: 1px solid #33373c;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+  font-size: 12px;
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: border-color 0.2s ease, transform 0.2s ease;
+  transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
 }
 
 .presetButton:hover:not(:disabled) {
-  border-color: #4f46e5;
-  transform: translateY(-1px);
+  border-color: #3a3f45;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.presetButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--control-focus);
 }
 
 .presetButton:disabled {
-  opacity: 0.45;
+  opacity: 0.55;
   cursor: not-allowed;
 }
 
 .helper {
-  margin: 0;
-  font-size: 0.75rem;
-  color: #6b7280;
+  margin: 10px 0 0;
+  font-size: 13px;
+  color: var(--muted);
 }
 
 .seriesSection {
-  gap: 12px;
+  margin-top: clamp(12px, 1.8vw, 18px);
 }
 
 .seriesSelect {
   position: relative;
 }
 
+.seriesSelectTrigger {
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  height: 56px;
+  padding: 0 16px;
+  border: 1px solid var(--control-stroke);
+  border-radius: var(--radius-md);
+  background: var(--control-bg);
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.04);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.seriesSelectTrigger:hover:not(:disabled) {
+  border-color: #33373c;
+}
+
+.seriesSelectTrigger:focus-visible {
+  outline: none;
+  border-color: #3a3f45;
+  box-shadow: 0 0 0 3px var(--control-focus);
+}
+
+.seriesSelectTrigger:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 .seriesSelectText {
   display: flex;
-  flex-direction: row;
-  align-items: baseline;
-  gap: 8px;
-  flex-wrap: nowrap;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
 }
 
 .seriesSelectIcon {
-  width: 20px;
-  height: 20px;
+  width: 22px;
+  height: 22px;
   flex-shrink: 0;
+  pointer-events: none;
+  opacity: 0.9;
   transition: transform 0.2s ease;
 }
 
@@ -159,70 +231,86 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 8px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(18, 18, 22, 0.95);
-  box-shadow: 0 18px 36px rgba(8, 8, 12, 0.45);
-  backdrop-filter: blur(8px);
+  gap: 4px;
+  padding: 8px 6px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--control-stroke);
+  background: var(--control-bg);
+  box-shadow: var(--panel-shadow);
   z-index: 10;
 }
 
 .seriesOptionItem {
   width: 100%;
+  height: 44px;
+  padding: 0 14px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+}
+
+.seriesOptionItem:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.seriesOptionItem:focus-visible {
+  outline: none;
+  border-color: #3a3f45;
+  box-shadow: 0 0 0 3px var(--control-focus);
 }
 
 .materialOption {
   display: flex;
-  align-items: baseline;
-  gap: 8px;
-  width: 100%;
-  padding: 14px 18px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(28, 28, 32, 0.6);
-  color: #f4f5f7;
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
-}
-
-.materialOption:hover:not(:disabled) {
-  border-color: rgba(99, 102, 241, 0.7);
-  background: rgba(40, 40, 46, 0.7);
-  transform: translateY(-1px);
-}
-
-.materialOptionActive {
-  border-color: #5a7bff;
-  background: rgba(60, 68, 112, 0.65);
-  box-shadow: 0 0 0 1px rgba(90, 123, 255, 0.3);
-}
-
-.materialOptionDisabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-.seriesSelectTrigger {
+  flex-direction: row;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  width: 100%;
+  border-radius: var(--radius-md);
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
 }
 
 .materialOptionTitle {
-  font-size: 0.95rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
 .materialOptionSubtitle {
-  text-transform: lowercase;
-  font-size: 0.8rem;
-  letter-spacing: 0.04em;
-  color: rgba(207, 212, 226, 0.85);
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
+.materialOptionActive {
+  border-color: #3a3f45;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.materialOptionDisabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+@media (max-width: 560px) {
+  .dimensionsRow {
+    grid-template-columns: 1fr;
+  }
+
+  .inputControl,
+  .seriesSelectTrigger {
+    height: 54px;
+  }
+
+  .input {
+    font-size: 15px;
+  }
 }

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -323,6 +323,7 @@ export default function Home() {
   ]
     .filter(Boolean)
     .join(' ');
+  const designNameFieldClass = `${styles.field} ${styles.designNameField}`;
 
   const updateConfigPanelPosition = useCallback(() => {
     if (!configOpen) return;
@@ -682,7 +683,7 @@ export default function Home() {
         disabled={!hasImage}
         ref={configTriggerButtonRef}
         aria-expanded={configOpen}
-        aria-controls="configuracion-editor"
+        aria-controls="config-panel"
         aria-haspopup="menu"
         aria-label="Configura tu mousepad"
       >
@@ -700,14 +701,14 @@ export default function Home() {
       </button>
       {configOpen && (
         <div
-          id="configuracion-editor"
+          id="config-panel"
           className={configPanelClasses}
           aria-disabled={!hasImage}
           ref={configPanelRef}
           style={configPanelStyle}
           role="menu"
         >
-          <div className={styles.field}>
+          <div className={designNameFieldClass}>
             <label className={styles.fieldLabel} htmlFor="design-name">
               Nombre de tu diseño
             </label>

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -175,69 +175,75 @@
 }
 
 .configTrigger {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 14px;
-  padding: 16px 20px;
-  border-radius: 16px;
-  background: #282828d0;
-  border: 1px solid #5c5c5ca2;
-  color: #f6f7fb;
-  font-weight: 400;
-  font-size: 1rem;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text, #f1f2f4);
+  font-family: "Poppins", system-ui, sans-serif;
   cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  transition: color 0.15s ease, opacity 0.15s ease;
 }
 
-.configTrigger:hover:not(:disabled) {
-  border: 1px solid #34343b;
- 
-  transform: translateY(-1px);
+.configTrigger:focus-visible {
+  outline: none;
 }
 
 .configTrigger:disabled,
 .configTriggerDisabled {
-  opacity: 0.45;
+  opacity: 0.55;
   cursor: not-allowed;
-  transform: none;
 }
 
-.configHeader {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 20px 24px;
-  border: none;
-  background: #181818;
-  border: 1px solid #34343b;
-  color: inherit;
-  cursor: pointer;
-  font-size: 1rem;
-  font-weight: 600;
-}
-
-.configTrigger:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.35);
-  outline-offset: 4px;
-}
-
-.configTriggerIcon {
-  width: 24px;
-  height: 24px;
+.configTriggerIcon,
+.configTriggerArrow {
+  flex: 0 0 auto;
+  width: 36px;
+  height: 36px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border-radius: 10px;
+  color: var(--text, #f1f2f4);
+  opacity: 0.9;
+  transition: background 0.15s ease, box-shadow 0.15s ease;
+}
+
+.configTriggerIcon img,
+.configTriggerArrow img {
+  width: 22px;
+  height: 22px;
+  display: block;
+}
+
+.configTrigger:not(:disabled):hover .configTriggerIcon,
+.configTrigger:not(:disabled):hover .configTriggerArrow {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.configTrigger:focus-visible .configTriggerIcon,
+.configTrigger:focus-visible .configTriggerArrow {
+  box-shadow: 0 0 0 3px var(--control-focus, rgba(255, 255, 255, 0.14));
 }
 
 .configTriggerLabel {
-  white-space: nowrap;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  margin: 6px 0 14px;
+  padding: 0 12px;
+  font-weight: 600;
+  font-size: clamp(18px, 2.2vw, 24px);
+  letter-spacing: 0.02em;
+  line-height: 1.1;
+  color: inherit;
 }
 
 .configTriggerArrow img {
-  width: 18px;
-  height: 18px;
   transition: transform 0.2s ease;
 }
 
@@ -245,107 +251,147 @@
   transform: rotate(180deg);
 }
 
+:global(#config-panel) {
+  --panel-bg: #151719;
+  --panel-grad: linear-gradient(180deg, rgba(255, 255, 255, 0.03) 0%, rgba(255, 255, 255, 0) 100%);
+  --panel-stroke: #2a2c2f;
+  --panel-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
+  --text: #f1f2f4;
+  --muted: #a7adb4;
+  --placeholder: #8d9399;
+  --control-bg: #0f1011;
+  --control-stroke: #2a2c2f;
+  --control-focus: rgba(255, 255, 255, 0.14);
+  --accent: #f1f2f4;
+  --radius-lg: 18px;
+  --radius-md: 14px;
+  --radius-sm: 12px;
+  font-family: "Poppins", system-ui, sans-serif;
+  color: var(--text);
+  background: var(--panel-bg);
+  background-image: var(--panel-grad);
+  border: 1px solid var(--panel-stroke);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--panel-shadow);
+  backdrop-filter: blur(4px);
+  padding-top: calc(clamp(16px, 2.2vw, 24px) + env(safe-area-inset-top));
+  padding-right: calc(clamp(16px, 2.2vw, 24px) + env(safe-area-inset-right));
+  padding-bottom: calc(clamp(16px, 2vw, 22px) + env(safe-area-inset-bottom));
+  padding-left: calc(clamp(16px, 2.2vw, 24px) + env(safe-area-inset-left));
+  width: min(640px, 92vw);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+:global(#config-panel) > * + * {
+  margin-top: clamp(12px, 1.8vw, 18px);
+}
+
 .configPanel {
   position: absolute;
   top: calc(100% + 12px);
   left: 0;
-  min-width: min(420px, calc(100vw - 96px));
-  max-width: min(520px, calc(100vw - 96px));
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-  padding: 28px;
-  padding-top: calc(28px + env(safe-area-inset-top));
-  padding-right: calc(28px + env(safe-area-inset-right));
-  padding-bottom: calc(28px + env(safe-area-inset-bottom));
-  padding-left: calc(28px + env(safe-area-inset-left));
-  border-radius: 24px;
-  border: 1px solid rgba(63, 63, 77, 0.6);
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(14, 14, 20, 0.96);
-  box-shadow: 0 32px 60px rgba(0, 0, 0, 0.5);
-  z-index: 30;
+  z-index: 40;
   max-height: 70vh;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  box-sizing: border-box;
 }
 
 .configPanelDisabled {
-  opacity: 0.6;
+  opacity: 0.55;
   pointer-events: none;
-}
-
-@media (max-width: 768px) {
-  .configTrigger {
-    width: auto;
-    min-width: 0;
-    padding: 12px 16px;
-    justify-content: center;
-  }
-
-  .configTriggerLabel,
-  .configTriggerArrow {
-    display: none;
-  }
-
-  .configPanel {
-    min-width: auto;
-    max-width: min(
-      520px,
-      calc(100vw - 24px - env(safe-area-inset-left) - env(safe-area-inset-right))
-    );
-  }
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+}
+
+.designNameField {
+  margin-bottom: 8px;
 }
 
 .fieldLabel {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(206, 212, 226, 0.85);
-  font-weight: 600;
+  margin: 14px 0 8px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--muted);
+  letter-spacing: 0.01em;
+}
+
+.field:first-child .fieldLabel {
+  margin-top: 0;
 }
 
 .textInput {
+  height: 56px;
   width: 100%;
-  padding: 14px 16px;
-  border-radius: 12px;
-  border: 1px solid rgba(63, 63, 77, 0.7);
-  background: rgba(22, 22, 28, 0.9);
-  color: #f3f4f6;
-  font-size: 1rem;
-  font-weight: 500;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  padding: 0 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--control-stroke);
+  background: var(--control-bg);
+  color: var(--text);
+  font-size: 16px;
+  line-height: 1.2;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.04);
 }
-
 
 .textInput::placeholder {
-  color: rgba(156, 163, 175, 0.7);
+  color: var(--placeholder);
 }
 
-.textInput:focus {
+.textInput:hover {
+  border-color: #33373c;
+}
+
+.textInput:focus-visible {
   outline: none;
-  border-color: rgba(170, 170, 190, 0.9);
-  box-shadow: 0 0 0 3px rgba(170, 170, 190, 0.2);
+  border-color: #3a3f45;
+  box-shadow: 0 0 0 3px var(--control-focus);
+}
+
+.textInput:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .textInputError,
-.textInputError:focus {
-  border-color: rgba(239, 68, 68, 0.7);
-  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.25);
+.textInputError:focus-visible {
+  border-color: #a33a3a;
+  box-shadow: 0 0 0 3px rgba(163, 58, 58, 0.25);
 }
 
 .fieldError {
-  margin: 0;
+  margin: 6px 0 0;
   color: #fca5a5;
   font-size: 0.85rem;
   font-weight: 500;
+}
+
+@media (min-width: 1024px) {
+  :global(#config-panel) {
+    width: min(640px, 46vw);
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  :global(#config-panel) {
+    width: min(640px, 70vw);
+  }
+}
+
+@media (max-width: 560px) {
+  :global(#config-panel) {
+    width: 92vw;
+  }
+
+  .textInput {
+    height: 54px;
+    font-size: 15px;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- scope the configuration dropdown panel to `#config-panel` and apply the new design tokens, spacing, and typography
- refresh the trigger and design-name field styling to match the updated copy and interaction states
- restyle size controls and the series selector to follow the new control treatments and responsive layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d606d69ed083278a3b0fa326892dc7