### PR TITLE
Improve color picker visuals

### DIFF
--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -1,5 +1,5 @@
 .colorPickerWrapper {
-  --picker-scale: 0.5;
+  --picker-scale: 0.65;
   position: relative;
   display: inline-block;
   overflow: visible;
@@ -78,8 +78,8 @@
 }
 
 .colorPicker :global(.react-colorful__saturation-pointer) {
-  width: 16px;
-  height: 16px;
+  width: 22px;
+  height: 22px;
   border-radius: 999px;
   border: 2px solid #ffffff;
   box-shadow: 0 3px 8px rgba(0, 0, 0, 0.4);
@@ -87,9 +87,9 @@
 }
 
 .colorPicker :global(.react-colorful__hue) {
-  height: 12px;
-  border-radius: 0;
-  margin: 0;
+  height: 18px;
+  border-radius: 12px;
+  margin: 2px 0 0;
   width: 100%;
   border: none;
   box-shadow: none;
@@ -97,8 +97,8 @@
 }
 
 .colorPicker :global(.react-colorful__hue-pointer) {
-  width: 14px;
-  height: 14px;
+  width: 20px;
+  height: 20px;
   border-radius: 999px;
   border: 2px solid #ffffff;
   box-shadow: 0 3px 8px rgba(0, 0, 0, 0.4);
@@ -116,6 +116,7 @@
   height: 25px;
   display: block;
   object-fit: contain;
+  filter: brightness(0) invert(1);
 }
 
 .eyedropperFallback {


### PR DESCRIPTION
## Summary
- increase the color picker scale and enlarge hue controls for better usability
- ensure the eyedropper icon renders white to match the surrounding controls

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6d7c7c1208327aa3212090e919932