### PR TITLE
Adjust low quality flow thresholds

### DIFF
--- a/mgm-front/src/lib/dpi.js
+++ b/mgm-front/src/lib/dpi.js
@@ -1,5 +1,8 @@
 const CM_PER_IN = 2.54;
 
+export const DPI_WARN_THRESHOLD = 260;
+export const DPI_LOW_THRESHOLD = 90;
+
 export function dpiFor(cmW, cmH, pxW, pxH) {
   const dpiW = pxW / (cmW / CM_PER_IN);
   const dpiH = pxH / (cmH / CM_PER_IN);
@@ -7,7 +10,7 @@ export function dpiFor(cmW, cmH, pxW, pxH) {
 }
 
 // antes: (warn=300, low=220)
-export function dpiLevel(dpi, warn = 300, low = 100) {
+export function dpiLevel(dpi, warn = DPI_WARN_THRESHOLD, low = DPI_LOW_THRESHOLD) {
   if (dpi >= warn) return 'ok';
   if (dpi >= low) return 'warn';  // “medio/aceptable”
   return 'bad';


### PR DESCRIPTION
## Summary
- lower the shared DPI thresholds for quality levels and reuse them across the front-end
- gate the low-quality acknowledgement checkbox only on bad quality with updated messaging and button disablement
- align the editor quality badge with the new thresholds and expose the new wording in the UI

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d6a81a92308327bf74deb57fac5e19