### PR TITLE
Keep private products active for checkout

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1906,7 +1906,10 @@ export async function publishProduct(req, res) {
 
     const productInput = {
       title,
-      status: isPrivate ? 'DRAFT' : 'ACTIVE',
+      // Keep private products out of sales channels by skipping publication, but
+      // leave the product status as ACTIVE so Shopify considers the variant
+      // sellable from the Storefront checkout flow.
+      status: 'ACTIVE',
       vendor: DEFAULT_VENDOR,
       templateSuffix: 'mousepads',
     };


### PR DESCRIPTION
## Summary
- ensure private products are created with an ACTIVE status so their variants remain sellable through the Storefront checkout
- document the rationale inline for future maintenance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6e33fe17c83278e47039b94cf9831