### PR TITLE
Improve cart variant polling for Storefront add-to-cart

### DIFF
--- a/api/[...slug].js
+++ b/api/[...slug].js
@@ -19,6 +19,7 @@ const RATE_LIMITS = {
   'POST create-cart-link': { limit: 45, windowMs: 60_000 },
   'POST create-checkout': { limit: 45, windowMs: 60_000 },
   'POST ensure-product-publication': { limit: 30, windowMs: 60_000 },
+  'POST product-publication-status': { limit: 45, windowMs: 60_000 },
   'POST variant-status': { limit: 90, windowMs: 60_000 },
   'GET search-assets': { limit: 30, windowMs: 60_000 },
   'POST shopify-webhook': { limit: 60, windowMs: 60_000 },
@@ -60,6 +61,10 @@ export default withCors(async function handler(req, res) {
       }
       case 'POST ensure-product-publication': {
         const m = await import('../lib/handlers/ensureProductPublication.js');
+        return m.default(req, res);
+      }
+      case 'POST product-publication-status': {
+        const m = await import('../lib/handlers/productPublicationStatus.js');
         return m.default(req, res);
       }
       case 'POST variant-status': {

--- a/lib/handlers/productPublicationStatus.js
+++ b/lib/handlers/productPublicationStatus.js
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+import { parseJsonBody } from '../_lib/http.js';
+import { shopifyAdminGraphQL } from '../shopify.js';
+import { ensureProductGid } from '../shopify/publication.js';
+
+const BodySchema = z.object({
+  productId: z.union([z.string(), z.number()]),
+}).passthrough();
+
+const PRODUCT_PUBLICATION_QUERY = `query ProductPublicationStatus($id: ID!) {
+  product(id: $id) {
+    id
+    publishedOnCurrentPublication
+  }
+}`;
+
+export default async function productPublicationStatus(req, res) {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    return res.json({ ok: false, error: 'method_not_allowed' });
+  }
+  try {
+    const body = await parseJsonBody(req).catch((err) => {
+      if (err?.code === 'payload_too_large') {
+        if (typeof res.status === 'function') res.status(413); else res.statusCode = 413;
+        throw err;
+      }
+      if (err?.code === 'invalid_json') {
+        if (typeof res.status === 'function') res.status(400); else res.statusCode = 400;
+        throw err;
+      }
+      throw err;
+    });
+    const parsed = BodySchema.safeParse(body);
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: 'invalid_body', issues: parsed.error.flatten().fieldErrors });
+    }
+    const { productId } = parsed.data;
+    const productGid = ensureProductGid(productId);
+    if (!productGid) {
+      return res.status(400).json({ ok: false, error: 'invalid_product' });
+    }
+
+    const resp = await shopifyAdminGraphQL(PRODUCT_PUBLICATION_QUERY, { id: productGid });
+    const json = await resp.json().catch(() => null);
+    if (!resp.ok) {
+      return res.status(502).json({ ok: false, error: 'publication_status_failed', status: resp.status, detail: json });
+    }
+    if (Array.isArray(json?.errors) && json.errors.length) {
+      return res.status(502).json({ ok: false, error: 'publication_status_failed', detail: json.errors });
+    }
+    const product = json?.data?.product;
+    if (!product) {
+      return res.status(404).json({ ok: false, error: 'product_not_found' });
+    }
+
+    const published = product?.publishedOnCurrentPublication === true;
+
+    return res.status(200).json({
+      ok: true,
+      published,
+      productId: product.id || productGid,
+    });
+  } catch (err) {
+    if (res.statusCode === 413) {
+      return res.json({ ok: false, error: 'payload_too_large' });
+    }
+    if (res.statusCode === 400) {
+      return res.json({ ok: false, error: 'invalid_json' });
+    }
+    if (err?.message === 'SHOPIFY_ENV_MISSING') {
+      return res.status(400).json({ ok: false, error: 'shopify_env_missing', missing: err?.missing });
+    }
+    console.error('product_publication_status_error', err);
+    return res.status(500).json({ ok: false, error: 'product_publication_status_failed' });
+  }
+}


### PR DESCRIPTION
## Summary
- poll Shopify Storefront for variants via node(id) with publication context and deterministic backoff that logs each attempt
- add an admin-backed publication status endpoint and client helper to confirm availability before retrying
- open the public cart add URL in a new tab once the variant is available, preserving existing fallbacks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6cd39db74832796a1e8362c906a28