### PR TITLE
Implement Storefront cart flow fallback

### DIFF
--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -7,8 +7,8 @@ import { downloadBlob } from '@/lib/mockup.js';
 import styles from './Mockup.module.css';
 import { buildExportBaseName } from '@/lib/filename.ts';
 import {
-  addVariantToCartAjax,
   addVariantToCartStorefront,
+  buildCartPermalink,
   createJobAndProduct,
   ONLINE_STORE_DISABLED_MESSAGE,
   ONLINE_STORE_MISSING_MESSAGE,
@@ -322,31 +322,23 @@ export default function Mockup() {
         } catch (logErr) {
           console.warn('[cart-flow] storefront cart log failed', logErr);
         }
-        try {
-          const ajaxResult = await addVariantToCartAjax(
-            current.variantId,
-            current.quantity || CART_DEFAULT_QUANTITY,
-          );
-          cartUrl = ajaxResult.webUrl;
+        const fallbackUrl = buildCartPermalink(
+          current.variantId,
+          current.quantity || CART_DEFAULT_QUANTITY,
+        );
+        if (fallbackUrl) {
+          cartUrl = fallbackUrl;
           current = {
             ...current,
-            webUrl: ajaxResult.webUrl,
+            webUrl: fallbackUrl,
           };
           setPendingCart(current);
-        } catch (ajaxError) {
-          const ajaxErr = ajaxError && typeof ajaxError === 'object'
-            ? ajaxError
-            : {};
           try {
-            console.error('[cart-flow] ajax cart fallback failed', {
-              error: ajaxError,
-              reason: typeof ajaxErr.reason === 'string' ? ajaxErr.reason : undefined,
-              requestId: typeof ajaxErr.requestId === 'string' ? ajaxErr.requestId : undefined,
-              detail: ajaxErr.detail,
-            });
+            console.info('[cart-flow] cart_permalink_redirect', { url: fallbackUrl });
           } catch (logErr) {
-            console.warn('[cart-flow] ajax cart log failed', logErr);
+            console.warn('[cart-flow] cart_permalink_log_failed', logErr);
           }
+        } else {
           setCartStatus('idle');
           setBusy(false);
           showCartFailureToast('');


### PR DESCRIPTION
## Summary
- add a reusable Storefront GraphQL helper and mutations to create carts and add lines with detailed logging
- poll ProductVariant visibility through the Storefront API before attempting cart creation
- update the cart flow UI to fall back to a permalink when Storefront calls fail while preserving existing toasts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6b0f162ac8327a3a0128596aa5c48