### PR TITLE
feat: refresh config panel styling

### DIFF
--- a/mgm-front/src/components/SizeControls.jsx
+++ b/mgm-front/src/components/SizeControls.jsx
@@ -359,10 +359,10 @@ export default function SizeControls({ material, size, onChange, locked = false,
   ]
     .filter(Boolean)
     .join(' ');
-  const inputControlClassName = [
-    styles.inputControl,
-    styles.inputNumber,
-    disabled ? styles.inputControlDisabled : '',
+
+  const measureFieldClass = (isDisabled) => [
+    styles.measureField,
+    isDisabled ? styles.measureFieldDisabled : '',
   ]
     .filter(Boolean)
     .join(' ');
@@ -372,80 +372,75 @@ export default function SizeControls({ material, size, onChange, locked = false,
     <div className={containerClasses} aria-disabled={disabled}>
       <div className={`${styles.section} ${styles.formRow}`}>
         <span className={styles.groupLabel}>Medidas (cm)</span>
-        <div className={`${styles.dimensionsRow} ${styles.inputGroup}`}>
-          <label className={styles.inputLabel}>
-            <span className={styles.visuallyHidden}>Largo</span>
-            <div className={inputControlClassName}>
-              <span className={styles.inputAffix} aria-hidden="true">
-                Largo
-              </span>
-              <img
-                src={WIDTH_ICON_SRC}
-                alt=""
-                className={styles.inputIcon}
-                aria-hidden="true"
-              />
-              <input
-                ref={wInputRef}
-                className={`${styles.input} ${styles.inputNumber}`}
-                value={isGlasspad ? GLASSPAD_SIZE_CM.w : wText}
-                onChange={!isGlasspad ? handleWChange : undefined}
-                onBlur={!isGlasspad ? handleWBlur : undefined}
-                onKeyDown={!isGlasspad ? handleDimensionKeyDown('w') : undefined}
-                inputMode="decimal"
-                pattern="[0-9]*"
-                aria-invalid={errors.w ? 'true' : 'false'}
-                aria-describedby={errors.w ? widthErrorId : undefined}
-                disabled={locked || isGlasspad || disabled}
-              />
-            </div>
-            {errors.w && (
-              <p className="errorText" id={widthErrorId} aria-live="polite">
-                {errors.w}
-              </p>
-            )}
+        <div className={styles.measureRow}>
+          <label className={measureFieldClass(locked || isGlasspad || disabled)}>
+            <span className={styles.measureLabel}>Largo</span>
+            <img
+              src={WIDTH_ICON_SRC}
+              alt=""
+              className={styles.measureIcon}
+              aria-hidden="true"
+            />
+            <input
+              ref={wInputRef}
+              className={styles.measureInput}
+              value={isGlasspad ? GLASSPAD_SIZE_CM.w : wText}
+              onChange={!isGlasspad ? handleWChange : undefined}
+              onBlur={!isGlasspad ? handleWBlur : undefined}
+              onKeyDown={!isGlasspad ? handleDimensionKeyDown('w') : undefined}
+              inputMode="decimal"
+              pattern="[0-9]*"
+              aria-invalid={errors.w ? 'true' : 'false'}
+              aria-describedby={errors.w ? widthErrorId : undefined}
+              disabled={locked || isGlasspad || disabled}
+            />
           </label>
-          <label className={styles.inputLabel}>
-            <span className={styles.visuallyHidden}>Ancho</span>
-            <div className={inputControlClassName}>
-              <span className={styles.inputAffix} aria-hidden="true">
-                Ancho
-              </span>
-              <img
-                src={HEIGHT_ICON_SRC}
-                alt=""
-                className={styles.inputIcon}
-                aria-hidden="true"
-              />
-              <input
-                ref={hInputRef}
-                className={`${styles.input} ${styles.inputNumber}`}
-                value={isGlasspad ? GLASSPAD_SIZE_CM.h : hText}
-                onChange={!isGlasspad ? handleHChange : undefined}
-                onBlur={!isGlasspad ? handleHBlur : undefined}
-                onKeyDown={!isGlasspad ? handleDimensionKeyDown('h') : undefined}
-                inputMode="decimal"
-                pattern="[0-9]*"
-                aria-invalid={errors.h ? 'true' : 'false'}
-                aria-describedby={errors.h ? heightErrorId : undefined}
-                disabled={locked || isGlasspad || disabled}
-              />
-            </div>
-            {errors.h && (
-              <p className="errorText" id={heightErrorId} aria-live="polite">
-                {errors.h}
-              </p>
-            )}
+          <label className={measureFieldClass(locked || isGlasspad || disabled)}>
+            <span className={styles.measureLabel}>Ancho</span>
+            <img
+              src={HEIGHT_ICON_SRC}
+              alt=""
+              className={styles.measureIcon}
+              aria-hidden="true"
+            />
+            <input
+              ref={hInputRef}
+              className={styles.measureInput}
+              value={isGlasspad ? GLASSPAD_SIZE_CM.h : hText}
+              onChange={!isGlasspad ? handleHChange : undefined}
+              onBlur={!isGlasspad ? handleHBlur : undefined}
+              onKeyDown={!isGlasspad ? handleDimensionKeyDown('h') : undefined}
+              inputMode="decimal"
+              pattern="[0-9]*"
+              aria-invalid={errors.h ? 'true' : 'false'}
+              aria-describedby={errors.h ? heightErrorId : undefined}
+              disabled={locked || isGlasspad || disabled}
+            />
           </label>
         </div>
 
+        {(errors.w || errors.h) && (
+          <div className={styles.measureErrors}>
+            {errors.w && (
+              <p className={styles.measureError} id={widthErrorId} aria-live="polite">
+                {errors.w}
+              </p>
+            )}
+            {errors.h && (
+              <p className={styles.measureError} id={heightErrorId} aria-live="polite">
+                {errors.h}
+              </p>
+            )}
+          </div>
+        )}
+
         {presets.length > 0 && (
-          <div className={`${styles.presets} ${styles.quickSizeChips}`}>
+          <div className={styles.quickSizes}>
             {presets.map(p => (
               <button
                 key={`${p.w}x${p.h}`}
                 type="button"
-                className={styles.presetButton}
+                className={styles.quickChip}
                 onClick={() => applyPreset(p.w, p.h)}
                 disabled={locked || disabled}
               >
@@ -499,7 +494,7 @@ export default function SizeControls({ material, size, onChange, locked = false,
                 <div
                   id={seriesMenuId}
                   role="listbox"
-                  className={styles.selectMenuFloating}
+                  className={styles.selectMenu}
                   style={floatingMenuStyle}
                   ref={seriesMenuRef}
                 >

--- a/mgm-front/src/components/SizeControls.module.css
+++ b/mgm-front/src/components/SizeControls.module.css
@@ -25,124 +25,124 @@
 }
 
 .groupLabel {
-  font-size: 0.75rem;
-  text-transform: uppercase;
+  font-size: 14px;
   letter-spacing: 0.08em;
-  font-weight: 600;
-  color: #cbd5f5;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--cfg-text);
+  opacity: 0.9;
 }
 
-.dimensionsRow {
-  display: flex;
+.measureRow {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
+  margin-top: 8px;
 }
 
-.inputLabel {
-  flex: 1;
-  display: block;
-  inline-size: 100%;
-}
-
-.inputControl {
+.measureField {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 12px 16px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(18, 18, 22, 0.85);
-  box-shadow: 0 12px 22px rgba(8, 8, 12, 0.25);
+  min-block-size: 56px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid var(--cfg-border);
+  background: var(--cfg-surface);
+  color: var(--cfg-text);
 }
 
-.inputControlDisabled {
-  border-color: rgba(255, 255, 255, 0.08);
-  background: rgba(24, 24, 28, 0.6);
-  box-shadow: none;
-}
-
-.inputNumber {
-  inline-size: 100%;
-}
-
-.input {
-  flex: 1;
-  font-size: 1rem;
-  font-weight: 500;
-  border: none;
-  background: transparent;
-  color: #f4f5f7;
-  outline: none;
-  text-align: right;
-}
-
-.inputIcon {
-  width: 24px;
-  height: 24px;
-  flex-shrink: 0;
-}
-
-.inputAffix {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: #9ca3af;
-}
-
-.visuallyHidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.input:disabled {
-  opacity: 0.5;
+.measureFieldDisabled {
+  opacity: 0.6;
   cursor: not-allowed;
 }
 
-.presets {
+.measureLabel {
+  font-size: 16px;
+  opacity: 0.95;
+}
+
+.measureIcon {
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  opacity: 0.9;
+}
+
+.measureInput {
+  margin-left: auto;
+  width: 72px;
+  text-align: right;
+  background: transparent;
+  border: 0;
+  color: var(--cfg-text);
+  font-size: 16px;
+  font-variant-numeric: tabular-nums;
+  outline: none;
+}
+
+.measureInput:disabled {
+  opacity: 1;
+  cursor: not-allowed;
+}
+
+.measureInput::-webkit-outer-spin-button,
+.measureInput::-webkit-inner-spin-button {
+  appearance: none;
+  margin: 0;
+}
+
+.measureInput[type='number'] {
+  appearance: textfield;
+}
+
+.measureErrors {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.measureError {
+  margin: 0;
+  color: #ffb4a6;
+  font-size: 14px;
+}
+
+.quickSizes {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  inline-size: 100%;
+  gap: 10px;
+  margin-top: 14px;
 }
 
-.quickSizeChips {
-  inline-size: 100%;
-}
-
-.presetButton {
-  padding: 6px 14px;
+.quickChip {
+  padding: 8px 12px;
   border-radius: 999px;
-  border: 1px solid #2d2d33;
-  background: rgba(20, 20, 24, 0.9);
-  color: #f4f4f5;
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  border: 1px solid var(--cfg-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--cfg-text-soft);
+  font-size: 14px;
   cursor: pointer;
-  transition: border-color 0.2s ease, transform 0.2s ease;
+  transition: background-color 0.18s ease, color 0.18s ease, transform 0.18s ease;
 }
 
-.presetButton:hover:not(:disabled) {
-  border-color: #4f46e5;
+.quickChip:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--cfg-text);
   transform: translateY(-1px);
 }
 
-.presetButton:disabled {
+.quickChip:disabled {
   opacity: 0.45;
   cursor: not-allowed;
+  transform: none;
 }
 
 .helper {
   margin: 0;
-  font-size: 0.75rem;
-  color: #6b7280;
+  font-size: 0.78rem;
+  color: rgba(246, 247, 251, 0.6);
 }
 
 .seriesSection {
@@ -162,13 +162,12 @@
   inline-size: 100%;
   min-block-size: 56px;
   padding: 14px 18px;
-  border-radius: 12px;
-  border: 1px solid rgba(128, 128, 128, 0.28);
-  background: linear-gradient(90deg, rgba(24, 24, 24, 0.92), rgba(24, 24, 24, 0.86));
-  color: #f6f7fb;
-  text-align: left;
+  border-radius: 16px;
+  border: 1px solid var(--cfg-border);
+  background: var(--cfg-surface);
+  color: var(--cfg-text);
   cursor: pointer;
-  transition: border-color 0.22s ease, box-shadow 0.22s ease, transform 0.22s ease;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .selectTrigger:disabled {
@@ -182,12 +181,11 @@
   align-items: baseline;
   gap: 6px;
   font-size: 16px;
-  letter-spacing: 0.01em;
-  color: #f6f7fb;
 }
 
 .selectLabelStrong {
-  font-weight: 700;
+  font-weight: 800;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
@@ -205,7 +203,7 @@
 }
 
 .selectTrigger:hover:not(:disabled) {
-  border-color: rgba(200, 200, 200, 0.45);
+  border-color: var(--cfg-border-strong);
   transform: translateY(-1px);
   box-shadow: 0 0 0 1px rgba(200, 200, 200, 0.06) inset;
 }
@@ -219,14 +217,14 @@
   outline-offset: 3px;
 }
 
-.selectMenuFloating {
+.selectMenu {
   position: fixed;
   z-index: 3000;
   border-radius: 12px;
-  border: 1px solid rgba(128, 128, 128, 0.28);
+  border: 1px solid var(--cfg-border);
   background: #1c1c1f;
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
-  overflow: auto;
+  overflow: hidden;
   max-height: min(320px, 70vh);
 }
 
@@ -242,20 +240,20 @@
 }
 
 .selectOption:hover {
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .selectOption[aria-selected='true'] {
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.08);
 }
 
-@media (max-width: 480px) {
-  .selectTrigger {
-    min-block-size: 52px;
-    padding: 12px 14px;
+@media (max-width: 640px) {
+  .measureRow {
+    grid-template-columns: 1fr;
   }
 
-  .selectLabel {
-    font-size: 15px;
+  .measureField,
+  .selectTrigger {
+    min-block-size: 54px;
   }
 }

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -451,9 +451,8 @@ export default function Home() {
   }, [configOpen]);
 
   const designNameInputClasses = [
-    styles.textInput,
     styles.inputText,
-    designNameError ? styles.textInputError : '',
+    designNameError ? styles.inputTextError : '',
   ]
     .filter(Boolean)
     .join(' ');
@@ -740,40 +739,42 @@ export default function Home() {
           style={configPanelStyle}
           role="menu"
         >
-          <div className={styles.configForm}>
-            <div className={`${styles.field} ${styles.formRow}`}>
-              <label className={styles.fieldLabel} htmlFor="design-name">
-                Nombre de tu diseño
-              </label>
-              <input
-                type="text"
-                id="design-name"
-                ref={designNameInputRef}
-                className={designNameInputClasses}
-                placeholder="Ej: Nubes y cielo rosa"
-                value={designName}
-                onChange={handleDesignNameChange}
-                disabled={!hasImage}
-                aria-invalid={designNameError ? 'true' : 'false'}
-                aria-describedby={
-                  designNameError ? 'design-name-error' : undefined
-                }
-              />
-              {designNameError && (
-                <p className={styles.fieldError} id="design-name-error">
-                  {designNameError}
-                </p>
-              )}
-            </div>
-            <div className={styles.fieldBlock}>
-              <SizeControls
-                material={material}
-                size={size}
-                mode={mode}
-                onChange={handleSizeChange}
-                locked={material === 'Glasspad'}
-                disabled={!hasImage}
-              />
+          <div className={styles.configSheet}>
+            <div className={styles.configForm}>
+              <div className={`${styles.field} ${styles.formRow}`}>
+                <label className={styles.configSectionTitle} htmlFor="design-name">
+                  Nombre de tu diseño
+                </label>
+                <input
+                  type="text"
+                  id="design-name"
+                  ref={designNameInputRef}
+                  className={designNameInputClasses}
+                  placeholder="Ej: Nubes y cielo rosa"
+                  value={designName}
+                  onChange={handleDesignNameChange}
+                  disabled={!hasImage}
+                  aria-invalid={designNameError ? 'true' : 'false'}
+                  aria-describedby={
+                    designNameError ? 'design-name-error' : undefined
+                  }
+                />
+                {designNameError && (
+                  <p className={styles.errorMessage} id="design-name-error">
+                    {designNameError}
+                  </p>
+                )}
+              </div>
+              <div className={styles.fieldBlock}>
+                <SizeControls
+                  material={material}
+                  size={size}
+                  mode={mode}
+                  onChange={handleSizeChange}
+                  locked={material === 'Glasspad'}
+                  disabled={!hasImage}
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -1,3 +1,13 @@
+:root {
+  --cfg-bg: #2f3034;
+  --cfg-surface: #1b1c1f;
+  --cfg-text: #f6f7fb;
+  --cfg-text-soft: rgba(246, 247, 251, 0.85);
+  --cfg-border: rgba(128, 128, 128, 0.28);
+  --cfg-border-strong: rgba(200, 200, 200, 0.45);
+  --cfg-shadow: 0 18px 36px rgba(0, 0, 0, 0.4);
+}
+
 .page {
   display: flex;
   flex-direction: column;
@@ -215,22 +225,15 @@
   left: 0;
   min-width: min(420px, calc(100vw - 96px));
   max-width: min(520px, calc(100vw - 96px));
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-  padding: 28px;
-  padding-top: calc(28px + env(safe-area-inset-top));
-  padding-right: calc(28px + env(safe-area-inset-right));
-  padding-bottom: calc(28px + env(safe-area-inset-bottom));
-  padding-left: calc(28px + env(safe-area-inset-left));
-  border-radius: 24px;
-  border: 1px solid rgba(63, 63, 77, 0.6);
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(14, 14, 20, 0.96);
-  box-shadow: 0 32px 60px rgba(0, 0, 0, 0.5);
+  display: block;
+  padding: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
   z-index: 30;
   max-height: 70vh;
   overflow-y: auto;
+  overflow-x: visible;
   -webkit-overflow-scrolling: touch;
   box-sizing: border-box;
 }
@@ -262,10 +265,22 @@
   }
 }
 
+@media (max-width: 640px) {
+  .configSheet {
+    border-radius: 14px;
+    padding: 18px 14px 20px;
+    overflow-x: hidden;
+  }
+
+  .inputText {
+    min-block-size: 54px;
+  }
+}
+
 .field {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 }
 
 .configForm {
@@ -273,7 +288,7 @@
   margin-inline: auto;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 20px;
 }
 
 .formRow,
@@ -283,54 +298,72 @@
   inline-size: 100%;
 }
 
-.inputText,
-.inputNumber,
-.quickSizeChips {
-  inline-size: 100%;
-}
-
-.fieldLabel {
-  font-size: 0.75rem;
-  text-transform: uppercase;
+.configSectionTitle {
+  font-size: 14px;
   letter-spacing: 0.08em;
-  color: rgba(206, 212, 226, 0.85);
-  font-weight: 600;
+  font-weight: 700;
+  opacity: 0.9;
+  margin: 10px 0 8px;
+  text-transform: uppercase;
 }
 
-.textInput {
-  width: 100%;
-  padding: 14px 16px;
-  border-radius: 12px;
-  border: 1px solid rgba(63, 63, 77, 0.7);
-  background: rgba(22, 22, 28, 0.9);
-  color: #f3f4f6;
-  font-size: 1rem;
-  font-weight: 500;
+.configSheet {
+  inline-size: min(100%, 720px);
+  margin-inline: auto;
+  background: var(--cfg-bg);
+  border: 1px solid var(--cfg-border);
+  border-radius: 16px;
+  box-shadow: var(--cfg-shadow);
+  padding: 20px 18px 22px;
+  color: var(--cfg-text);
+  overflow: hidden;
+  touch-action: pan-y;
+}
+
+.inputText {
+  display: block;
+  inline-size: 100%;
+  min-block-size: 56px;
+  padding: 14px 18px;
+  border-radius: 16px;
+  border: 1px solid var(--cfg-border);
+  background: var(--cfg-surface);
+  color: var(--cfg-text);
+  font-size: 16px;
+  letter-spacing: 0.01em;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-
-.textInput::placeholder {
-  color: rgba(156, 163, 175, 0.7);
+.inputText::placeholder {
+  color: var(--cfg-text-soft);
+  opacity: 0.85;
 }
 
-.textInput:focus {
-  outline: none;
-  border-color: rgba(170, 170, 190, 0.9);
-  box-shadow: 0 0 0 3px rgba(170, 170, 190, 0.2);
+.inputText:focus-visible {
+  outline: 2px solid #79c0ff66;
+  outline-offset: 3px;
+  border-color: var(--cfg-border-strong);
 }
 
-.textInputError,
-.textInputError:focus {
-  border-color: rgba(239, 68, 68, 0.7);
-  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.25);
+.inputText:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
-.fieldError {
-  margin: 0;
-  color: #fca5a5;
-  font-size: 0.85rem;
-  font-weight: 500;
+.inputTextError {
+  border-color: #ffb4a6;
+  box-shadow: 0 0 0 1px rgba(255, 180, 166, 0.25) inset;
+}
+
+.inputTextError:focus-visible {
+  border-color: #ffb4a6;
+  box-shadow: 0 0 0 1px rgba(255, 180, 166, 0.3) inset;
+}
+
+.errorMessage {
+  margin-top: 8px;
+  color: #ffb4a6;
+  font-size: 14px;
 }
 
 


### PR DESCRIPTION
## Summary
- restyle the configuration sheet with the new palette, spacing, and typography tokens
- update the design name input, measurement controls, quick size chips, and series selector to pill-style layouts with consistent focus and disabled states

## Testing
- manual sanity check in dev server

------
https://chatgpt.com/codex/tasks/task_e_68d6e06f5eec832792c6d0495c4f1b9a