### PR TITLE
Improve Shopify cart creation flow

### DIFF
--- a/lib/handlers/createCartLink.js
+++ b/lib/handlers/createCartLink.js
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 import { getPublicStorefrontBase } from '../publicStorefront.js';
-import { getShopifySalesChannel, shopifyStorefrontGraphQL } from '../shopify.js';
+import { shopifyStorefrontGraphQL } from '../shopify.js';
 import { parseJsonBody, getClientIp } from '../_lib/http.js';
 import getSupabaseAdmin from '../_lib/supabaseAdmin.js';
 
-function normalizeVariantId(value) {
+function normalizeVariantNumericId(value) {
   if (value == null) return '';
   const raw = String(value).trim();
   if (!raw) return '';
@@ -24,26 +24,6 @@ function ensureVariantGid(preferred, fallback, numericId) {
     return `gid://shopify/ProductVariant/${numericId}`;
   }
   return '';
-}
-
-function sanitizeReturnTarget(value) {
-  if (!value || typeof value !== 'string') return '';
-  const trimmed = value.trim();
-  if (!trimmed || /checkout/i.test(trimmed)) return '';
-  return trimmed;
-}
-
-function normalizeAbsolute(value, base) {
-  const sanitized = sanitizeReturnTarget(value);
-  if (!sanitized) return '';
-  if (/^https?:\/\//i.test(sanitized)) return sanitized;
-  if (!base) return sanitized;
-  try {
-    const url = new URL(sanitized, base);
-    return url.toString();
-  } catch {
-    return sanitized;
-  }
 }
 
 function normalizeAttributeEntry(entry) {
@@ -131,95 +111,102 @@ async function fetchJobForCart(jobId) {
   return { ok: true, job: data };
 }
 
-const JobIdSchema = z
-  .string()
-  .trim()
-  .min(8, 'job_id must be at least 8 characters')
-  .max(64, 'job_id too long')
-  .regex(/^[A-Za-z0-9_-]+$/, 'job_id has invalid characters');
+function buildCartPermalink(variantNumericId, quantity) {
+  if (!variantNumericId) return '';
+  const qty = Number.isFinite(quantity) ? Math.max(1, Math.floor(quantity)) : 1;
+  return `https://www.mgmgamers.store/cart/${variantNumericId}:${qty}?return_to=/cart`;
+}
 
-function buildLegacyCartPayload(base, variantId, qty, discountCode) {
-  const buildUrl = (path) => {
-    try {
-      return new URL(path, base);
-    } catch (err) {
-      try { console.error('create_cart_link_url_error', err); } catch {}
-      return null;
-    }
-  };
+const PRECHECK_DELAYS = [0, 600, 1200, 2000, 2000];
 
-  const cartAddUrl = buildUrl('/cart/add');
-  if (!cartAddUrl) return null;
-  cartAddUrl.searchParams.set('id', variantId);
-  cartAddUrl.searchParams.set('quantity', String(qty));
-  const cartChannel = getShopifySalesChannel('cart');
-  if (cartChannel) cartAddUrl.searchParams.set('channel', cartChannel);
-  if (discountCode) {
-    cartAddUrl.searchParams.set('discount', discountCode);
-  }
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
-  const homeUrl = buildUrl('/');
-  const cartPlainUrl = buildUrl('/cart');
-  const cartPlainString = cartPlainUrl ? cartPlainUrl.toString() : '';
-  const checkoutPlainUrl = buildUrl('/checkout');
+function readRequestId(resp) {
+  if (!resp || typeof resp.headers?.get !== 'function') return '';
+  return (
+    resp.headers.get('x-request-id') ||
+    resp.headers.get('x-requestid') ||
+    resp.headers.get('X-Request-ID') ||
+    resp.headers.get('X-RequestId') ||
+    ''
+  );
+}
 
-  let mgmHome = '';
-  try {
-    const baseUrl = new URL(base);
-    if (/mgmgamers/i.test(baseUrl.hostname)) {
-      mgmHome = normalizeAbsolute('https://www.mgmgamers.store/', base);
-    }
-  } catch {
-    mgmHome = normalizeAbsolute('https://www.mgmgamers.store/', base);
-  }
-
-  const mgmCart = mgmHome
-    ? normalizeAbsolute(`${mgmHome.replace(/\/$/, '')}/cart`, base)
-    : '';
-
-  const candidates = [
-    normalizeAbsolute(process.env.SHOPIFY_CART_RETURN_TO, base),
-    mgmCart,
-    cartPlainString,
-    normalizeAbsolute(process.env.SHOPIFY_HOME_URL, base),
-    mgmHome,
-    homeUrl ? homeUrl.toString() : '',
-    (() => {
-      try {
-        return new URL('/', base).toString();
-      } catch {
-        return '';
+const VARIANT_AVAILABILITY_QUERY = `
+  query VariantAvailability($id: ID!) {
+    node(id: $id) {
+      ... on ProductVariant {
+        id
+        availableForSale
       }
-    })(),
-    '/',
-  ];
-  const returnTarget = candidates.find((value) => sanitizeReturnTarget(value)) || '/';
-  if (returnTarget) {
-    cartAddUrl.searchParams.set('return_to', returnTarget);
-  }
-
-  const checkoutNowUrl = buildUrl(`/cart/${variantId}:${qty}`);
-  if (checkoutNowUrl) {
-    const checkoutChannel = getShopifySalesChannel('checkout');
-    if (checkoutChannel) checkoutNowUrl.searchParams.set('channel', checkoutChannel);
-    const checkoutReturnToRaw = typeof process.env.SHOPIFY_CHECKOUT_RETURN_TO === 'string'
-      ? process.env.SHOPIFY_CHECKOUT_RETURN_TO.trim()
-      : '';
-    const checkoutReturnTo = checkoutReturnToRaw || '/checkout';
-    if (checkoutReturnTo) {
-      checkoutNowUrl.searchParams.set('return_to', checkoutReturnTo);
-    }
-    if (discountCode) {
-      checkoutNowUrl.searchParams.set('discount', discountCode);
     }
   }
+`;
 
+async function precheckVariantAvailability(variantGid, { maxAttempts = 3 } = {}) {
+  if (!variantGid) {
+    return { ok: false, reason: 'missing_variant_gid', attempts: 0 };
+  }
+  let attempts = 0;
+  let lastReason = 'unknown';
+  let lastStatus;
+  let lastRequestId = '';
+  for (let i = 0; i < maxAttempts; i += 1) {
+    if (i > 0) {
+      const delay = PRECHECK_DELAYS[Math.min(i, PRECHECK_DELAYS.length - 1)] || 600;
+      await sleep(delay);
+    }
+    attempts += 1;
+    let resp;
+    try {
+      resp = await shopifyStorefrontGraphQL(VARIANT_AVAILABILITY_QUERY, { id: variantGid });
+    } catch (err) {
+      if (err?.message === 'SHOPIFY_STOREFRONT_ENV_MISSING') {
+        return { ok: false, reason: 'storefront_env_missing', attempts, missing: err.missing };
+      }
+      throw err;
+    }
+    const requestId = readRequestId(resp);
+    lastRequestId = requestId || lastRequestId;
+    const text = await resp.text();
+    let json;
+    try {
+      json = text ? JSON.parse(text) : null;
+    } catch {
+      json = null;
+    }
+    if (!resp.ok) {
+      lastReason = 'http_error';
+      lastStatus = resp.status;
+      continue;
+    }
+    if (!json || typeof json !== 'object') {
+      lastReason = 'invalid_response';
+      continue;
+    }
+    if (Array.isArray(json.errors) && json.errors.length) {
+      lastReason = 'graphql_errors';
+      continue;
+    }
+    const node = json?.data?.node;
+    if (!node) {
+      lastReason = 'not_found';
+      continue;
+    }
+    if (node.availableForSale !== false) {
+      return { ok: true, available: true, attempts, requestId };
+    }
+    lastReason = 'not_available';
+  }
   return {
-    cartUrl: cartAddUrl.toString(),
-    cartUrlFollow: cartAddUrl.toString(),
-    cartPlain: cartPlainString || undefined,
-    checkoutUrlNow: checkoutNowUrl ? checkoutNowUrl.toString() : undefined,
-    checkoutPlain: checkoutPlainUrl ? checkoutPlainUrl.toString() : undefined,
+    ok: false,
+    available: false,
+    attempts,
+    reason: lastReason,
+    status: lastStatus,
+    requestId: lastRequestId || undefined,
   };
 }
 
@@ -233,20 +220,62 @@ const CART_CREATE_MUTATION = `
       userErrors {
         field
         message
+        code
       }
     }
   }
 `;
 
-async function tryCreateStorefrontCart({
-  base,
-  variantGid,
-  quantity,
-  buyerIp,
-  attributes,
-  note,
-  discountCode,
-}) {
+function buildStorefrontUrls({ cartId, checkoutUrl }) {
+  if (!cartId) return {};
+  const token = String(cartId).split('/').pop();
+  if (!token) return {};
+  const candidates = [];
+  if (typeof checkoutUrl === 'string' && checkoutUrl.trim()) {
+    try {
+      const parsed = new URL(checkoutUrl);
+      const origin = `${parsed.protocol}//${parsed.host}`;
+      candidates.push(origin);
+      return {
+        cartUrl: `${origin}/cart/c/${token}`,
+        checkoutUrl,
+        cartPlain: `${origin}/cart`,
+        checkoutPlain: `${origin}/checkout`,
+        cartToken: token,
+      };
+    } catch {
+      // ignore
+    }
+  }
+  const base = getPublicStorefrontBase();
+  if (base) {
+    const normalized = base.replace(/\/$/, '');
+    candidates.push(normalized);
+    return {
+      cartUrl: `${normalized}/cart/c/${token}`,
+      checkoutUrl,
+      cartPlain: `${normalized}/cart`,
+      checkoutPlain: `${normalized}/checkout`,
+      cartToken: token,
+    };
+  }
+  return { cartToken: token };
+}
+
+const DEFAULT_COUNTRY_CODE = typeof process.env.SHOPIFY_CART_COUNTRY_CODE === 'string'
+  ? process.env.SHOPIFY_CART_COUNTRY_CODE.trim() || 'AR'
+  : 'AR';
+
+const DEFAULT_PRESENTMENT = (() => {
+  const envValue = typeof process.env.SHOPIFY_CART_PRESENTMENT_CURRENCY === 'string'
+    ? process.env.SHOPIFY_CART_PRESENTMENT_CURRENCY.trim()
+    : '';
+  if (envValue) return envValue;
+  if (DEFAULT_COUNTRY_CODE === 'AR') return 'ARS';
+  return '';
+})();
+
+async function createStorefrontCart({ variantGid, quantity, buyerIp, attributes, note }) {
   if (!variantGid) {
     return { ok: false, reason: 'missing_variant_gid' };
   }
@@ -257,7 +286,13 @@ async function tryCreateStorefrontCart({
         quantity,
       },
     ],
+    buyerIdentity: {
+      countryCode: DEFAULT_COUNTRY_CODE,
+    },
   };
+  if (DEFAULT_PRESENTMENT) {
+    input.presentmentCurrencyCode = DEFAULT_PRESENTMENT;
+  }
   const mergedAttributes = mergeAttributes(attributes);
   if (mergedAttributes.length) {
     input.attributes = mergedAttributes;
@@ -266,83 +301,81 @@ async function tryCreateStorefrontCart({
   if (noteValue) {
     input.note = noteValue;
   }
-
+  let resp;
   try {
-    const resp = await shopifyStorefrontGraphQL(
+    resp = await shopifyStorefrontGraphQL(
       CART_CREATE_MUTATION,
       { input },
       { buyerIp },
     );
-    const text = await resp.text();
-    let json;
-    try {
-      json = text ? JSON.parse(text) : null;
-    } catch {
-      json = null;
-    }
-    if (!resp.ok) {
-      return { ok: false, reason: 'http_error', status: resp.status, body: text?.slice(0, 2000) };
-    }
-    if (!json || typeof json !== 'object') {
-      return { ok: false, reason: 'invalid_response' };
-    }
-    if (Array.isArray(json.errors) && json.errors.length) {
-      return { ok: false, reason: 'graphql_errors', errors: json.errors };
-    }
-    const cartCreate = json?.data?.cartCreate;
-    if (!cartCreate || typeof cartCreate !== 'object') {
-      return { ok: false, reason: 'invalid_response' };
-    }
-    const userErrors = Array.isArray(cartCreate.userErrors)
-      ? cartCreate.userErrors.filter((err) => err && typeof err.message === 'string' && err.message.trim())
-      : [];
-    if (userErrors.length) {
-      return { ok: false, reason: 'user_errors', userErrors };
-    }
-    const cart = cartCreate.cart;
-    if (!cart || typeof cart !== 'object' || !cart.id) {
-      return { ok: false, reason: 'missing_cart' };
-    }
-    const token = String(cart.id).split('/').pop();
-    if (!token) {
-      return { ok: false, reason: 'missing_cart_token' };
-    }
-    const baseUrl = base.replace(/\/$/, '');
-    let cartUrl = `${baseUrl}/cart/c/${token}`;
-    if (discountCode) {
-      try {
-        const cartUrlObj = new URL(cartUrl);
-        cartUrlObj.searchParams.set('discount', discountCode);
-        cartUrl = cartUrlObj.toString();
-      } catch {}
-    }
-    return {
-      ok: true,
-      cartUrl,
-      cartUrlFollow: cartUrl,
-      cartPlain: `${baseUrl}/cart`,
-      checkoutUrlNow: (() => {
-        if (typeof cart.checkoutUrl !== 'string' || !cart.checkoutUrl) return undefined;
-        if (!discountCode) return cart.checkoutUrl;
-        try {
-          const checkoutUrlObj = new URL(cart.checkoutUrl);
-          checkoutUrlObj.searchParams.set('discount', discountCode);
-          return checkoutUrlObj.toString();
-        } catch {
-          return cart.checkoutUrl;
-        }
-      })(),
-      checkoutPlain: `${baseUrl}/checkout`,
-      cartId: cart.id,
-      cartToken: token,
-    };
   } catch (err) {
     if (err?.message === 'SHOPIFY_STOREFRONT_ENV_MISSING') {
       return { ok: false, reason: 'storefront_env_missing', missing: err.missing };
     }
-    return { ok: false, reason: 'exception', error: err };
+    throw err;
   }
+  const requestId = readRequestId(resp);
+  const text = await resp.text();
+  let json;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+  if (!resp.ok) {
+    return { ok: false, reason: 'http_error', status: resp.status, body: text?.slice(0, 2000), requestId };
+  }
+  if (!json || typeof json !== 'object') {
+    return { ok: false, reason: 'invalid_response', requestId };
+  }
+  if (Array.isArray(json.errors) && json.errors.length) {
+    return { ok: false, reason: 'graphql_errors', errors: json.errors, requestId };
+  }
+  const cartCreate = json?.data?.cartCreate;
+  if (!cartCreate || typeof cartCreate !== 'object') {
+    return { ok: false, reason: 'invalid_response', requestId };
+  }
+  const userErrors = Array.isArray(cartCreate.userErrors)
+    ? cartCreate.userErrors
+        .map((err) => {
+          if (!err || typeof err !== 'object') return null;
+          const message = typeof err.message === 'string' ? err.message.trim() : '';
+          if (!message) return null;
+          const code = typeof err.code === 'string' ? err.code : undefined;
+          const field = Array.isArray(err.field) ? err.field.map((item) => String(item)).filter(Boolean) : undefined;
+          return { message, ...(code ? { code } : {}), ...(field && field.length ? { field } : {}) };
+        })
+        .filter(Boolean)
+    : [];
+  if (userErrors.length) {
+    return { ok: false, reason: 'user_errors', userErrors, requestId };
+  }
+  const cart = cartCreate.cart;
+  if (!cart || typeof cart !== 'object' || !cart.id) {
+    return { ok: false, reason: 'missing_cart', requestId };
+  }
+  const urls = buildStorefrontUrls({ cartId: cart.id, checkoutUrl: cart.checkoutUrl });
+  if (!urls.cartUrl) {
+    return { ok: false, reason: 'missing_cart_url', requestId };
+  }
+  return {
+    ok: true,
+    cartUrl: urls.cartUrl,
+    checkoutUrl: urls.checkoutUrl,
+    cartPlain: urls.cartPlain,
+    checkoutPlain: urls.checkoutPlain,
+    cartId: cart.id,
+    cartToken: urls.cartToken,
+    requestId,
+  };
 }
+
+const JobIdSchema = z
+  .string()
+  .trim()
+  .min(8, 'job_id must be at least 8 characters')
+  .max(64, 'job_id too long')
+  .regex(/^[A-Za-z0-9_-]+$/, 'job_id has invalid characters');
 
 const BodySchema = z
   .object({
@@ -357,6 +390,32 @@ const BodySchema = z
     discount: z.string().optional(),
   })
   .passthrough();
+
+function respondWithPermalink(res, { variantNumericId, quantity, reason, requestId, userErrors }) {
+  const webUrl = buildCartPermalink(variantNumericId, quantity);
+  const cartPlain = 'https://www.mgmgamers.store/cart';
+  const checkoutPlain = 'https://www.mgmgamers.store/checkout';
+  try {
+    console.warn('[create-cart-link] fallback_permalink', {
+      variantNumericId,
+      reason,
+      requestId: requestId || null,
+      userErrors: userErrors && userErrors.length ? userErrors : undefined,
+    });
+  } catch {}
+  return res.status(200).json({
+    ok: true,
+    webUrl,
+    url: webUrl,
+    cart_url: webUrl,
+    cart_url_follow: webUrl,
+    cart_plain: cartPlain,
+    checkout_url_now: undefined,
+    checkout_plain: checkoutPlain,
+    cart_method: 'permalink',
+    reason,
+  });
+}
 
 export default async function createCartLink(req, res) {
   if (req.method !== 'POST') {
@@ -377,13 +436,13 @@ export default async function createCartLink(req, res) {
       }
       throw err;
     });
-    const parsed = BodySchema.safeParse(body);
+    const parsed = BodySchema.safeParse(body || {});
     if (!parsed.success) {
-      return res.status(400).json({ ok: false, error: 'invalid_body', issues: parsed.error.flatten().fieldErrors });
+      return res.status(400).json({ reason: 'bad_request' });
     }
     const {
       variantId,
-      variantGid,
+      variantGid: variantGidRaw,
       quantity,
       attributes: attrInput,
       cartAttributes,
@@ -394,11 +453,11 @@ export default async function createCartLink(req, res) {
     } = parsed.data;
 
     const providedJobId = jobIdRaw || jobIdCamel || '';
-    let normalizedVariantId = normalizeVariantId(variantId ?? variantGid);
-    let variantGidValue = ensureVariantGid(variantGid, variantId, normalizedVariantId);
+    let variantNumericId = normalizeVariantNumericId(variantId ?? variantGidRaw);
+    let variantGidValue = ensureVariantGid(variantGidRaw, variantId, variantNumericId);
     const normalizedDiscount = typeof discount === 'string' ? discount.trim() : '';
 
-    if (!normalizedVariantId && providedJobId) {
+    if (!variantNumericId && providedJobId) {
       const jobResult = await fetchJobForCart(providedJobId);
       if (!jobResult.ok) {
         if (jobResult.reason === 'supabase_env_missing') {
@@ -413,12 +472,12 @@ export default async function createCartLink(req, res) {
       } else {
         const { job } = jobResult;
         if (typeof job?.shopify_variant_id === 'string' && job.shopify_variant_id) {
-          normalizedVariantId = normalizeVariantId(job.shopify_variant_id);
-          variantGidValue = ensureVariantGid(variantGidValue || job.shopify_variant_id, variantId, normalizedVariantId);
+          variantNumericId = normalizeVariantNumericId(job.shopify_variant_id);
+          variantGidValue = ensureVariantGid(variantGidValue || job.shopify_variant_id, variantId, variantNumericId);
         }
-        if (!normalizedVariantId && typeof job?.cart_url === 'string' && job.cart_url) {
-          let checkoutUrlStored = typeof job.checkout_url === 'string' && job.checkout_url ? job.checkout_url : undefined;
+        if (!variantNumericId && typeof job?.cart_url === 'string' && job.cart_url) {
           let cartUrlStored = job.cart_url;
+          let checkoutUrlStored = typeof job.checkout_url === 'string' && job.checkout_url ? job.checkout_url : undefined;
           if (normalizedDiscount) {
             try {
               const cartUrlObj = new URL(cartUrlStored);
@@ -447,6 +506,7 @@ export default async function createCartLink(req, res) {
           }
           return res.status(200).json({
             ok: true,
+            webUrl: cartUrlStored,
             url: cartUrlStored,
             cart_url: cartUrlStored,
             cart_url_follow: cartUrlStored,
@@ -456,97 +516,149 @@ export default async function createCartLink(req, res) {
             cart_method: 'stored',
           });
         }
-        if (!normalizedVariantId) {
+        if (!variantNumericId) {
           return res.status(409).json({ ok: false, error: 'job_variant_missing' });
         }
       }
     }
 
-    if (!normalizedVariantId) {
-      return res.status(400).json({ ok: false, error: 'missing_variant' });
+    if (!variantNumericId) {
+      return res.status(400).json({ reason: 'bad_request' });
     }
-    variantGidValue = ensureVariantGid(variantGidValue, variantId, normalizedVariantId);
+    variantGidValue = ensureVariantGid(variantGidValue, variantId, variantNumericId);
+
     const qtyRaw = Number(quantity);
     const qty = Number.isFinite(qtyRaw) && qtyRaw > 0 ? Math.min(Math.floor(qtyRaw), 99) : 1;
-    const base = getPublicStorefrontBase();
-    if (!base) return res.status(500).json({ ok: false, error: 'missing_store_domain' });
 
-    const attributes = collectCustomAttributes(cartAttributes ?? attrInput);
     const buyerIp = getClientIp(req);
+    const attributes = collectCustomAttributes(cartAttributes ?? attrInput);
 
-    const storefrontAttempt = await tryCreateStorefrontCart({
-      base,
-      variantGid: variantGidValue,
-      quantity: qty,
-      buyerIp,
-      attributes,
-      note,
-      discountCode: normalizedDiscount,
-    });
+    let precheck;
+    try {
+      precheck = await precheckVariantAvailability(variantGidValue, { maxAttempts: 3 });
+    } catch (err) {
+      console.error?.('[create-cart-link] precheck_failed', {
+        variantGid: variantGidValue,
+        variantNumericId,
+        error: err?.message || err,
+      });
+      return res.status(502).json({ reason: 'shopify_unreachable' });
+    }
+
+    if (!precheck.ok) {
+      return respondWithPermalink(res, {
+        variantNumericId,
+        quantity: qty,
+        reason: precheck.reason || 'precheck_failed',
+        requestId: precheck.requestId,
+      });
+    }
+
+    let storefrontAttempt;
+    try {
+      storefrontAttempt = await createStorefrontCart({
+        variantGid: variantGidValue,
+        quantity: qty,
+        buyerIp,
+        attributes,
+        note,
+      });
+    } catch (err) {
+      console.error?.('[create-cart-link] cart_create_network_error', {
+        variantGid: variantGidValue,
+        variantNumericId,
+        error: err?.message || err,
+      });
+      return res.status(502).json({ reason: 'shopify_unreachable' });
+    }
 
     if (storefrontAttempt.ok) {
-      return res.status(200).json({
+      const payload = {
         ok: true,
+        webUrl: storefrontAttempt.cartUrl,
         url: storefrontAttempt.cartUrl,
         cart_url: storefrontAttempt.cartUrl,
-        cart_url_follow: storefrontAttempt.cartUrlFollow || storefrontAttempt.cartUrl,
+        cart_url_follow: storefrontAttempt.cartUrl,
         cart_plain: storefrontAttempt.cartPlain,
-        checkout_url_now: storefrontAttempt.checkoutUrlNow,
+        checkout_url_now: storefrontAttempt.checkoutUrl,
         checkout_plain: storefrontAttempt.checkoutPlain,
         cart_id: storefrontAttempt.cartId,
         cart_token: storefrontAttempt.cartToken,
         cart_method: 'storefront',
-      });
+      };
+      return res.status(200).json(payload);
     }
 
     if (storefrontAttempt.reason === 'user_errors') {
-      const detailMessages = (storefrontAttempt.userErrors || [])
-        .map((err) => (typeof err?.message === 'string' ? err.message.trim() : ''))
-        .filter(Boolean);
-      return res.status(422).json({
-        ok: false,
-        error: 'shopify_cart_user_error',
-        detail: storefrontAttempt.userErrors,
-        message: detailMessages.join(' ') || 'Shopify rechazó la creación del carrito.',
-      });
-    }
-
-    if (
-      storefrontAttempt.reason &&
-      !['missing_variant_gid', 'storefront_env_missing'].includes(storefrontAttempt.reason)
-    ) {
       try {
-        console.error('create_cart_link_storefront_failed', {
-          reason: storefrontAttempt.reason,
-          status: storefrontAttempt.status,
+        console.warn('[create-cart-link] cart_create_user_errors', {
+          variantGid: variantGidValue,
+          variantNumericId,
+          requestId: storefrontAttempt.requestId || null,
+          userErrors: storefrontAttempt.userErrors,
         });
       } catch {}
+      try {
+        const retryPrecheck = await precheckVariantAvailability(variantGidValue, { maxAttempts: 5 });
+        if (retryPrecheck.ok) {
+          try {
+            storefrontAttempt = await createStorefrontCart({
+              variantGid: variantGidValue,
+              quantity: qty < 1 ? 1 : qty,
+              buyerIp,
+              attributes,
+              note,
+            });
+            if (storefrontAttempt.ok) {
+              const payload = {
+                ok: true,
+                webUrl: storefrontAttempt.cartUrl,
+                url: storefrontAttempt.cartUrl,
+                cart_url: storefrontAttempt.cartUrl,
+                cart_url_follow: storefrontAttempt.cartUrl,
+                cart_plain: storefrontAttempt.cartPlain,
+                checkout_url_now: storefrontAttempt.checkoutUrl,
+                checkout_plain: storefrontAttempt.checkoutPlain,
+                cart_id: storefrontAttempt.cartId,
+                cart_token: storefrontAttempt.cartToken,
+                cart_method: 'storefront',
+              };
+              return res.status(200).json(payload);
+            }
+          } catch (err) {
+            console.error?.('[create-cart-link] cart_create_retry_network_error', {
+              variantGid: variantGidValue,
+              variantNumericId,
+              error: err?.message || err,
+            });
+            return res.status(502).json({ reason: 'shopify_unreachable' });
+          }
+        }
+      } catch (err) {
+        console.error?.('[create-cart-link] precheck_retry_failed', {
+          variantGid: variantGidValue,
+          variantNumericId,
+          error: err?.message || err,
+        });
+        return res.status(502).json({ reason: 'shopify_unreachable' });
+      }
     }
 
-    const fallback = buildLegacyCartPayload(base, normalizedVariantId, qty, normalizedDiscount);
-    if (!fallback) {
-      return res.status(500).json({ ok: false, error: 'create_cart_link_failed' });
-    }
-
-    return res.status(200).json({
-      ok: true,
-      url: fallback.cartUrl,
-      cart_url: fallback.cartUrl,
-      cart_url_follow: fallback.cartUrlFollow,
-      cart_plain: fallback.cartPlain,
-      checkout_url_now: fallback.checkoutUrlNow,
-      checkout_plain: fallback.checkoutPlain,
-      cart_method: 'legacy',
+    return respondWithPermalink(res, {
+      variantNumericId,
+      quantity: qty,
+      reason: storefrontAttempt.reason || 'storefront_failed',
+      requestId: storefrontAttempt.requestId,
+      userErrors: storefrontAttempt.userErrors,
     });
   } catch (e) {
     if (res.statusCode === 413) {
       return res.json({ ok: false, error: 'payload_too_large' });
     }
     if (res.statusCode === 400) {
-      return res.json({ ok: false, error: 'invalid_json' });
+      return res.json({ reason: 'bad_request' });
     }
-    try { console.error('create_cart_link_error', e); } catch {}
+    console.error?.('create_cart_link_error', e);
     return res.status(500).json({ ok: false, error: 'create_cart_link_failed' });
   }
 }
-


### PR DESCRIPTION
## Summary
- normalize variant identifiers, pre-check availability, and add a permalink fallback when cartCreate fails
- ensure the create-cart-link endpoint returns a webUrl without 422 responses and logs useful metadata
- update the Mockup cart flow to open the server-provided cart link and refresh tests for the new behavior

## Testing
- npm test -- --test-name-pattern=create-cart-link

------
https://chatgpt.com/codex/tasks/task_e_68d6dd48091083279d2668e009fca945