### PR TITLE
Add draft order fallback for private checkout when storefront flow fails

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -40,7 +40,7 @@ Creates a Shopify cart that includes a single product variant and returns `{ web
 
 Produces a checkout link for the private flow based on `PRIVATE_CHECKOUT_MODE`.
 
-- `storefront` (default): creates a Storefront cart and responds with `{ checkoutUrl, cartUrl?, strategy: 'storefront' }`, preserving Shopify's coupon UI.
+- `storefront` (default): creates a Storefront cart and responds with `{ checkoutUrl, cartUrl?, strategy: 'storefront' }`, preserving Shopify's coupon UI. When the storefront path fails (variant unavailable, Storefront credentials missing, etc.) the handler transparently falls back to the draft-order flow.
 - `draft_order`: creates an Admin draft order and returns `{ checkoutUrl, strategy: 'draft_order' }` pointing to the invoice URL.
 
 The request accepts `variantId`, optional `quantity`, `email`, `note` and `noteAttributes`. Missing or invalid payloads yield `400 { reason: 'bad_request' }`. Shopify failures return `502` with a `reason` field and, when available, `userErrors`.

--- a/lib/handlers/privateCheckout.js
+++ b/lib/handlers/privateCheckout.js
@@ -179,7 +179,7 @@ export default async function privateCheckout(req, res) {
     const attributesInput = noteAttributes ?? attributes;
     const normalizedAttributes = normalizeCartAttributes(attributesInput);
 
-    if (mode === 'draft_order') {
+    async function handleDraftOrder(trigger = null) {
       let draftAttempt;
       try {
         draftAttempt = await createDraftOrder({
@@ -191,38 +191,52 @@ export default async function privateCheckout(req, res) {
         });
       } catch (err) {
         console.error?.('[private-checkout] draft_order_error', err);
-        return res.status(502).json({ reason: 'shopify_unreachable' });
+        res.status(502).json({ reason: 'shopify_unreachable' });
+        return true;
       }
       if (!draftAttempt.ok) {
         logResult('warn', {
           mode,
           variantGid: resolvedVariantGid,
           variantNumericId,
+          strategy: 'draft_order',
+          fallbackFrom: trigger,
           reason: draftAttempt.reason,
           userErrors: draftAttempt.userErrors || null,
         });
         if (draftAttempt.reason === 'shopify_env_missing') {
-          return res.status(500).json({ reason: 'shopify_env_missing', missing: draftAttempt.missing });
+          res.status(500).json({ reason: 'shopify_env_missing', missing: draftAttempt.missing });
+          return true;
         }
         if (draftAttempt.reason === 'user_errors') {
-          return res.status(502).json({ reason: 'shopify_user_errors', userErrors: draftAttempt.userErrors });
+          res.status(502).json({ reason: 'shopify_user_errors', userErrors: draftAttempt.userErrors });
+          return true;
         }
-        return res.status(502).json({ reason: draftAttempt.reason || 'draft_order_failed' });
+        res.status(502).json({ reason: draftAttempt.reason || 'draft_order_failed' });
+        return true;
       }
       logResult('info', {
         mode,
         variantGid: resolvedVariantGid,
         variantNumericId,
         strategy: 'draft_order',
+        fallbackFrom: trigger,
       });
-      return res.status(200).json({
+      res.status(200).json({
         checkoutUrl: draftAttempt.checkoutUrl,
         draftOrderId: draftAttempt.draftOrderId || undefined,
         draftOrderName: draftAttempt.draftOrderName || undefined,
         draft_order_id: draftAttempt.draftOrderId || undefined,
         draft_order_name: draftAttempt.draftOrderName || undefined,
         strategy: 'draft_order',
+        ...(trigger ? { fallbackFrom: trigger } : {}),
       });
+      return true;
+    }
+
+    if (mode === 'draft_order') {
+      await handleDraftOrder();
+      return;
     }
 
     const buyerIp = getClientIp(req);
@@ -234,7 +248,8 @@ export default async function privateCheckout(req, res) {
         variantNumericId,
         reason: precheck.reason || 'precheck_failed',
       });
-      return res.status(502).json({ reason: 'variant_unavailable' });
+      await handleDraftOrder('precheck');
+      return;
     }
 
     let storefrontAttempt;
@@ -248,7 +263,8 @@ export default async function privateCheckout(req, res) {
       });
     } catch (err) {
       console.error?.('[private-checkout] storefront_error', err);
-      return res.status(502).json({ reason: 'shopify_unreachable' });
+      await handleDraftOrder('storefront_exception');
+      return;
     }
     if (!storefrontAttempt.ok) {
       logResult('warn', {
@@ -259,12 +275,15 @@ export default async function privateCheckout(req, res) {
         userErrors: storefrontAttempt.userErrors || null,
       });
       if (storefrontAttempt.reason === 'storefront_env_missing') {
-        return res.status(500).json({ reason: 'shopify_env_missing', missing: storefrontAttempt.missing });
+        await handleDraftOrder('storefront_env_missing');
+        return;
       }
       if (storefrontAttempt.reason === 'user_errors') {
-        return res.status(502).json({ reason: 'shopify_user_errors', userErrors: storefrontAttempt.userErrors });
+        await handleDraftOrder('storefront_user_errors');
+        return;
       }
-      return res.status(502).json({ reason: storefrontAttempt.reason || 'checkout_failed' });
+      await handleDraftOrder(storefrontAttempt.reason || 'storefront_failed');
+      return;
     }
 
     let checkoutUrl = storefrontAttempt.checkoutUrl || '';
@@ -274,6 +293,11 @@ export default async function privateCheckout(req, res) {
         checkoutObj.searchParams.set('checkout[email]', email);
         checkoutUrl = checkoutObj.toString();
       } catch {}
+    }
+
+    if (!checkoutUrl) {
+      await handleDraftOrder('missing_checkout_url');
+      return;
     }
 
     logResult('info', {


### PR DESCRIPTION
## Summary
- add a draft-order handler that the private checkout endpoint can reuse and fall back to when the storefront path fails
- document that the storefront mode automatically falls back to draft orders when necessary

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6edd7501483278dc4b12feafec5d4