### PR TITLE
Handle job-based cart creation fallback

### DIFF
--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { getPublicStorefrontBase } from '../publicStorefront.js';
 import { getShopifySalesChannel, shopifyStorefrontGraphQL } from '../shopify.js';
 import { parseJsonBody, getClientIp } from '../_lib/http.js';
+import getSupabaseAdmin from '../_lib/supabaseAdmin.js';
 
 function normalizeVariantId(value) {
   if (value == null) return '';
@@ -106,6 +107,36 @@ function normalizeCartNote(value) {
   if (!raw) return '';
   return raw.slice(0, 1000);
 }
+
+async function fetchJobForCart(jobId) {
+  let supabase;
+  try {
+    supabase = getSupabaseAdmin();
+  } catch (err) {
+    return { ok: false, reason: 'supabase_env_missing', error: err };
+  }
+
+  const { data, error } = await supabase
+    .from('jobs')
+    .select('shopify_variant_id, cart_url, checkout_url')
+    .eq('job_id', jobId)
+    .maybeSingle();
+
+  if (error) {
+    return { ok: false, reason: 'supabase_error', detail: error.message };
+  }
+  if (!data) {
+    return { ok: false, reason: 'job_not_found' };
+  }
+  return { ok: true, job: data };
+}
+
+const JobIdSchema = z
+  .string()
+  .trim()
+  .min(8, 'job_id must be at least 8 characters')
+  .max(64, 'job_id too long')
+  .regex(/^[A-Za-z0-9_-]+$/, 'job_id has invalid characters');
 
 function buildLegacyCartPayload(base, variantId, qty) {
   const buildUrl = (path) => {
@@ -297,6 +328,8 @@ const BodySchema = z
     attributes: z.any().optional(),
     cartAttributes: z.any().optional(),
     note: z.any().optional(),
+    job_id: JobIdSchema.optional(),
+    jobId: JobIdSchema.optional(),
   })
   .passthrough();
 
@@ -330,12 +363,67 @@ export default async function createCartLink(req, res) {
       attributes: attrInput,
       cartAttributes,
       note,
+      job_id: jobIdRaw,
+      jobId: jobIdCamel,
     } = parsed.data;
-    const normalizedVariantId = normalizeVariantId(variantId ?? variantGid);
+
+    const providedJobId = jobIdRaw || jobIdCamel || '';
+    let normalizedVariantId = normalizeVariantId(variantId ?? variantGid);
+    let variantGidValue = ensureVariantGid(variantGid, variantId, normalizedVariantId);
+
+    if (!normalizedVariantId && providedJobId) {
+      const jobResult = await fetchJobForCart(providedJobId);
+      if (!jobResult.ok) {
+        if (jobResult.reason === 'supabase_env_missing') {
+          return res.status(500).json({ ok: false, error: 'supabase_env_missing' });
+        }
+        if (jobResult.reason === 'supabase_error') {
+          return res.status(500).json({ ok: false, error: 'job_lookup_failed', detail: jobResult.detail });
+        }
+        if (jobResult.reason === 'job_not_found') {
+          return res.status(404).json({ ok: false, error: 'job_not_found' });
+        }
+      } else {
+        const { job } = jobResult;
+        if (typeof job?.shopify_variant_id === 'string' && job.shopify_variant_id) {
+          normalizedVariantId = normalizeVariantId(job.shopify_variant_id);
+          variantGidValue = ensureVariantGid(variantGidValue || job.shopify_variant_id, variantId, normalizedVariantId);
+        }
+        if (!normalizedVariantId && typeof job?.cart_url === 'string' && job.cart_url) {
+          const checkoutUrlStored = typeof job.checkout_url === 'string' && job.checkout_url ? job.checkout_url : undefined;
+          let cartPlain;
+          let checkoutPlain;
+          try {
+            const parsedCart = new URL(job.cart_url);
+            cartPlain = `${parsedCart.origin}/cart`;
+          } catch {}
+          if (checkoutUrlStored) {
+            try {
+              const parsedCheckout = new URL(checkoutUrlStored);
+              checkoutPlain = `${parsedCheckout.origin}/checkout`;
+            } catch {}
+          }
+          return res.status(200).json({
+            ok: true,
+            url: job.cart_url,
+            cart_url: job.cart_url,
+            cart_url_follow: job.cart_url,
+            cart_plain: cartPlain,
+            checkout_url_now: checkoutUrlStored,
+            checkout_plain: checkoutPlain,
+            cart_method: 'stored',
+          });
+        }
+        if (!normalizedVariantId) {
+          return res.status(409).json({ ok: false, error: 'job_variant_missing' });
+        }
+      }
+    }
+
     if (!normalizedVariantId) {
       return res.status(400).json({ ok: false, error: 'missing_variant' });
     }
-    const variantGidValue = ensureVariantGid(variantGid, variantId, normalizedVariantId);
+    variantGidValue = ensureVariantGid(variantGidValue, variantId, normalizedVariantId);
     const qtyRaw = Number(quantity);
     const qty = Number.isFinite(qtyRaw) && qtyRaw > 0 ? Math.min(Math.floor(qtyRaw), 99) : 1;
     const base = getPublicStorefrontBase();

--- a/mgm-front/src/lib/pollJobAndCreateCart.ts
+++ b/mgm-front/src/lib/pollJobAndCreateCart.ts
@@ -86,6 +86,8 @@ export async function pollJobAndCreateCart(
     "assets_not_ready",
     "invalid_price",
     "job_not_found",
+    "job_variant_missing",
+    "missing_variant",
   ]);
   for (let i = 1; i <= maxAttempts; i++) {
     if (!retriable.has(String(attempt.code))) break;


### PR DESCRIPTION
## Summary
- resolve Shopify variant details for cart links using the stored job record when only a job_id is provided
- reuse a previously stored cart URL before falling back to Shopify APIs and add retry handling for job variant readiness

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d60992656c83278c229c00c5ee8b40