### PR TITLE
Use Storefront checkout for private purchases

### DIFF
--- a/lib/handlers/createCheckout.js
+++ b/lib/handlers/createCheckout.js
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { getPublicStorefrontBase } from '../publicStorefront.js';
-import { getShopifySalesChannel, shopifyAdmin } from '../shopify.js';
-import { parseJsonBody } from '../_lib/http.js';
+import { getShopifySalesChannel, shopifyStorefrontGraphQL } from '../shopify.js';
+import { parseJsonBody, getClientIp } from '../_lib/http.js';
 
 function normalizeVariantId(value) {
   if (value == null) return '';
@@ -38,80 +38,150 @@ function parseVariantNumericId(value) {
   return Math.floor(numeric);
 }
 
-async function createDraftOrderCheckout({ variantId, quantity, email, note, noteAttributes }) {
-  const numericVariantId = parseVariantNumericId(variantId);
-  if (!numericVariantId) {
+function buildVariantGid(value) {
+  const numeric = parseVariantNumericId(value);
+  if (!numeric) return '';
+  return `gid://shopify/ProductVariant/${numeric}`;
+}
+
+function normalizeCartNote(value) {
+  if (value == null) return '';
+  const raw = String(value).trim();
+  if (!raw) return '';
+  return raw.slice(0, 1000);
+}
+
+function collectAttributes({ noteAttributes, email }) {
+  const normalized = [];
+  const seen = new Set();
+  const push = (key, value) => {
+    if (!key || typeof key !== 'string') return;
+    const trimmedKey = key.trim();
+    if (!trimmedKey) return;
+    const dedupeKey = trimmedKey.toLowerCase();
+    if (seen.has(dedupeKey)) return;
+    seen.add(dedupeKey);
+    const stringValue = value == null ? '' : String(value).trim();
+    normalized.push({ key: trimmedKey.slice(0, 255), value: stringValue.slice(0, 255) });
+  };
+  push('mgm_source', 'editor');
+  if (email) {
+    push('customer_email', email);
+  }
+  if (Array.isArray(noteAttributes)) {
+    for (const attr of noteAttributes) {
+      if (!attr || typeof attr !== 'object') continue;
+      const nameRaw = typeof attr.name === 'string' ? attr.name : typeof attr.key === 'string' ? attr.key : '';
+      const valueRaw = typeof attr.value === 'string' ? attr.value : '';
+      push(nameRaw, valueRaw);
+      if (normalized.length >= 30) break;
+    }
+  }
+  return normalized;
+}
+
+const CART_CREATE_MUTATION = `
+  mutation CartCreate($input: CartInput!) {
+    cartCreate(input: $input) {
+      cart {
+        id
+        checkoutUrl
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+async function createStorefrontCheckout({ variantId, quantity, email, note, noteAttributes, buyerIp, discount }) {
+  const variantGid = buildVariantGid(variantId);
+  if (!variantGid) {
     return { ok: false, reason: 'invalid_variant' };
   }
 
-  const payload = {
-    draft_order: {
-      line_items: [
-        {
-          variant_id: numericVariantId,
-          quantity,
-        },
-      ],
-      use_customer_default_address: true,
-      tags: 'private, editor',
-    },
+  const input = {
+    lines: [
+      {
+        merchandiseId: variantGid,
+        quantity,
+      },
+    ],
   };
 
-  if (email) {
-    payload.draft_order.email = email;
+  const attributes = collectAttributes({ noteAttributes, email });
+  if (attributes.length) {
+    input.attributes = attributes;
   }
 
-  if (typeof note === 'string') {
-    const trimmedNote = note.trim();
-    if (trimmedNote) {
-      payload.draft_order.note = trimmedNote.slice(0, 1024);
+  const noteValue = normalizeCartNote(note);
+  if (noteValue) {
+    input.note = noteValue;
+  }
+
+  let response;
+  let text;
+  try {
+    response = await shopifyStorefrontGraphQL(CART_CREATE_MUTATION, { input }, buyerIp ? { buyerIp } : {});
+    text = await response.text();
+  } catch (err) {
+    if (err?.message === 'SHOPIFY_STOREFRONT_ENV_MISSING') {
+      return { ok: false, reason: 'storefront_env_missing', missing: err.missing };
     }
+    return { ok: false, reason: 'storefront_request_failed', error: err };
   }
 
-  const attributesList = Array.isArray(noteAttributes) ? noteAttributes : [];
-  const baseAttributes = [{ name: 'mgm_source', value: 'editor' }, ...attributesList];
-  const normalizedAttributes = [];
-  const seenNames = new Set();
-  for (const attr of baseAttributes) {
-    if (!attr || typeof attr.name !== 'string' || typeof attr.value !== 'string') continue;
-    const name = attr.name.trim();
-    const value = attr.value.trim();
-    if (!name || !value) continue;
-    if (seenNames.has(name)) continue;
-    seenNames.add(name);
-    normalizedAttributes.push({ name, value: value.slice(0, 255) });
-  }
-  if (normalizedAttributes.length) {
-    payload.draft_order.note_attributes = normalizedAttributes;
+  let json = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
   }
 
-  const resp = await shopifyAdmin('draft_orders.json', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-
-  const json = await resp.json().catch(() => null);
-  if (!resp.ok) {
-    return {
-      ok: false,
-      reason: 'draft_order_http_error',
-      status: resp.status,
-      detail: typeof json === 'object' ? json : undefined,
-    };
+  if (!response.ok) {
+    return { ok: false, reason: 'storefront_http_error', status: response.status, body: text?.slice(0, 2000) };
+  }
+  if (!json || typeof json !== 'object') {
+    return { ok: false, reason: 'invalid_response' };
+  }
+  if (Array.isArray(json.errors) && json.errors.length) {
+    return { ok: false, reason: 'graphql_errors', errors: json.errors };
+  }
+  const payload = json?.data?.cartCreate;
+  if (!payload || typeof payload !== 'object') {
+    return { ok: false, reason: 'invalid_response' };
+  }
+  const userErrors = Array.isArray(payload.userErrors)
+    ? payload.userErrors
+        .map((entry) => (entry && typeof entry.message === 'string' ? entry.message.trim() : ''))
+        .filter(Boolean)
+    : [];
+  if (userErrors.length) {
+    return { ok: false, reason: 'user_errors', userErrors };
+  }
+  const checkoutUrl = typeof payload?.cart?.checkoutUrl === 'string' ? payload.cart.checkoutUrl : '';
+  if (!checkoutUrl) {
+    return { ok: false, reason: 'missing_checkout_url' };
   }
 
-  const invoiceUrl = json?.draft_order?.invoice_url;
-  if (!invoiceUrl) {
-    return { ok: false, reason: 'missing_invoice_url', detail: json };
+  let finalUrl = checkoutUrl;
+  if (discount) {
+    try {
+      const checkoutUrlObj = new URL(finalUrl);
+      checkoutUrlObj.searchParams.set('discount', discount);
+      finalUrl = checkoutUrlObj.toString();
+    } catch {}
+  }
+  if (email) {
+    try {
+      const checkoutUrlObj = new URL(finalUrl);
+      checkoutUrlObj.searchParams.set('checkout[email]', email);
+      finalUrl = checkoutUrlObj.toString();
+    } catch {}
   }
 
-  return {
-    ok: true,
-    url: invoiceUrl,
-    draftOrderId: json?.draft_order?.id,
-    draftOrderName: json?.draft_order?.name,
-  };
+  return { ok: true, url: finalUrl };
 }
 
 export default async function createCheckout(req, res) {
@@ -152,35 +222,41 @@ export default async function createCheckout(req, res) {
       if (!normalizedEmail) {
         return res.status(400).json({ ok: false, error: 'missing_email' });
       }
-      try {
-        const draftCheckout = await createDraftOrderCheckout({
-          variantId: normalizedVariantId,
-          quantity: qty,
-          email: normalizedEmail,
-          note,
-          noteAttributes,
-        });
-        if (!draftCheckout?.ok || !draftCheckout?.url) {
+      const buyerIp = getClientIp(req);
+      const storefrontCheckout = await createStorefrontCheckout({
+        variantId: normalizedVariantId,
+        quantity: qty,
+        email: normalizedEmail,
+        note,
+        noteAttributes,
+        buyerIp,
+        discount: normalizedDiscount,
+      });
+      if (!storefrontCheckout?.ok || !storefrontCheckout?.url) {
+        if (storefrontCheckout?.missing) {
+          return res.status(400).json({ ok: false, error: 'shopify_env_missing', missing: storefrontCheckout.missing });
+        }
+        if (storefrontCheckout?.reason === 'user_errors') {
+          return res.status(400).json({ ok: false, error: 'storefront_user_errors', userErrors: storefrontCheckout.userErrors });
+        }
+        if (storefrontCheckout?.reason === 'graphql_errors') {
+          return res.status(502).json({ ok: false, error: 'storefront_graphql_errors', detail: storefrontCheckout.errors });
+        }
+        if (storefrontCheckout?.reason === 'storefront_http_error') {
           return res.status(502).json({
             ok: false,
-            error: draftCheckout?.reason || 'draft_order_failed',
-            detail: draftCheckout?.detail,
-            status: draftCheckout?.status,
+            error: 'storefront_http_error',
+            status: storefrontCheckout.status,
+            detail: storefrontCheckout.body,
           });
         }
-        return res.status(200).json({
-          ok: true,
-          url: draftCheckout.url,
-          draft_order_id: draftCheckout.draftOrderId,
-          draft_order_name: draftCheckout.draftOrderName,
+        return res.status(502).json({
+          ok: false,
+          error: storefrontCheckout?.reason || 'storefront_checkout_failed',
+          detail: storefrontCheckout?.error,
         });
-      } catch (err) {
-        if (err?.message === 'SHOPIFY_ENV_MISSING') {
-          return res.status(400).json({ ok: false, error: 'shopify_env_missing', missing: err?.missing });
-        }
-        console.error('create_checkout_draft_order_error', err);
-        return res.status(500).json({ ok: false, error: 'draft_order_failed' });
       }
+      return res.status(200).json({ ok: true, url: storefrontCheckout.url });
     }
 
     let checkoutUrl;


### PR DESCRIPTION
## Summary
- replace the private checkout draft order flow with a Storefront cart checkout so Shopify renders the online store coupon box
- carry over private order metadata via cart note and attributes while preserving existing behaviour for public checkouts
- surface Storefront-specific error details to help diagnose missing configuration or user errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6d02f18288327b08ebe4081023301