### PR TITLE
Implement private draft order checkout flow

### DIFF
--- a/lib/handlers/createCheckout.js
+++ b/lib/handlers/createCheckout.js
@@ -19,6 +19,15 @@ const BodySchema = z
     quantity: z.union([z.string(), z.number()]).optional(),
     email: z.string().email().optional(),
     mode: z.enum(['checkout', 'cart', 'private']).optional(),
+    note: z.string().optional(),
+    noteAttributes: z
+      .array(
+        z.object({
+          name: z.string(),
+          value: z.string(),
+        }),
+      )
+      .optional(),
   })
   .passthrough();
 
@@ -28,7 +37,7 @@ function parseVariantNumericId(value) {
   return Math.floor(numeric);
 }
 
-async function createDraftOrderCheckout({ variantId, quantity, email }) {
+async function createDraftOrderCheckout({ variantId, quantity, email, note, noteAttributes }) {
   const numericVariantId = parseVariantNumericId(variantId);
   if (!numericVariantId) {
     return { ok: false, reason: 'invalid_variant' };
@@ -43,15 +52,36 @@ async function createDraftOrderCheckout({ variantId, quantity, email }) {
         },
       ],
       use_customer_default_address: true,
-      tags: 'mgm_private_checkout',
-      note_attributes: [
-        { name: 'mgm_source', value: 'editor' },
-      ],
+      tags: 'private, editor',
     },
   };
 
   if (email) {
     payload.draft_order.email = email;
+  }
+
+  if (typeof note === 'string') {
+    const trimmedNote = note.trim();
+    if (trimmedNote) {
+      payload.draft_order.note = trimmedNote.slice(0, 1024);
+    }
+  }
+
+  const attributesList = Array.isArray(noteAttributes) ? noteAttributes : [];
+  const baseAttributes = [{ name: 'mgm_source', value: 'editor' }, ...attributesList];
+  const normalizedAttributes = [];
+  const seenNames = new Set();
+  for (const attr of baseAttributes) {
+    if (!attr || typeof attr.name !== 'string' || typeof attr.value !== 'string') continue;
+    const name = attr.name.trim();
+    const value = attr.value.trim();
+    if (!name || !value) continue;
+    if (seenNames.has(name)) continue;
+    seenNames.add(name);
+    normalizedAttributes.push({ name, value: value.slice(0, 255) });
+  }
+  if (normalizedAttributes.length) {
+    payload.draft_order.note_attributes = normalizedAttributes;
   }
 
   const resp = await shopifyAdmin('draft_orders.json', {
@@ -106,7 +136,7 @@ export default async function createCheckout(req, res) {
     if (!parsed.success) {
       return res.status(400).json({ ok: false, error: 'invalid_body', issues: parsed.error.flatten().fieldErrors });
     }
-    const { variantId, variantGid, quantity, email, mode } = parsed.data;
+    const { variantId, variantGid, quantity, email, mode, note, noteAttributes } = parsed.data;
     const normalizedVariantId = normalizeVariantId(variantId ?? variantGid);
     if (!normalizedVariantId) return res.status(400).json({ ok: false, error: 'missing_variant' });
     const qtyRaw = Number(quantity);
@@ -125,6 +155,8 @@ export default async function createCheckout(req, res) {
           variantId: normalizedVariantId,
           quantity: qty,
           email: normalizedEmail,
+          note,
+          noteAttributes,
         });
         if (!draftCheckout?.ok || !draftCheckout?.url) {
           return res.status(502).json({

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1906,7 +1906,7 @@ export async function publishProduct(req, res) {
 
     const productInput = {
       title,
-      status: 'ACTIVE',
+      status: isPrivate ? 'DRAFT' : 'ACTIVE',
       vendor: DEFAULT_VENDOR,
       templateSuffix: 'mousepads',
     };
@@ -2903,7 +2903,7 @@ export async function publishProduct(req, res) {
       }
     }
 
-    if (!isActiveStatus(product)) {
+    if (!isPrivate && !isActiveStatus(product)) {
       return res.status(400).json({
         ok: false,
         reason: 'product_not_active',
@@ -2923,64 +2923,56 @@ export async function publishProduct(req, res) {
       });
     }
 
-    let publicationInfo;
-    try {
-      publicationInfo = await resolveOnlineStorePublicationId({ preferEnv: true });
-      if (publicationInfo?.id) {
-        try {
-          console.info('publish_product_publication_resolved', {
-            id: publicationInfo.id,
-            source: publicationInfo.source || 'unknown',
-            name: publicationInfo.name || null,
+    let publicationInfo = null;
+    let publishResult = null;
+
+    if (!isPrivate) {
+      try {
+        publicationInfo = await resolveOnlineStorePublicationId({ preferEnv: true });
+        if (publicationInfo?.id) {
+          try {
+            console.info('publish_product_publication_resolved', {
+              id: publicationInfo.id,
+              source: publicationInfo.source || 'unknown',
+              name: publicationInfo.name || null,
+            });
+          } catch {}
+        }
+      } catch (err) {
+        if (err?.message === 'online_store_publication_empty') {
+          logPublicationAbort(meta, 'no_publications');
+          return respondWithPublicationIssue(res, { ...meta, visibility }, 'online_store_publication_empty', ONLINE_STORE_DISABLED_MESSAGE, {
+            allowSkipPublication: true,
+            missing: ['online_store_channel'],
           });
-        } catch {}
+        }
+        if (err?.message === 'online_store_publication_missing') {
+          logPublicationAbort(meta, 'missing_scope');
+          return respondWithPublicationIssue(res, { ...meta, visibility }, 'online_store_publication_missing', ONLINE_STORE_MISSING_MESSAGE, {
+            missing: ['write_publications'],
+          });
+        }
+        if (err?.message === 'online_store_publication_query_failed') {
+          logPublicationAbort(meta, 'publication_query_failed', { errors: err?.errors || null });
+          return respondWithPublicationIssue(res, { ...meta, visibility }, 'online_store_publication_missing', ONLINE_STORE_MISSING_MESSAGE, {
+            missing: ['read_publications', 'write_publications'],
+            errors: err?.errors || null,
+          });
+        }
+        throw err;
       }
-    } catch (err) {
-      if (err?.message === 'online_store_publication_empty') {
-        logPublicationAbort(meta, 'no_publications');
-        return respondWithPublicationIssue(res, { ...meta, visibility }, 'online_store_publication_empty', ONLINE_STORE_DISABLED_MESSAGE, {
-          allowSkipPublication: true,
-          missing: ['online_store_channel'],
-        });
-      }
-      if (err?.message === 'online_store_publication_missing') {
-        logPublicationAbort(meta, 'missing_scope');
-        return respondWithPublicationIssue(res, { ...meta, visibility }, 'online_store_publication_missing', ONLINE_STORE_MISSING_MESSAGE, {
-          missing: ['write_publications'],
-        });
-      }
-      if (err?.message === 'online_store_publication_query_failed') {
-        logPublicationAbort(meta, 'publication_query_failed', { errors: err?.errors || null });
-        return respondWithPublicationIssue(res, { ...meta, visibility }, 'online_store_publication_missing', ONLINE_STORE_MISSING_MESSAGE, {
-          missing: ['read_publications', 'write_publications'],
-          errors: err?.errors || null,
-        });
-      }
-      throw err;
-    }
 
-    const publishResult = await publishToOnlineStore(meta.productAdminId, publicationInfo?.id, {
-      maxAttempts: 5,
-      initialDelayMs: 200,
-      maxDelayMs: 3200,
-      preferEnv: publicationInfo?.source === 'env' || publicationInfo?.source === 'override',
-    });
+      publishResult = await publishToOnlineStore(meta.productAdminId, publicationInfo?.id, {
+        maxAttempts: 5,
+        initialDelayMs: 200,
+        maxDelayMs: 3200,
+        preferEnv: publicationInfo?.source === 'env' || publicationInfo?.source === 'override',
+      });
 
-    if (!publishResult?.ok) {
-      const requestIds = Array.isArray(publishResult?.requestIds) ? publishResult.requestIds : [];
-      if (publishResult.reason === 'publication_missing') {
-        logPublicationAbort(meta, 'still_missing_after_retries', { requestIds });
-        return respondWithPublicationIssue(res, { ...meta, visibility }, 'online_store_publication_missing', ONLINE_STORE_MISSING_MESSAGE, {
-          publicationId: publicationInfo?.id || null,
-          publicationSource: publicationInfo?.source || null,
-          requestIds,
-          missing: ['write_publications'],
-        });
-      }
-      if (publishResult.reason === 'graphql_errors' || publishResult.reason === 'user_errors') {
-        const combined = publishResult.errors || publishResult.userErrors || [];
-        if (detectMissingScope(combined)) {
-          logPublicationAbort(meta, 'missing_scope', { requestIds });
+      if (!publishResult?.ok) {
+        const requestIds = Array.isArray(publishResult?.requestIds) ? publishResult.requestIds : [];
+        if (publishResult.reason === 'publication_missing') {
+          logPublicationAbort(meta, 'still_missing_after_retries', { requestIds });
           return respondWithPublicationIssue(res, { ...meta, visibility }, 'online_store_publication_missing', ONLINE_STORE_MISSING_MESSAGE, {
             publicationId: publicationInfo?.id || null,
             publicationSource: publicationInfo?.source || null,
@@ -2988,18 +2980,30 @@ export async function publishProduct(req, res) {
             missing: ['write_publications'],
           });
         }
-      }
+        if (publishResult.reason === 'graphql_errors' || publishResult.reason === 'user_errors') {
+          const combined = publishResult.errors || publishResult.userErrors || [];
+          if (detectMissingScope(combined)) {
+            logPublicationAbort(meta, 'missing_scope', { requestIds });
+            return respondWithPublicationIssue(res, { ...meta, visibility }, 'online_store_publication_missing', ONLINE_STORE_MISSING_MESSAGE, {
+              publicationId: publicationInfo?.id || null,
+              publicationSource: publicationInfo?.source || null,
+              requestIds,
+              missing: ['write_publications'],
+            });
+          }
+        }
 
-      logPublicationAbort(meta, publishResult.reason || 'publish_failed', { requestIds });
-      return res.status(502).json({
-        ok: false,
-        reason: publishResult.reason || 'publish_failed',
-        message: 'Shopify rechazó la publicación del producto.',
-        detail: publishResult,
-        ...meta,
-        visibility,
-        publishAttempts: typeof publishResult.attempt === 'number' ? publishResult.attempt : undefined,
-      });
+        logPublicationAbort(meta, publishResult.reason || 'publish_failed', { requestIds });
+        return res.status(502).json({
+          ok: false,
+          reason: publishResult.reason || 'publish_failed',
+          message: 'Shopify rechazó la publicación del producto.',
+          detail: publishResult,
+          ...meta,
+          visibility,
+          publishAttempts: typeof publishResult.attempt === 'number' ? publishResult.attempt : undefined,
+        });
+      }
     }
 
     const warningMessages = warnings
@@ -3009,19 +3013,30 @@ export async function publishProduct(req, res) {
       .map((entry) => (entry && typeof entry.code === 'string' ? entry.code : ''))
       .filter((entry) => entry);
 
-    return res.status(200).json({
+    const responsePayload = {
       ok: true,
       ...meta,
       status: product?.status,
       visibility,
-      publicationId: publishResult.publicationId,
-      publicationSource: publicationInfo?.source || null,
-      requestIds: publishResult.requestIds || null,
-      publishAttempts: typeof publishResult.attempt === 'number' ? publishResult.attempt : undefined,
       ...(warnings.length ? { warnings } : {}),
       ...(warningMessages.length ? { warningMessages } : {}),
       ...(warningCodes.length ? { warningCodes } : {}),
-    });
+    };
+
+    if (!isPrivate) {
+      responsePayload.publicationId = publishResult?.publicationId || null;
+      responsePayload.publicationSource = publicationInfo?.source || null;
+      responsePayload.requestIds = publishResult?.requestIds || null;
+      if (typeof publishResult?.attempt === 'number') {
+        responsePayload.publishAttempts = publishResult.attempt;
+      }
+    } else {
+      responsePayload.publicationId = null;
+      responsePayload.publicationSource = null;
+      responsePayload.requestIds = null;
+    }
+
+    return res.status(200).json(responsePayload);
   } catch (e) {
     if (e?.message === 'SHOPIFY_ENV_MISSING') {
       const missing = Array.isArray(e?.missing) && e.missing.length


### PR DESCRIPTION
## Summary
- create private purchase flow that keeps products in draft status and skips storefront publication
- generate Shopify draft orders with metadata and open the invoice URL in a new tab with updated toasts
- add private tagging and enriched checkout notes for traceability

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6added3208327978073b4972ea5fb