### PR TITLE
Prevent canvas auto-centering on measure changes

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -1038,8 +1038,37 @@ const EditorCanvas = forwardRef(function EditorCanvas(
     });
   }, [material, wCm, hCm, workCm.w, workCm.h, imgBaseCm]);
 
+  const autoCenterStateRef = useRef({
+    wrapW: wrapSize.w,
+    wrapH: wrapSize.h,
+    workW: workCm.w,
+    workH: workCm.h,
+    base: baseScale,
+    material,
+  });
+
   useEffect(() => {
-    if (hasAdjustedViewRef.current) return;
+    const prev = autoCenterStateRef.current;
+    const wrapChanged = prev.wrapW !== wrapSize.w || prev.wrapH !== wrapSize.h;
+    const workChanged = prev.workW !== workCm.w || prev.workH !== workCm.h;
+    const baseChanged = prev.base !== baseScale;
+    const materialChanged = prev.material !== material;
+
+    autoCenterStateRef.current = {
+      wrapW: wrapSize.w,
+      wrapH: wrapSize.h,
+      workW: workCm.w,
+      workH: workCm.h,
+      base: baseScale,
+      material,
+    };
+
+    if (!wrapChanged && (workChanged || baseChanged || materialChanged)) {
+      return;
+    }
+
+    if (hasAdjustedViewRef.current && !wrapChanged) return;
+
     const stageW = workCm.w * baseScale;
     const stageH = workCm.h * baseScale;
     const targetX = (wrapSize.w - stageW) / 2;
@@ -1061,6 +1090,7 @@ const EditorCanvas = forwardRef(function EditorCanvas(
     workCm.h,
     imageUrl,
     imageFile,
+    material,
   ]);
 
   // calidad


### PR DESCRIPTION
## Summary
- track canvas auto-centering dependencies to detect when the wrap size changes versus a material or size change
- skip the auto-centering adjustment when only the selected material or measurements change so the view stays put

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6bdb4f0f08327b4845ec4489836ec