### PR TITLE
Fix duplicate cart options declaration

### DIFF
--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -324,7 +324,7 @@ export default function Mockup() {
     setToast(null);
     let current = pendingCart;
     const normalizedDiscountCode = discountCode || '';
-    const baseCartOptions = normalizedDiscountCode ? { discountCode: normalizedDiscountCode } : {};
+    const creationCartOptions = normalizedDiscountCode ? { discountCode: normalizedDiscountCode } : {};
     try {
       setBusy(true);
       if (!skipCreation || !current) {
@@ -334,7 +334,7 @@ export default function Mockup() {
           flow,
           skipCreation
             ? { reuseLastProduct: true, skipPublication, ...(normalizedDiscountCode ? { discountCode: normalizedDiscountCode } : {}) }
-            : baseCartOptions,
+            : creationCartOptions,
         );
         if (!result?.variantId) throw new Error('missing_variant');
         const warningMessages = extractWarningMessages(result?.warnings, result?.warningMessages);
@@ -444,12 +444,12 @@ export default function Mockup() {
         showCartFailureToast('', { fallbackUrl: current?.fallbackUrl });
         return;
       }
-      const baseCartOptions = normalizedDiscountCode
+      const linkCartOptions = normalizedDiscountCode
         ? { baseUrl: CART_BASE_URL, discountCode: normalizedDiscountCode }
         : { baseUrl: CART_BASE_URL };
-      const cartUrl = buildCartAddUrl(current.variantId, desiredQuantity, baseCartOptions);
+      const cartUrl = buildCartAddUrl(current.variantId, desiredQuantity, linkCartOptions);
       const fallbackCandidate = buildCartPermalink(current.variantId, desiredQuantity, {
-        ...baseCartOptions,
+        ...linkCartOptions,
         returnTo: null,
       });
       const fallbackUrl = fallbackCandidate && fallbackCandidate !== cartUrl ? fallbackCandidate : '';


### PR DESCRIPTION
## Summary
- rename the cart creation options variable to avoid redeclaration conflicts
- use a distinct name for cart link options when building the add-to-cart URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f351c27c8327a631c9e472414a38