### PR TITLE
Add Shopify bulk variant update fallback

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -512,57 +512,138 @@ async function executeProductCreate({ input, filename, maxAttempts = 3 }) {
   return attempts[attempts.length - 1];
 }
 
-async function executeProductVariantUpdate({ input, maxAttempts = 3 }) {
+function shouldUseBulkVariantUpdate(json) {
+  const errors = Array.isArray(json?.errors) ? json.errors : [];
+  return errors.some((error) => {
+    const message = typeof error?.message === 'string' ? error.message : '';
+    const code = typeof error?.extensions?.code === 'string' ? error.extensions.code : '';
+    if (!message && !code) return false;
+    const normalizedMessage = message.toLowerCase();
+    return (
+      code === 'undefinedField'
+      || normalizedMessage.includes("field 'productvariantupdate' doesn't exist")
+      || normalizedMessage.includes('productvariantupdate is not defined')
+    );
+  });
+}
+
+function buildBulkVariantUpdateVariables({ productId, input }) {
+  const variant = {};
+  if (typeof input?.id === 'string' && input.id) {
+    variant.id = input.id;
+  }
+  if (typeof input?.price === 'string' && input.price) {
+    variant.price = input.price;
+  }
+  if (typeof input?.sku === 'string' && input.sku) {
+    variant.sku = input.sku;
+  }
+  if (typeof input?.taxable === 'boolean') {
+    variant.taxable = input.taxable;
+  }
+  return {
+    productId,
+    variants: [variant],
+  };
+}
+
+function normalizeBulkVariantUpdateJson(json) {
+  if (!json || typeof json !== 'object') return json;
+  const payload = json?.data?.productVariantsBulkUpdate;
+  if (!payload || typeof payload !== 'object') return json;
+  const productVariants = Array.isArray(payload.productVariants) ? payload.productVariants : [];
+  const firstVariant = productVariants.find((variant) => variant && typeof variant === 'object') || null;
+  const userErrors = Array.isArray(payload.userErrors) ? payload.userErrors : [];
+  return {
+    ...json,
+    data: {
+      ...json.data,
+      productVariantUpdate: {
+        productVariant: firstVariant,
+        userErrors,
+      },
+    },
+  };
+}
+
+async function executeProductVariantUpdate({ input, productId, maxAttempts = 3 }) {
   const attempts = [];
   let lastError = null;
-  const variables = { input };
+  let useBulkMutation = false;
 
-  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+  for (let attempt = 0; attempt < maxAttempts;) {
+    attempt += 1;
+    const attemptIndex = attempt - 1;
+    const variantId = typeof input?.id === 'string' ? input.id : undefined;
+    const mutation = useBulkMutation ? PRODUCT_VARIANTS_BULK_UPDATE_MUTATION : PRODUCT_VARIANT_UPDATE_MUTATION;
+    const variables = useBulkMutation
+      ? buildBulkVariantUpdateVariables({ productId, input })
+      : { input };
+    const eventName = useBulkMutation
+      ? 'product_variants_bulk_update_request'
+      : 'product_variant_update_request';
+
     try {
-      const resp = await shopifyAdminGraphQL(PRODUCT_VARIANT_UPDATE_MUTATION, variables);
-      const requestId = logRequestId('product_variant_update_request', resp, {
-        attempt: attempt + 1,
-        variantId: typeof input?.id === 'string' ? input.id : undefined,
+      const resp = await shopifyAdminGraphQL(mutation, variables);
+      const requestId = logRequestId(eventName, resp, {
+        attempt,
+        variantId,
+        ...(useBulkMutation && typeof productId === 'string' ? { productId } : {}),
       });
-      const json = await resp.json().catch(() => null);
-      const attemptInfo = { resp, json, requestId };
+      const rawJson = await resp.json().catch(() => null);
+      const json = useBulkMutation ? normalizeBulkVariantUpdateJson(rawJson) : rawJson;
+      const attemptInfo = { resp, json, requestId, mode: useBulkMutation ? 'bulk' : 'single' };
       attempts.push(attemptInfo);
+
+      if (
+        !useBulkMutation
+        && typeof variantId === 'string'
+        && variantId
+        && shouldUseBulkVariantUpdate(json)
+        && typeof productId === 'string'
+        && productId
+      ) {
+        useBulkMutation = true;
+        continue;
+      }
 
       if (resp.ok) {
         return { ...attemptInfo, attempts };
       }
 
-      if (!RETRYABLE_SHOPIFY_STATUS.has(resp.status) || attempt === maxAttempts - 1) {
+      if (!RETRYABLE_SHOPIFY_STATUS.has(resp.status) || attempt >= maxAttempts) {
         return { ...attemptInfo, attempts };
       }
 
       try {
         console.warn('product_variant_update_retry', {
-          attempt: attempt + 1,
+          attempt,
           status: resp.status,
           requestId: requestId || null,
-          variantId: typeof input?.id === 'string' ? input.id : undefined,
+          variantId,
+          mode: attemptInfo.mode,
         });
       } catch {}
 
-      await sleep(200 * 2 ** attempt);
+      await sleep(200 * 2 ** attemptIndex);
     } catch (err) {
       lastError = err;
       attempts.push({ error: err });
 
-      if (attempt === maxAttempts - 1) {
+      if (attempt >= maxAttempts) {
         throw err;
       }
 
       try {
         console.warn('product_variant_update_retry_error', {
-          attempt: attempt + 1,
+          attempt,
           message: err?.message || String(err),
-          variantId: typeof input?.id === 'string' ? input.id : undefined,
+          variantId,
+          mode: useBulkMutation ? 'bulk' : 'single',
         });
       } catch {}
 
-      await sleep(200 * 2 ** attempt);
+      await sleep(200 * 2 ** attemptIndex);
     }
   }
 
@@ -1058,6 +1139,28 @@ const PRODUCT_CREATE_MUTATION = `mutation ProductCreate($input: ProductInput!) {
 const PRODUCT_VARIANT_UPDATE_MUTATION = `mutation ProductVariantUpdate($input: ProductVariantInput!) {
   productVariantUpdate(input: $input) {
     productVariant {
+      id
+      legacyResourceId
+      title
+      price
+      sku
+      inventoryItem {
+        id
+      }
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}`;
+
+const PRODUCT_VARIANTS_BULK_UPDATE_MUTATION = `mutation ProductVariantsBulkUpdate(
+  $productId: ID!
+  $variants: [ProductVariantsBulkInput!]!
+) {
+  productVariantsBulkUpdate(productId: $productId, variants: $variants) {
+    productVariants {
       id
       legacyResourceId
       title
@@ -2093,7 +2196,7 @@ export async function publishProduct(req, res) {
       json: variantJson,
       requestId: variantGraphQLRequestIdRaw,
       attempts: variantAttempts,
-    } = await executeProductVariantUpdate({ input: variantUpdateInput });
+    } = await executeProductVariantUpdate({ input: variantUpdateInput, productId: productIdForVariants });
 
     const variantGraphQLRequestId = variantGraphQLRequestIdRaw || null;
     const variantGraphQLRequestIds = Array.isArray(variantAttempts)


### PR DESCRIPTION
## Summary
- detect when the Admin GraphQL productVariantUpdate mutation is unavailable and switch to productVariantsBulkUpdate
- normalize the bulk mutation response so downstream handling continues to work and keep retry/backoff logic intact
- pass the product id into the variant update helper so the bulk mutation has the necessary context

## Testing
- npm test -- tests/create-cart-link.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d60c78407c8327993169d981754fc9