### PR TITLE
Handle missing Storefront configuration in variant status

### DIFF
--- a/lib/handlers/variantStatus.js
+++ b/lib/handlers/variantStatus.js
@@ -54,10 +54,29 @@ export default async function variantStatus(req, res) {
       return res.status(400).json({ ok: false, error: 'invalid_product' });
     }
 
-    const resp = await shopifyStorefrontGraphQL(PRODUCT_VARIANT_QUERY, {
-      productId: productGid,
-      first: 10,
-    });
+    let resp;
+    try {
+      resp = await shopifyStorefrontGraphQL(PRODUCT_VARIANT_QUERY, {
+        productId: productGid,
+        first: 10,
+      });
+    } catch (err) {
+      if (err?.message === 'SHOPIFY_STOREFRONT_ENV_MISSING') {
+        return res.status(200).json({
+          ok: true,
+          ready: true,
+          available: true,
+          published: true,
+          variantPresent: true,
+          productId: productGid,
+          variantId: variantGid,
+          variantCount: null,
+          source: 'fallback',
+          reason: 'storefront_env_missing',
+        });
+      }
+      throw err;
+    }
     const json = await resp.json().catch(() => null);
     if (!resp.ok) {
       return res.status(502).json({ ok: false, error: 'variant_status_failed', status: resp.status, detail: json });


### PR DESCRIPTION
## Summary
- short-circuit the variant availability check when the Shopify Storefront configuration is missing
- return a successful response so the cart flow can continue using the legacy fallback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6a11b9b708327b5e046c910187520