### PR TITLE
Fix add-to-cart flow with storefront polling

### DIFF
--- a/mgm-front/src/lib/cart.ts
+++ b/mgm-front/src/lib/cart.ts
@@ -4,84 +4,19 @@ export interface OpenCartOptions {
   focus?: boolean;
 }
 
-const CART_ADD_PATH = '/cart/add';
-
-function normalizePathname(path: string) {
-  return path.replace(/\/+$/, '') || '/';
-}
-
-function buildHiddenInput(name: string, value: string) {
-  const input = document.createElement('input');
-  input.type = 'hidden';
-  input.name = name;
-  input.value = value;
-  return input;
-}
-
-function submitCartForm(url: URL, target: string, popup?: Window | null, focus = true) {
-  if (typeof document === 'undefined' || typeof window === 'undefined') return false;
-  const form = document.createElement('form');
-  form.method = 'POST';
-  form.action = `${url.origin}${url.pathname}`;
-  form.enctype = 'application/x-www-form-urlencoded';
-  const params = new URLSearchParams(url.search);
-  if (!params.has('form_type')) params.set('form_type', 'product');
-  if (!params.has('utf8')) params.set('utf8', '✓');
-
-  params.forEach((value, key) => {
-    form.appendChild(buildHiddenInput(key, value));
-  });
-
-  // Ensure return_to defaults to home when missing
-  if (!params.has('return_to')) {
-    form.appendChild(buildHiddenInput('return_to', '/'));
-  }
-
-  let targetName = target;
-  let popupRef: Window | null = popup && !popup.closed ? popup : null;
-  if (targetName === '_blank') {
-    if (!popupRef) {
-      targetName = `mgm_cart_${Date.now()}`;
-      popupRef = window.open('', targetName, 'noopener');
-      if (!popupRef) {
-        targetName = '_self';
-      }
-    } else {
-      targetName = popupRef.name || targetName;
-    }
-  } else if (popupRef) {
-    targetName = popupRef.name || targetName || '_self';
-  }
-  if (!targetName) targetName = '_self';
-  form.target = targetName;
-  form.style.display = 'none';
-  document.body.appendChild(form);
-  form.submit();
-  window.setTimeout(() => {
-    form.remove();
-  }, 0);
-  if (popupRef && focus && typeof popupRef.focus === 'function') {
-    popupRef.focus();
-  }
-  return popupRef !== null || targetName === '_self';
-}
-
 export function openCartUrl(rawUrl: string, options?: OpenCartOptions): boolean {
   const target = options?.target ?? '_blank';
-  const popup = options?.popup && !options.popup.closed ? options.popup : null;
   const focus = options?.focus !== false;
   try {
     const parsed = new URL(rawUrl);
-    if (normalizePathname(parsed.pathname) === CART_ADD_PATH) {
-      const submitted = submitCartForm(parsed, target, popup, focus);
-      if (submitted) return true;
-    } else if (popup) {
+    const popup = options?.popup && !options.popup.closed ? options.popup : null;
+    if (popup) {
       try {
         popup.location.href = rawUrl;
         if (focus && typeof popup.focus === 'function') popup.focus();
         return true;
       } catch (err) {
-        // fall through to window.open
+        console.warn?.('[openCartUrl] popup_navigation_failed', err);
       }
     }
   } catch (err) {
@@ -89,5 +24,12 @@ export function openCartUrl(rawUrl: string, options?: OpenCartOptions): boolean 
   }
   const features = target === '_blank' ? 'noopener' : undefined;
   const win = window.open(rawUrl, target, features);
+  if (win && focus && typeof win.focus === 'function') {
+    try {
+      win.focus();
+    } catch (focusErr) {
+      console.warn?.('[openCartUrl] focus_failed', focusErr);
+    }
+  }
   return !!win;
 }

--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -1089,7 +1089,7 @@ export async function waitForVariantAvailability(
     } catch (logErr) {
       console.warn?.('[waitForVariantAvailability] env_log_failed', logErr);
     }
-    return { ready: true, timedOut: false, attempts: 0, lastResponse: null };
+    return { ready: true, available: true, timedOut: false, attempts: 0, lastResponse: null };
   }
   const { config } = configResult;
   const variantGid = buildVariantGid(numericVariant);
@@ -1128,13 +1128,13 @@ export async function waitForVariantAvailability(
       } catch (logErr) {
         console.warn?.('[waitForVariantAvailability] poll_log_failed', logErr);
       }
-      if (variantPresent) {
+      if (variantPresent && availableForSale) {
         try {
           console.info('[cart-flow] variant disponible en Storefront', { attempt, requestId });
         } catch (logErr) {
           console.warn?.('[waitForVariantAvailability] ready_log_failed', logErr);
         }
-        return { ready: true, timedOut: false, attempts: attempt, lastResponse: data };
+        return { ready: true, available: true, timedOut: false, attempts: attempt, lastResponse: data };
       }
       if (!response.ok || payload?.errors?.length) {
         console.warn('[waitForVariantAvailability] storefront response issue', {
@@ -1151,5 +1151,5 @@ export async function waitForVariantAvailability(
     await sleep(delay);
     delay = Math.min(delay * 2, maxDelayMs);
   }
-  return { ready: false, timedOut: true, attempts: attempt, lastResponse };
+  return { ready: false, available: false, timedOut: true, attempts: attempt, lastResponse };
 }

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -12,6 +12,7 @@ import {
   ONLINE_STORE_DISABLED_MESSAGE,
   ONLINE_STORE_MISSING_MESSAGE,
   ensureProductPublication,
+  waitForVariantAvailability,
 } from '@/lib/shopify.ts';
 
 const CART_STATUS_LABELS = {
@@ -199,7 +200,7 @@ export default function Mockup() {
   function openCartTab(url) {
     if (typeof window === 'undefined' || !url) return false;
     try {
-      const popup = window.open(url, '_blank');
+      const popup = window.open(url, '_blank', 'noopener');
       if (!popup) {
         return false;
       }
@@ -332,6 +333,60 @@ export default function Mockup() {
         }
       }
 
+      if (current.productId && current.variantId) {
+        try {
+          console.info('[cart-flow] wait_variant_start', {
+            productId: current.productId,
+            variantId: current.variantId,
+          });
+        } catch (logErr) {
+          console.debug?.('[cart-flow] wait_variant_start_log_failed', logErr);
+        }
+        try {
+          const pollResult = await waitForVariantAvailability(
+            current.variantId,
+            current.productId,
+            { timeoutMs: 15_000, initialDelayMs: 600, maxDelayMs: 2_000 },
+          );
+          try {
+            console.info('[cart-flow] wait_variant_result', {
+              productId: current.productId,
+              variantId: current.variantId,
+              ready: Boolean(pollResult?.ready),
+              available: pollResult?.available !== false,
+              timedOut: Boolean(pollResult?.timedOut),
+              attempts: Number.isFinite(pollResult?.attempts)
+                ? pollResult.attempts
+                : null,
+            });
+          } catch (logErr) {
+            console.debug?.('[cart-flow] wait_variant_result_log_failed', logErr);
+          }
+          if (!pollResult?.ready || pollResult?.available === false) {
+            setCartStatus('idle');
+            setBusy(false);
+            showCartFailureToast('');
+            return;
+          }
+        } catch (pollErr) {
+          console.error('[cart-flow] wait_variant_failed', pollErr);
+          setCartStatus('idle');
+          setBusy(false);
+          showCartFailureToast('');
+          return;
+        }
+      }
+      if (!current.productId || !current.variantId) {
+        try {
+          console.warn('[cart-flow] skip_variant_poll_missing_ids', {
+            productId: current.productId || null,
+            variantId: current.variantId || null,
+          });
+        } catch (logErr) {
+          console.debug?.('[cart-flow] skip_variant_poll_log_failed', logErr);
+        }
+      }
+
       let cartUrl = latestCartUrl || current?.webUrl || '';
       if (!cartUrl) {
         cartUrl = buildCartPermalink(
@@ -354,6 +409,16 @@ export default function Mockup() {
           webUrl: cartUrl,
         };
         setPendingCart(current);
+      }
+
+      try {
+        console.info('[cart-flow] open_cart_url', {
+          productId: current.productId || null,
+          variantId: current.variantId || null,
+          url: cartUrl,
+        });
+      } catch (logErr) {
+        console.debug?.('[cart-flow] open_cart_url_log_failed', logErr);
       }
 
       openCartAndFinalize(cartUrl);


### PR DESCRIPTION
## Summary
- wait for the Shopify variant to become available before opening the cart tab and add diagnostic logging
- open cart URLs with window.open noopener instead of submitting hidden forms
- require availableForSale in the variant availability helper so polling stops only when the variant is live

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6c2b6dffc8327a8ea7c942c57285a