### PR TITLE
Fix Storefront polling to remove publication context

### DIFF
--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -327,20 +327,13 @@ export default function Mockup() {
       if (!current?.variantId) throw new Error('missing_variant');
 
       setCartStatus('adding');
-      let publicationId = typeof current?.publicationId === 'string' ? current.publicationId.trim() : '';
       if (!skipPublication && current.productId) {
         try {
           const ensureResult = await ensureProductPublication(current.productId);
-          const ensuredPublicationId = typeof ensureResult?.publicationId === 'string'
-            ? ensureResult.publicationId.trim()
-            : '';
-          if (ensuredPublicationId) {
-            publicationId = ensuredPublicationId;
-          }
-          if (publicationId && current.publicationId !== publicationId) {
+          if (ensureResult?.publicationId && ensureResult.publicationId !== current.publicationId) {
             current = {
               ...current,
-              publicationId,
+              publicationId: ensureResult.publicationId,
             };
             setPendingCart(current);
           }
@@ -359,19 +352,11 @@ export default function Mockup() {
           console.debug?.('[cart-flow] wait_variant_start_log_failed', logErr);
         }
         try {
-          const publicationIdForStorefront = typeof publicationId === 'string' && publicationId.trim()
-            ? publicationId.trim()
-            : typeof current.publicationId === 'string'
-              ? current.publicationId.trim()
-              : '';
-          const verifyPublication = publicationIdForStorefront
-            ? () => verifyProductPublicationStatus(current.productId)
-            : undefined;
+          const verifyPublication = () => verifyProductPublicationStatus(current.productId);
           const pollResult = await waitForVariantAvailability(
             current.variantId,
             current.productId,
             {
-              publicationId: publicationIdForStorefront,
               verifyProductPublication: verifyPublication,
             },
           );


### PR DESCRIPTION
## Summary
- drop publicationId usage from the Storefront variant polling query and surface GraphQL errors as retryable failures
- limit client storefront configuration to the public Shopify environment variables before issuing requests
- update the cart flow to await variant availability without passing publication context while still verifying publication status via the server

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6d236663c8327893571cac0cd4fef