### PR TITLE
Overlay mockup heading over preview

### DIFF
--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -487,11 +487,9 @@ export default function Mockup() {
 
   return (
     <div id="mockup-review" className={styles.review}>
-      <div className={styles.hero}>
-        <h1 className={styles.heroTitle}>¿Te gustó cómo quedó?</h1>
-      </div>
       <main className={styles.main}>
         <div className={styles.previewWrapper}>
+          <h1 className={styles.previewTitle}>¿Te gustó cómo quedó?</h1>
           <img
             src={flow.mockupUrl}
             className={styles.mockupImage}

--- a/mgm-front/src/pages/Mockup.module.css
+++ b/mgm-front/src/pages/Mockup.module.css
@@ -25,18 +25,6 @@
   position: relative;
 }
 
-.hero {
-  text-align: center;
-}
-
-.heroTitle {
-  font-size: clamp(28px, 4.5vw, 48px);
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  margin: 0;
-  margin-bottom: clamp(20px, 3vh, 28px);
-}
-
 .main {
   width: min(960px, 100%);
   margin: 0 auto;
@@ -47,14 +35,35 @@
 }
 
 .previewWrapper {
-  max-width: 900px;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  max-width: min(640px, 90vw);
   margin: 0 auto clamp(20px, 4vh, 36px);
+}
+
+.previewTitle {
+  position: absolute;
+  top: clamp(18px, 4vw, 32px);
+  left: 50%;
+  transform: translateX(-50%);
+  margin: 0;
+  font-size: clamp(26px, 4vw, 44px);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: rgba(242, 243, 245, 0.98);
+  text-shadow: 0 4px 22px rgba(0, 0, 0, 0.55);
+  pointer-events: none;
+  z-index: 1;
 }
 
 .mockupImage {
   display: block;
-  width: min(860px, 90vw);
+  width: 100%;
+  max-width: min(640px, 90vw);
   height: auto;
+  object-fit: contain;
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   border: 1px solid rgba(255, 255, 255, 0.04);


### PR DESCRIPTION
## Summary
- move the mockup review heading inside the preview container so it renders on top of the image
- tweak the preview styles to center the overlay text and constrain the PNG dimensions for a lighter look

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d608eaeed08327a51f5101df82b7fc