### PR TITLE
Adjust mobile header and canvas continue button

### DIFF
--- a/mgm-front/src/App.module.css
+++ b/mgm-front/src/App.module.css
@@ -46,3 +46,29 @@
 
 ._brand_1doot_43{font-size: 28px;}
 
+@media (max-width: 640px) {
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 12px;
+    flex-wrap: nowrap;
+  }
+
+  .header .brand,
+  .header span {
+    white-space: nowrap;
+  }
+
+  .brand {
+    font-size: clamp(16px, 4.2vw, 20px) !important;
+  }
+
+  .header span {
+    font-size: clamp(16px, 4.2vw, 20px) !important;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+  }
+}
+

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -799,4 +799,33 @@
     width: min(360px, 100%);
     padding: 20px 24px;
   }
+
+  .canvasAck {
+    position: static;
+    right: auto;
+    bottom: auto;
+    width: 100%;
+    max-width: none;
+    margin-top: 16px;
+  }
+
+  .canvasFeedback {
+    position: static;
+    left: auto;
+    right: auto;
+    bottom: auto;
+    justify-content: flex-start;
+    padding-right: 0;
+    width: 100%;
+    margin-top: 12px;
+  }
+
+  .canvasContinue {
+    position: static;
+    right: auto;
+    bottom: auto;
+    width: 100%;
+    max-width: none;
+    margin-top: 16px;
+  }
 }


### PR DESCRIPTION
## Summary
- keep the MGM GAMERS® | EDITOR header on a single line on small screens with responsive typography
- reposition the canvas acknowledgement, errors, and Continue button below the canvas for the mobile layout

## Testing
- not run (CSS-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d6ddb08218832781fa480d2ddb1075