### PR TITLE
Support Vite Shopify env variables

### DIFF
--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -722,13 +722,13 @@ interface StorefrontConfig {
 
 function resolveStorefrontConfig(): { ok: true; config: StorefrontConfig } | { ok: false; missing: string[] } {
   const missing: string[] = [];
-  const domainRaw = readEnv(['NEXT_PUBLIC_SHOPIFY_DOMAIN']);
-  const token = readEnv(['NEXT_PUBLIC_SHOPIFY_STOREFRONT_TOKEN']);
-  const versionRaw = readEnv(['NEXT_PUBLIC_SHOPIFY_API_VERSION']);
+  const domainRaw = readEnv(['VITE_SHOPIFY_DOMAIN', 'NEXT_PUBLIC_SHOPIFY_DOMAIN']);
+  const token = readEnv(['VITE_SHOPIFY_STOREFRONT_TOKEN', 'NEXT_PUBLIC_SHOPIFY_STOREFRONT_TOKEN']);
+  const versionRaw = readEnv(['VITE_SHOPIFY_API_VERSION', 'NEXT_PUBLIC_SHOPIFY_API_VERSION']);
 
-  if (!domainRaw) missing.push('NEXT_PUBLIC_SHOPIFY_DOMAIN');
-  if (!token) missing.push('NEXT_PUBLIC_SHOPIFY_STOREFRONT_TOKEN');
-  if (!versionRaw) missing.push('NEXT_PUBLIC_SHOPIFY_API_VERSION');
+  if (!domainRaw) missing.push('VITE_SHOPIFY_DOMAIN (or NEXT_PUBLIC_SHOPIFY_DOMAIN)');
+  if (!token) missing.push('VITE_SHOPIFY_STOREFRONT_TOKEN (or NEXT_PUBLIC_SHOPIFY_STOREFRONT_TOKEN)');
+  if (!versionRaw) missing.push('VITE_SHOPIFY_API_VERSION (or NEXT_PUBLIC_SHOPIFY_API_VERSION)');
 
   if (missing.length) {
     return { ok: false, missing };


### PR DESCRIPTION
## Summary
- allow the Shopify storefront configuration to read either Vite or Next.js prefixed environment variables
- improve missing environment variable messaging to mention both variable names

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6e20a75f48327895f4fd6775c4fac