### PR TITLE
Fix missing apiFetch import in mockup cart flow

### DIFF
--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -14,6 +14,7 @@ import {
   verifyProductPublicationStatus,
   waitForVariantAvailability,
 } from '@/lib/shopify.ts';
+import { apiFetch } from '@/lib/api.js';
 
 const CART_STATUS_LABELS = {
   idle: 'Agregar al carrito',


### PR DESCRIPTION
## Summary
- import apiFetch into the Mockup page so the cart creation flow can call the API helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e13561e08327b380edef5ce51c94