### PR TITLE
Support discount codes in checkout links

### DIFF
--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -138,7 +138,7 @@ const JobIdSchema = z
   .max(64, 'job_id too long')
   .regex(/^[A-Za-z0-9_-]+$/, 'job_id has invalid characters');
 
-function buildLegacyCartPayload(base, variantId, qty) {
+function buildLegacyCartPayload(base, variantId, qty, discountCode) {
   const buildUrl = (path) => {
     try {
       return new URL(path, base);
@@ -154,6 +154,9 @@ function buildLegacyCartPayload(base, variantId, qty) {
   cartAddUrl.searchParams.set('quantity', String(qty));
   const cartChannel = getShopifySalesChannel('cart');
   if (cartChannel) cartAddUrl.searchParams.set('channel', cartChannel);
+  if (discountCode) {
+    cartAddUrl.searchParams.set('discount', discountCode);
+  }
 
   const homeUrl = buildUrl('/');
   const cartPlainUrl = buildUrl('/cart');
@@ -206,6 +209,9 @@ function buildLegacyCartPayload(base, variantId, qty) {
     if (checkoutReturnTo) {
       checkoutNowUrl.searchParams.set('return_to', checkoutReturnTo);
     }
+    if (discountCode) {
+      checkoutNowUrl.searchParams.set('discount', discountCode);
+    }
   }
 
   return {
@@ -239,6 +245,7 @@ async function tryCreateStorefrontCart({
   buyerIp,
   attributes,
   note,
+  discountCode,
 }) {
   if (!variantGid) {
     return { ok: false, reason: 'missing_variant_gid' };
@@ -301,13 +308,30 @@ async function tryCreateStorefrontCart({
       return { ok: false, reason: 'missing_cart_token' };
     }
     const baseUrl = base.replace(/\/$/, '');
-    const cartUrl = `${baseUrl}/cart/c/${token}`;
+    let cartUrl = `${baseUrl}/cart/c/${token}`;
+    if (discountCode) {
+      try {
+        const cartUrlObj = new URL(cartUrl);
+        cartUrlObj.searchParams.set('discount', discountCode);
+        cartUrl = cartUrlObj.toString();
+      } catch {}
+    }
     return {
       ok: true,
       cartUrl,
       cartUrlFollow: cartUrl,
       cartPlain: `${baseUrl}/cart`,
-      checkoutUrlNow: typeof cart.checkoutUrl === 'string' && cart.checkoutUrl ? cart.checkoutUrl : undefined,
+      checkoutUrlNow: (() => {
+        if (typeof cart.checkoutUrl !== 'string' || !cart.checkoutUrl) return undefined;
+        if (!discountCode) return cart.checkoutUrl;
+        try {
+          const checkoutUrlObj = new URL(cart.checkoutUrl);
+          checkoutUrlObj.searchParams.set('discount', discountCode);
+          return checkoutUrlObj.toString();
+        } catch {
+          return cart.checkoutUrl;
+        }
+      })(),
       checkoutPlain: `${baseUrl}/checkout`,
       cartId: cart.id,
       cartToken: token,
@@ -330,6 +354,7 @@ const BodySchema = z
     note: z.any().optional(),
     job_id: JobIdSchema.optional(),
     jobId: JobIdSchema.optional(),
+    discount: z.string().optional(),
   })
   .passthrough();
 
@@ -365,11 +390,13 @@ export default async function createCartLink(req, res) {
       note,
       job_id: jobIdRaw,
       jobId: jobIdCamel,
+      discount,
     } = parsed.data;
 
     const providedJobId = jobIdRaw || jobIdCamel || '';
     let normalizedVariantId = normalizeVariantId(variantId ?? variantGid);
     let variantGidValue = ensureVariantGid(variantGid, variantId, normalizedVariantId);
+    const normalizedDiscount = typeof discount === 'string' ? discount.trim() : '';
 
     if (!normalizedVariantId && providedJobId) {
       const jobResult = await fetchJobForCart(providedJobId);
@@ -390,11 +417,26 @@ export default async function createCartLink(req, res) {
           variantGidValue = ensureVariantGid(variantGidValue || job.shopify_variant_id, variantId, normalizedVariantId);
         }
         if (!normalizedVariantId && typeof job?.cart_url === 'string' && job.cart_url) {
-          const checkoutUrlStored = typeof job.checkout_url === 'string' && job.checkout_url ? job.checkout_url : undefined;
+          let checkoutUrlStored = typeof job.checkout_url === 'string' && job.checkout_url ? job.checkout_url : undefined;
+          let cartUrlStored = job.cart_url;
+          if (normalizedDiscount) {
+            try {
+              const cartUrlObj = new URL(cartUrlStored);
+              cartUrlObj.searchParams.set('discount', normalizedDiscount);
+              cartUrlStored = cartUrlObj.toString();
+            } catch {}
+            if (checkoutUrlStored) {
+              try {
+                const checkoutUrlObj = new URL(checkoutUrlStored);
+                checkoutUrlObj.searchParams.set('discount', normalizedDiscount);
+                checkoutUrlStored = checkoutUrlObj.toString();
+              } catch {}
+            }
+          }
           let cartPlain;
           let checkoutPlain;
           try {
-            const parsedCart = new URL(job.cart_url);
+            const parsedCart = new URL(cartUrlStored);
             cartPlain = `${parsedCart.origin}/cart`;
           } catch {}
           if (checkoutUrlStored) {
@@ -405,9 +447,9 @@ export default async function createCartLink(req, res) {
           }
           return res.status(200).json({
             ok: true,
-            url: job.cart_url,
-            cart_url: job.cart_url,
-            cart_url_follow: job.cart_url,
+            url: cartUrlStored,
+            cart_url: cartUrlStored,
+            cart_url_follow: cartUrlStored,
             cart_plain: cartPlain,
             checkout_url_now: checkoutUrlStored,
             checkout_plain: checkoutPlain,
@@ -439,6 +481,7 @@ export default async function createCartLink(req, res) {
       buyerIp,
       attributes,
       note,
+      discountCode: normalizedDiscount,
     });
 
     if (storefrontAttempt.ok) {
@@ -480,7 +523,7 @@ export default async function createCartLink(req, res) {
       } catch {}
     }
 
-    const fallback = buildLegacyCartPayload(base, normalizedVariantId, qty);
+    const fallback = buildLegacyCartPayload(base, normalizedVariantId, qty, normalizedDiscount);
     if (!fallback) {
       return res.status(500).json({ ok: false, error: 'create_cart_link_failed' });
     }

--- a/lib/handlers/createCheckout.js
+++ b/lib/handlers/createCheckout.js
@@ -28,6 +28,7 @@ const BodySchema = z
         }),
       )
       .optional(),
+    discount: z.string().optional(),
   })
   .passthrough();
 
@@ -136,7 +137,7 @@ export default async function createCheckout(req, res) {
     if (!parsed.success) {
       return res.status(400).json({ ok: false, error: 'invalid_body', issues: parsed.error.flatten().fieldErrors });
     }
-    const { variantId, variantGid, quantity, email, mode, note, noteAttributes } = parsed.data;
+    const { variantId, variantGid, quantity, email, mode, note, noteAttributes, discount } = parsed.data;
     const normalizedVariantId = normalizeVariantId(variantId ?? variantGid);
     if (!normalizedVariantId) return res.status(400).json({ ok: false, error: 'missing_variant' });
     const qtyRaw = Number(quantity);
@@ -145,6 +146,7 @@ export default async function createCheckout(req, res) {
     if (!base) return res.status(500).json({ ok: false, error: 'missing_store_domain' });
 
     const normalizedEmail = typeof email === 'string' ? email.trim() : '';
+    const normalizedDiscount = typeof discount === 'string' ? discount.trim() : '';
 
     if (mode === 'private') {
       if (!normalizedEmail) {
@@ -193,6 +195,9 @@ export default async function createCheckout(req, res) {
     if (checkoutChannel) checkoutUrl.searchParams.set('channel', checkoutChannel);
     if (normalizedEmail) {
       checkoutUrl.searchParams.set('checkout[email]', normalizedEmail);
+    }
+    if (normalizedDiscount) {
+      checkoutUrl.searchParams.set('discount', normalizedDiscount);
     }
     const checkoutReturnToRaw = typeof process.env.SHOPIFY_CHECKOUT_RETURN_TO === 'string'
       ? process.env.SHOPIFY_CHECKOUT_RETURN_TO.trim()


### PR DESCRIPTION
## Summary
- persist discount codes from the URL/session and send them when creating carts or checkouts
- update Shopify cart and checkout handlers to append the discount query parameter to generated URLs
- prevent duplicate browser tabs when opening Shopify purchase links

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6b790f5a0832792d9e27379c00b96