### PR TITLE
Align config form layout and update series select styling

### DIFF
--- a/mgm-front/src/components/SizeControls.jsx
+++ b/mgm-front/src/components/SizeControls.jsx
@@ -6,7 +6,6 @@ import { resolveIconAsset } from '../lib/iconRegistry.js';
 
 const WIDTH_ICON_SRC = resolveIconAsset('largo.svg');
 const HEIGHT_ICON_SRC = resolveIconAsset('ancho.svg');
-const DOWN_ICON_SRC = resolveIconAsset('down.svg');
 
 const INVALID_NUMBER_MESSAGE = 'Ingresá un número';
 const DIMENSION_MIN_CM = 1;
@@ -43,9 +42,9 @@ const formatDisplayValue = (value) => {
 };
 
 const MATERIAL_OPTIONS = [
-  { value: 'Glasspad', title: 'GLASSPAD', subtitle: 'speed' },
-  { value: 'PRO', title: 'PRO', subtitle: 'control' },
-  { value: 'Classic', title: 'CLASSIC', subtitle: 'híbrido' },
+  { value: 'Glasspad', main: 'GLASSPAD', variant: 'speed' },
+  { value: 'PRO', main: 'PRO', variant: 'control' },
+  { value: 'Classic', main: 'CLASSIC', variant: 'híbrido' },
 ];
 
 /**
@@ -326,12 +325,14 @@ export default function SizeControls({ material, size, onChange, locked = false,
 
   const containerClasses = [
     styles.container,
+    styles.fieldBlock,
     disabled ? styles.containerDisabled : '',
   ]
     .filter(Boolean)
     .join(' ');
   const inputControlClassName = [
     styles.inputControl,
+    styles.inputNumber,
     disabled ? styles.inputControlDisabled : '',
   ]
     .filter(Boolean)
@@ -340,9 +341,9 @@ export default function SizeControls({ material, size, onChange, locked = false,
   const activeMaterialOption = MATERIAL_OPTIONS.find((option) => option.value === material) || MATERIAL_OPTIONS[0];
   return (
     <div className={containerClasses} aria-disabled={disabled}>
-      <div className={styles.section}>
+      <div className={`${styles.section} ${styles.formRow}`}>
         <span className={styles.groupLabel}>Medidas (cm)</span>
-        <div className={styles.dimensionsRow}>
+        <div className={`${styles.dimensionsRow} ${styles.inputGroup}`}>
           <label className={styles.inputLabel}>
             <span className={styles.visuallyHidden}>Largo</span>
             <div className={inputControlClassName}>
@@ -357,7 +358,7 @@ export default function SizeControls({ material, size, onChange, locked = false,
               />
               <input
                 ref={wInputRef}
-                className={styles.input}
+                className={`${styles.input} ${styles.inputNumber}`}
                 value={isGlasspad ? GLASSPAD_SIZE_CM.w : wText}
                 onChange={!isGlasspad ? handleWChange : undefined}
                 onBlur={!isGlasspad ? handleWBlur : undefined}
@@ -389,7 +390,7 @@ export default function SizeControls({ material, size, onChange, locked = false,
               />
               <input
                 ref={hInputRef}
-                className={styles.input}
+                className={`${styles.input} ${styles.inputNumber}`}
                 value={isGlasspad ? GLASSPAD_SIZE_CM.h : hText}
                 onChange={!isGlasspad ? handleHChange : undefined}
                 onBlur={!isGlasspad ? handleHBlur : undefined}
@@ -410,7 +411,7 @@ export default function SizeControls({ material, size, onChange, locked = false,
         </div>
 
         {presets.length > 0 && (
-          <div className={styles.presets}>
+          <div className={`${styles.presets} ${styles.quickSizeChips}`}>
             {presets.map(p => (
               <button
                 key={`${p.w}x${p.h}`}
@@ -436,62 +437,40 @@ export default function SizeControls({ material, size, onChange, locked = false,
         )}
       </div>
 
-      <div className={`${styles.section} ${styles.seriesSection}`}>
+      <div className={`${styles.section} ${styles.seriesSection} ${styles.formRow}`}>
         <span className={styles.groupLabel}>Serie</span>
-        <div className={styles.seriesSelect} ref={seriesSelectRef}>
+        <div className={styles.selectGroup} ref={seriesSelectRef}>
           <button
             type="button"
-            className={[
-              styles.materialOption,
-              styles.seriesSelectTrigger,
-              disabled ? styles.materialOptionDisabled : '',
-            ].filter(Boolean).join(' ')}
+            className={styles.selectTrigger}
+            aria-haspopup="listbox"
+            aria-expanded={isSeriesOpen}
             onClick={() => {
               if (disabled) return;
               setSeriesOpen((prev) => !prev);
             }}
-            aria-haspopup="listbox"
-            aria-expanded={isSeriesOpen}
             disabled={disabled}
           >
-            <span className={styles.seriesSelectText}>
-              <span className={styles.materialOptionTitle}>{activeMaterialOption.title}</span>
-              <span className={styles.materialOptionSubtitle}>{activeMaterialOption.subtitle}</span>
+            <span className={styles.selectLabel}>
+              <strong className={styles.selectLabelStrong}>{activeMaterialOption.main}</strong>
+              <em className={styles.selectLabelSoft}>{activeMaterialOption.variant}</em>
             </span>
-            <img
-              src={DOWN_ICON_SRC}
-              alt=""
-              aria-hidden="true"
-              className={[
-                styles.seriesSelectIcon,
-                isSeriesOpen ? styles.seriesSelectIconOpen : '',
-              ].filter(Boolean).join(' ')}
-            />
+            <svg className={styles.selectChevron} viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor" strokeWidth="2" />
+            </svg>
           </button>
+
           {isSeriesOpen && (
-            <div
-              className={styles.seriesOptions}
-              role="listbox"
-              aria-activedescendant={`material-option-${activeMaterialOption.value}`}
-            >
+            <div role="listbox" className={styles.selectMenu}>
               {MATERIAL_OPTIONS.map((option) => {
                 const isActive = material === option.value;
-                const optionClassName = [
-                  styles.materialOption,
-                  styles.seriesOptionItem,
-                  isActive ? styles.materialOptionActive : '',
-                ]
-                  .filter(Boolean)
-                  .join(' ');
-
                 return (
-                  <button
-                    id={`material-option-${option.value}`}
-                    key={option.value}
-                    type="button"
+                  <div
                     role="option"
+                    key={option.value}
                     aria-selected={isActive}
-                    className={optionClassName}
+                    className={styles.selectOption}
+                    tabIndex={0}
                     onClick={() => {
                       if (disabled) return;
                       setSeriesOpen(false);
@@ -499,10 +478,22 @@ export default function SizeControls({ material, size, onChange, locked = false,
                         onChange({ material: option.value });
                       }
                     }}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        if (disabled) return;
+                        setSeriesOpen(false);
+                        if (option.value !== material) {
+                          onChange({ material: option.value });
+                        }
+                      }
+                    }}
                   >
-                    <span className={styles.materialOptionTitle}>{option.title}</span>
-                    <span className={styles.materialOptionSubtitle}>{option.subtitle}</span>
-                  </button>
+                    <span className={styles.selectLabel}>
+                      <strong className={styles.selectLabelStrong}>{option.main}</strong>
+                      <em className={styles.selectLabelSoft}>{option.variant}</em>
+                    </span>
+                  </div>
                 );
               })}
             </div>

--- a/mgm-front/src/components/SizeControls.module.css
+++ b/mgm-front/src/components/SizeControls.module.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
+  inline-size: 100%;
 }
 
 .containerDisabled {
@@ -12,6 +13,15 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.fieldBlock {
+  inline-size: 100%;
+}
+
+.formRow,
+.inputGroup {
+  inline-size: 100%;
 }
 
 .groupLabel {
@@ -30,6 +40,7 @@
 .inputLabel {
   flex: 1;
   display: block;
+  inline-size: 100%;
 }
 
 .inputControl {
@@ -47,6 +58,10 @@
   border-color: rgba(255, 255, 255, 0.08);
   background: rgba(24, 24, 28, 0.6);
   box-shadow: none;
+}
+
+.inputNumber {
+  inline-size: 100%;
 }
 
 .input {
@@ -93,6 +108,11 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  inline-size: 100%;
+}
+
+.quickSizeChips {
+  inline-size: 100%;
 }
 
 .presetButton {
@@ -129,100 +149,116 @@
   gap: 12px;
 }
 
-.seriesSelect {
+.selectGroup {
   position: relative;
+  inline-size: 100%;
 }
 
-.seriesSelectText {
+.selectTrigger {
   display: flex;
-  flex-direction: row;
-  align-items: baseline;
-  gap: 8px;
-  flex-wrap: nowrap;
-}
-
-.seriesSelectIcon {
-  width: 20px;
-  height: 20px;
-  flex-shrink: 0;
-  transition: transform 0.2s ease;
-}
-
-.seriesSelectIconOpen {
-  transform: rotate(180deg);
-}
-
-.seriesOptions {
-  position: absolute;
-  top: calc(100% + 8px);
-  left: 0;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 8px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(18, 18, 22, 0.95);
-  box-shadow: 0 18px 36px rgba(8, 8, 12, 0.45);
-  backdrop-filter: blur(8px);
-  z-index: 10;
-}
-
-.seriesOptionItem {
-  width: 100%;
-}
-
-.materialOption {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  width: 100%;
-  padding: 14px 18px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(28, 28, 32, 0.6);
-  color: #f4f5f7;
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
-}
-
-.materialOption:hover:not(:disabled) {
-  border-color: rgba(99, 102, 241, 0.7);
-  background: rgba(40, 40, 46, 0.7);
-  transform: translateY(-1px);
-}
-
-.materialOptionActive {
-  border-color: #5a7bff;
-  background: rgba(60, 68, 112, 0.65);
-  box-shadow: 0 0 0 1px rgba(90, 123, 255, 0.3);
-}
-
-.materialOptionDisabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-.seriesSelectTrigger {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  inline-size: 100%;
+  min-block-size: 56px;
+  padding: 14px 18px;
+  border-radius: 12px;
+  border: 1px solid rgba(128, 128, 128, 0.28);
+  background: linear-gradient(90deg, rgba(24, 24, 24, 0.92), rgba(24, 24, 24, 0.86));
+  color: #f6f7fb;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.22s ease, box-shadow 0.22s ease, transform 0.22s ease;
 }
 
-.materialOptionTitle {
-  font-size: 0.95rem;
+.selectTrigger:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.selectLabel {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 16px;
+  letter-spacing: 0.01em;
+  color: #f6f7fb;
+}
+
+.selectLabelStrong {
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 
-.materialOptionSubtitle {
-  text-transform: lowercase;
-  font-size: 0.8rem;
-  letter-spacing: 0.04em;
-  color: rgba(207, 212, 226, 0.85);
-  font-weight: 600;
+.selectLabelSoft {
+  font-style: italic;
+  opacity: 0.9;
+}
+
+.selectChevron {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  color: #e7e5e4;
+  transition: transform 0.18s ease;
+}
+
+.selectTrigger:hover:not(:disabled) {
+  border-color: rgba(200, 200, 200, 0.45);
+  transform: translateY(-1px);
+  box-shadow: 0 0 0 1px rgba(200, 200, 200, 0.06) inset;
+}
+
+.selectTrigger[aria-expanded='true'] .selectChevron {
+  transform: rotate(180deg);
+}
+
+.selectTrigger:focus-visible {
+  outline: 2px solid #79c0ff66;
+  outline-offset: 3px;
+}
+
+.selectMenu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 8px;
+  inline-size: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(128, 128, 128, 0.28);
+  background: #1c1c1f;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+  z-index: 20;
+}
+
+.selectOption {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px 16px;
+  color: #f3f4f6;
+  cursor: pointer;
+  transition: background-color 0.18s ease;
+}
+
+.selectOption:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.selectOption[aria-selected='true'] {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+@media (max-width: 480px) {
+  .selectTrigger {
+    min-block-size: 52px;
+    padding: 12px 14px;
+  }
+
+  .selectLabel {
+    font-size: 15px;
+  }
 }

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -452,6 +452,7 @@ export default function Home() {
 
   const designNameInputClasses = [
     styles.textInput,
+    styles.inputText,
     designNameError ? styles.textInputError : '',
   ]
     .filter(Boolean)
@@ -739,38 +740,42 @@ export default function Home() {
           style={configPanelStyle}
           role="menu"
         >
-          <div className={styles.field}>
-            <label className={styles.fieldLabel} htmlFor="design-name">
-              Nombre de tu diseño
-            </label>
-            <input
-              type="text"
-              id="design-name"
-              ref={designNameInputRef}
-              className={designNameInputClasses}
-              placeholder="Ej: Nubes y cielo rosa"
-              value={designName}
-              onChange={handleDesignNameChange}
-              disabled={!hasImage}
-              aria-invalid={designNameError ? 'true' : 'false'}
-              aria-describedby={
-                designNameError ? 'design-name-error' : undefined
-              }
-            />
-            {designNameError && (
-              <p className={styles.fieldError} id="design-name-error">
-                {designNameError}
-              </p>
-            )}
+          <div className={styles.configForm}>
+            <div className={`${styles.field} ${styles.formRow}`}>
+              <label className={styles.fieldLabel} htmlFor="design-name">
+                Nombre de tu diseño
+              </label>
+              <input
+                type="text"
+                id="design-name"
+                ref={designNameInputRef}
+                className={designNameInputClasses}
+                placeholder="Ej: Nubes y cielo rosa"
+                value={designName}
+                onChange={handleDesignNameChange}
+                disabled={!hasImage}
+                aria-invalid={designNameError ? 'true' : 'false'}
+                aria-describedby={
+                  designNameError ? 'design-name-error' : undefined
+                }
+              />
+              {designNameError && (
+                <p className={styles.fieldError} id="design-name-error">
+                  {designNameError}
+                </p>
+              )}
+            </div>
+            <div className={styles.fieldBlock}>
+              <SizeControls
+                material={material}
+                size={size}
+                mode={mode}
+                onChange={handleSizeChange}
+                locked={material === 'Glasspad'}
+                disabled={!hasImage}
+              />
+            </div>
           </div>
-          <SizeControls
-            material={material}
-            size={size}
-            mode={mode}
-            onChange={handleSizeChange}
-            locked={material === 'Glasspad'}
-            disabled={!hasImage}
-          />
         </div>
       )}
     </div>

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -268,6 +268,27 @@
   gap: 12px;
 }
 
+.configForm {
+  inline-size: min(100%, 720px);
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.formRow,
+.fieldBlock,
+.inputGroup,
+.selectGroup {
+  inline-size: 100%;
+}
+
+.inputText,
+.inputNumber,
+.quickSizeChips {
+  inline-size: 100%;
+}
+
 .fieldLabel {
   font-size: 0.75rem;
   text-transform: uppercase;


### PR DESCRIPTION
## Summary
- center the configuration form content within a 720px container so each field spans the same width
- update size controls markup to use full-width rows and adopt the new select trigger/menu structure
- restyle the series dropdown trigger and menu to match the requested pill design and typography

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6dbcfa0148327817b716dda21f2c7