### PR TITLE
Implement floating portal menu for series selector

### DIFF
--- a/mgm-front/src/components/SizeControls.module.css
+++ b/mgm-front/src/components/SizeControls.module.css
@@ -219,18 +219,15 @@
   outline-offset: 3px;
 }
 
-.selectMenu {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  margin-top: 8px;
-  inline-size: 100%;
+.selectMenuFloating {
+  position: fixed;
+  z-index: 3000;
   border-radius: 12px;
   border: 1px solid rgba(128, 128, 128, 0.28);
   background: #1c1c1f;
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
-  overflow: hidden;
-  z-index: 20;
+  overflow: auto;
+  max-height: min(320px, 70vh);
 }
 
 .selectOption {

--- a/mgm-front/src/hooks/useFloatingMenu.js
+++ b/mgm-front/src/hooks/useFloatingMenu.js
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+
+const GAP = 8;
+const ESTIMATED_MENU_HEIGHT = 3 * 48 + 16 + 2;
+const MIN_VIEWPORT_PADDING = 8;
+
+export function useFloatingMenu(triggerRef, isOpen) {
+  const [style, setStyle] = useState({});
+
+  useEffect(() => {
+    if (!isOpen) {
+      setStyle({});
+      return undefined;
+    }
+
+    function positionMenu() {
+      const triggerEl = triggerRef.current;
+      if (!triggerEl) return;
+      const rect = triggerEl.getBoundingClientRect();
+      const width = Math.round(rect.width);
+
+      let left = rect.left;
+      let top = rect.bottom + GAP;
+
+      let menuHeight = ESTIMATED_MENU_HEIGHT;
+      const controlsId = triggerEl.getAttribute('aria-controls');
+      if (controlsId) {
+        const menuEl = document.getElementById(controlsId);
+        if (menuEl) {
+          menuHeight = menuEl.offsetHeight || menuHeight;
+        }
+      }
+
+      const fitsBelow = top + menuHeight <= window.innerHeight - MIN_VIEWPORT_PADDING;
+      if (!fitsBelow) {
+        top = Math.max(
+          MIN_VIEWPORT_PADDING,
+          rect.top - GAP - menuHeight,
+        );
+      }
+
+      const maxLeft = window.innerWidth - width - MIN_VIEWPORT_PADDING;
+      left = Math.max(MIN_VIEWPORT_PADDING, Math.min(left, maxLeft));
+
+      setStyle({
+        position: 'fixed',
+        top,
+        left,
+        width,
+        minWidth: width,
+      });
+    }
+
+    positionMenu();
+    const raf = requestAnimationFrame(positionMenu);
+    const handleScroll = () => positionMenu();
+    const handleResize = () => positionMenu();
+
+    window.addEventListener('scroll', handleScroll, true);
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('scroll', handleScroll, true);
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [triggerRef, isOpen]);
+
+  return style;
+}


### PR DESCRIPTION
## Summary
- add a reusable `useFloatingMenu` hook to position floating menus with viewport-aware flipping
- render the Serie selector menu through a portal with fixed positioning, outside/keyboard dismissal, and accessibility attributes
- update the select menu styles for the new floating overlay presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6de48629c8327ac072a2861f74496