### PR TITLE
Prevent automatic canvas zoom reset

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -1044,7 +1044,6 @@ const EditorCanvas = forwardRef(function EditorCanvas(
     const stageH = workCm.h * baseScale;
     const targetX = (wrapSize.w - stageW) / 2;
     const targetY = (wrapSize.h - stageH) / 2;
-    setViewScale((prev) => (prev === 1 ? prev : 1));
     setViewPos((prev) => {
       if (
         Math.abs(prev.x - targetX) < 0.5 &&


### PR DESCRIPTION
## Summary
- keep the editor canvas zoom level untouched when layout dimensions or material options change
- still recenter the canvas viewport without forcing a zoom reset

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6b7c85ac08327bfdb06ed8e226499