### PR TITLE
Ensure editor hero fits without scrolling

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -869,22 +869,16 @@ export default function Home() {
                   Continuar
                 </button>
               )}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className={styles.sectionTwo}>
-        <div className={styles.sectionTwoInner} style={editorMaxWidthStyle}>
-          <div className={styles.footerRow}>
-            <div className={styles.feedbackGroup}>
               {err && (
-                <p
-                  id={err === ACK_LOW_ERROR_MESSAGE ? ackLowErrorDescriptionId : undefined}
-                  className={`errorText ${styles.errorMessage}`}
-                >
-                  {err}
-                </p>
+                <div className={styles.canvasFeedback}>
+                  <p
+                    id={err === ACK_LOW_ERROR_MESSAGE ? ackLowErrorDescriptionId : undefined}
+                    className={`errorText ${styles.errorMessage}`}
+                    role="alert"
+                  >
+                    {err}
+                  </p>
+                </div>
               )}
             </div>
           </div>

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -21,42 +21,6 @@
   min-height: 100%;
 }
 
-.sectionTwo {
-  width: 100%;
-  display: flex;
-}
-
-.sectionTwoInner {
-  width: 100%;
-  max-width: 1920px !important;
-  margin: 0 auto;
-}
-
-/* STACK centrado */
-.footerRow {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  width: min(100%, 534px);   /* ← ancho pedido */
-  margin: 0 auto;            /* ← centrado en la pantalla */
-}
-
-/* fila del checkbox: texto izq, check der */
-
-
-/* STACK centrado */
-.footerRow {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  width: min(100%, 534px);   /* ← ancho pedido */
-  margin: 0 auto;            /* ← centrado en la pantalla */
-}
-
-/* fila del checkbox: texto izq, check der */
-
-
-/* botón ocupa todo el ancho del stack */
 .continueButton {
   width: 100%;
 }
@@ -557,15 +521,6 @@
 
 
 
-.feedbackGroup {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  flex: 1 1 20px;
-  min-width: 0;
-  width: 100%;
-}
-
 .ackLabel {
   position: relative;
   display: flex;
@@ -695,6 +650,17 @@
   color: rgba(239, 68, 68, 0.85);
 }
 
+.canvasFeedback {
+  position: absolute;
+  left: var(--canvas-floating-right);
+  right: var(--canvas-floating-right);
+  bottom: calc(var(--canvas-floating-bottom) + var(--canvas-continue-height) + 6px);
+  z-index: 60;
+  display: flex;
+  justify-content: flex-start;
+  padding-right: calc(clamp(220px, 26vw, 320px) + var(--canvas-floating-gap));
+}
+
 .canvasContinue {
   position: absolute;
   right: var(--canvas-floating-right);
@@ -812,9 +778,4 @@
     width: min(360px, 100%);
     padding: 20px 24px;
   }
-
-  .footerRow {
-    gap: 16px;
-  }
-
 }


### PR DESCRIPTION
## Summary
- move the editor feedback message into the main stage so the first viewport loads without extra scroll
- clean up the home page layout styles and add a floating feedback container that respects the floating controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6a3c3370c8327af83ecb35389e61d