### PR TITLE
Fix Supabase upload URL handler

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -59,10 +59,17 @@ Checks whether a product variant is visible and available for sale through the S
 
 ### `POST /api/upload-url`
 
-Creates a public Supabase storage URL for an upload. Requires:
+Creates a Supabase Storage upload target for the original artwork. Requires:
 
 - `design_name`, `ext`, `mime`, `size_bytes`, `material`, `w_cm`, `h_cm`, `sha256`.
 - Rejects files above `MAX_UPLOAD_MB` (defaults to 40 MB) or sizes exceeding material limits.
+
+Returns:
+
+- `object_key`: path within the `uploads` bucket.
+- `file_original_url` / `canonical_url`: deterministic public URL to persist on the job record.
+- `upload_url`: direct REST endpoint (`/storage/v1/object/uploads/...`) kept for backwards compatibility.
+- `upload`: `{ signed_url, token, expires_in }` for `PUT` uploads using Supabase's signed URLs (recommended).
 
 ### `POST /api/submit-job`
 

--- a/docs/curl-examples.md
+++ b/docs/curl-examples.md
@@ -15,11 +15,11 @@ curl -X POST https://mgm-api.vercel.app/api/upload-url \
   }'
 ```
 
-La respuesta incluye `object_key` y `signed_url`.
+La respuesta incluye `object_key`, `file_original_url` y un objeto `upload` con `signed_url` + `token` (firmado para subir).
 
 ## 2. Subir el archivo con el `signed_url`
 ```bash
-curl -X PUT '<SIGNED_URL>' \
+curl -X PUT 'https://<project>.supabase.co/storage/v1/object/sign/uploads/<OBJECT_KEY>?token=<TOKEN>' \
   -H 'Content-Type: image/png' \
   --data-binary '@local.png'
 ```

--- a/lib/handlers/uploadUrl.js
+++ b/lib/handlers/uploadUrl.js
@@ -2,6 +2,40 @@ import crypto from 'node:crypto';
 import { supa } from '../supa.js';
 import { buildObjectKey } from '../_lib/slug.js';
 
+const UPLOAD_BUCKET = 'uploads';
+
+function normalizeBaseUrl(raw = '') {
+  return String(raw || '').replace(/\/$/, '');
+}
+
+function buildCanonicalUrl(key) {
+  const base = normalizeBaseUrl(process.env.SUPABASE_URL);
+  return `${base}/storage/v1/object/public/${UPLOAD_BUCKET}/${key}`;
+}
+
+function buildDirectUploadUrl(key) {
+  const base = normalizeBaseUrl(process.env.SUPABASE_URL);
+  return `${base}/storage/v1/object/${UPLOAD_BUCKET}/${key}`;
+}
+
+function toSignedUpload({ signedUrl, token }) {
+  if (!signedUrl || !token) return null;
+  const base = normalizeBaseUrl(process.env.SUPABASE_URL);
+  const absolute = signedUrl.startsWith('http')
+    ? signedUrl
+    : `${base}${signedUrl.startsWith('/') ? '' : '/'}${signedUrl}`;
+  return {
+    signed_url: absolute,
+    token,
+  };
+}
+
+function resolveExpirySeconds() {
+  const raw = Number(process.env.SIGNED_UPLOAD_EXPIRES_IN || process.env.UPLOAD_URL_EXPIRES_IN || 900);
+  if (!Number.isFinite(raw) || raw <= 0) return 900;
+  return Math.min(Math.max(Math.round(raw), 60), 60 * 60 * 24);
+}
+
 function validateUploadBody(body) {
   if (!body || typeof body !== 'object') return 'invalid_body';
   const { design_name, ext, mime, size_bytes, material, w_cm, h_cm, sha256 } = body;
@@ -64,9 +98,26 @@ export default async function uploadUrl(req, res) {
       ext: body.ext,
     });
 
-    const uploadsPrefix = `${process.env.SUPABASE_URL}/storage/v1/object/public/uploads/`;
-    const url = uploadsPrefix + encodeURIComponent(key);
-    return res.status(200).json({ ok: true, upload_url: url, object_key: key });
+    const storage = supa.storage.from(UPLOAD_BUCKET);
+    const expiresIn = resolveExpirySeconds();
+    const { data: signed, error } = await storage.createSignedUploadUrl(key, expiresIn, { upsert: true });
+    if (error) {
+      console.error('upload-url signed', { diagId, error: error.message });
+      return res.status(500).json({ ok: false, diag_id: diagId, message: 'supabase_signed_error' });
+    }
+
+    const canonical = buildCanonicalUrl(key);
+    const direct = buildDirectUploadUrl(key);
+    const upload = toSignedUpload(signed || {}, key);
+
+    return res.status(200).json({
+      ok: true,
+      object_key: key,
+      upload_url: direct,
+      file_original_url: canonical,
+      canonical_url: canonical,
+      upload: upload ? { ...upload, expires_in: expiresIn } : null,
+    });
   } catch (e) {
     return res.status(500).json({ ok: false, diag_id: diagId, message: 'internal_error' });
   }


### PR DESCRIPTION
## Summary
- generate signed Supabase Storage upload URLs from the upload-url endpoint and return canonical metadata
- document the updated response payload and signed upload usage in the API and curl guides

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6a23d5b4083278bd0d9d27e9c50b4