### PR TITLE
feat: upload print PDFs to Supabase and add search UI

### DIFF
--- a/api/[...slug].js
+++ b/api/[...slug].js
@@ -23,6 +23,7 @@ const RATE_LIMITS = {
   'POST product-publication-status': { limit: 45, windowMs: 60_000 },
   'POST variant-status': { limit: 90, windowMs: 60_000 },
   'GET search-assets': { limit: 30, windowMs: 60_000 },
+  'GET outputs/search': { limit: 30, windowMs: 60_000 },
   'POST shopify-webhook': { limit: 60, windowMs: 60_000 },
 };
 
@@ -99,6 +100,13 @@ export default withCors(async function handler(req, res) {
       case 'GET search-assets': {
         const { searchAssets } = await import('../lib/api/handlers/assets.js');
         const { status, body } = await searchAssets({ query: req.query });
+        res.statusCode = status;
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        return res.end(JSON.stringify(body));
+      }
+      case 'GET outputs/search': {
+        const { searchOutputFiles } = await import('../lib/api/handlers/outputsSearch.js');
+        const { status, body } = await searchOutputFiles({ query: req.query });
         res.statusCode = status;
         res.setHeader('Content-Type', 'application/json; charset=utf-8');
         return res.end(JSON.stringify(body));

--- a/lib/_lib/savePrintPdfToSupabase.js
+++ b/lib/_lib/savePrintPdfToSupabase.js
@@ -1,0 +1,117 @@
+import { randomUUID } from 'node:crypto';
+import getSupabaseAdmin from './supabaseAdmin.js';
+
+const OUTPUT_BUCKET = 'outputs';
+const SIGNED_URL_TTL_SECONDS = 600;
+
+function ensureFilename(input) {
+  const raw = String(input || '').trim();
+  if (!raw) {
+    const fallback = randomUUID().replace(/[^a-z0-9]+/gi, '').slice(0, 12) || 'design';
+    return `${fallback}.pdf`;
+  }
+  const withoutPath = raw.split(/[\\/]/).pop() || raw;
+  const ensured = withoutPath.toLowerCase().endsWith('.pdf')
+    ? withoutPath
+    : `${withoutPath}.pdf`;
+  return ensured.replace(/[^a-z0-9._-]+/gi, '-');
+}
+
+function buildPdfPath(filename) {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  return `pdf/${year}/${month}/${filename}`;
+}
+
+function normalizeMetadata(meta = {}) {
+  const base = { private: 'true', createdBy: 'editor' };
+  const output = { ...base };
+  for (const [key, value] of Object.entries(meta)) {
+    if (value == null) continue;
+    if (typeof value === 'boolean') {
+      output[key] = value ? 'true' : 'false';
+    } else {
+      output[key] = typeof value === 'string' ? value : String(value);
+    }
+  }
+  if (!('private' in meta)) output.private = 'true';
+  if (!('createdBy' in meta)) output.createdBy = 'editor';
+  return output;
+}
+
+export async function savePrintPdfToSupabase(buffer, filename, metadata = {}) {
+  if (!buffer || !Buffer.isBuffer(buffer) || buffer.length === 0) {
+    const error = new Error('pdf_buffer_empty');
+    error.code = 'pdf_buffer_empty';
+    throw error;
+  }
+
+  const diagId = randomUUID();
+  let supabase;
+  try {
+    supabase = getSupabaseAdmin();
+  } catch (err) {
+    console.error('pdf_save_env_error', { diagId, message: err?.message || err });
+    const error = new Error('Faltan credenciales de Supabase');
+    error.code = 'supabase_credentials_missing';
+    error.cause = err;
+    throw error;
+  }
+
+  const safeFilename = ensureFilename(filename);
+  const path = buildPdfPath(safeFilename);
+  const size = buffer.length;
+  console.info('pdf_save_start', { diagId, path, size });
+
+  const storage = supabase.storage.from(OUTPUT_BUCKET);
+  const { error: uploadError } = await storage.upload(path, buffer, {
+    upsert: true,
+    cacheControl: '3600',
+    contentType: 'application/pdf',
+    metadata: normalizeMetadata(metadata),
+  });
+  if (uploadError) {
+    console.error('pdf_save_upload_error', {
+      diagId,
+      path,
+      size,
+      status: uploadError?.status || uploadError?.statusCode || null,
+      message: uploadError?.message,
+      name: uploadError?.name,
+    });
+    const error = new Error('supabase_upload_failed');
+    error.code = 'supabase_upload_failed';
+    error.cause = uploadError;
+    throw error;
+  }
+
+  const { data: signedData, error: signedError } = await storage.createSignedUrl(path, SIGNED_URL_TTL_SECONDS, {
+    download: true,
+  });
+  if (signedError) {
+    console.error('pdf_save_signed_url_error', {
+      diagId,
+      path,
+      size,
+      status: signedError?.status || signedError?.statusCode || null,
+      message: signedError?.message,
+      name: signedError?.name,
+    });
+    const error = new Error('supabase_signed_url_failed');
+    error.code = 'supabase_signed_url_failed';
+    error.cause = signedError;
+    throw error;
+  }
+
+  console.info('pdf_save_ok', { diagId, path, size });
+
+  return {
+    path,
+    signedUrl: signedData?.signedUrl || null,
+    expiresIn: SIGNED_URL_TTL_SECONDS,
+    diagId,
+  };
+}
+
+export default savePrintPdfToSupabase;

--- a/lib/api/handlers/outputsSearch.js
+++ b/lib/api/handlers/outputsSearch.js
@@ -1,0 +1,169 @@
+import { randomUUID } from 'node:crypto';
+import getSupabaseAdmin from '../../_lib/supabaseAdmin.js';
+
+const OUTPUT_BUCKET = 'outputs';
+const SIGNED_URL_TTL_SECONDS = 600;
+const MAX_MONTHS = 12;
+const MIN_QUERY_LENGTH = 2;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+function normalizeForSearch(input) {
+  return String(input || '')
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/\.pdf$/gi, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function parseLimit(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return DEFAULT_LIMIT;
+  return Math.min(Math.max(Math.floor(num), 1), MAX_LIMIT);
+}
+
+function parseOffset(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num < 0) return 0;
+  return Math.floor(num);
+}
+
+function buildRecentMonths(count) {
+  const results = [];
+  const now = new Date();
+  for (let idx = 0; idx < count; idx += 1) {
+    const date = new Date(now.getFullYear(), now.getMonth() - idx, 1);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    results.push({ year, month, key: `pdf/${year}/${month}` });
+  }
+  return results;
+}
+
+function toTimestamp(input) {
+  if (!input) return 0;
+  const time = Date.parse(input);
+  return Number.isFinite(time) ? time : 0;
+}
+
+export async function searchOutputFiles({ query } = {}) {
+  const diagId = randomUUID();
+  const rawQuery = typeof query?.query === 'string' ? query.query.trim() : '';
+  if (!rawQuery) {
+    return {
+      status: 400,
+      body: { error: 'missing_query', message: 'Ingresá al menos 2 caracteres para buscar.' },
+    };
+  }
+  if (rawQuery.length < MIN_QUERY_LENGTH) {
+    return {
+      status: 400,
+      body: { error: 'query_too_short', message: 'Ingresá al menos 2 caracteres para buscar.' },
+    };
+  }
+
+  const normalizedQuery = normalizeForSearch(rawQuery);
+  const limit = parseLimit(query?.limit);
+  const offset = parseOffset(query?.offset);
+
+  let supabase;
+  try {
+    supabase = getSupabaseAdmin();
+  } catch (err) {
+    console.error('outputs_search_env_error', { diagId, message: err?.message || err });
+    return {
+      status: 500,
+      body: { error: 'supabase_credentials_missing', message: 'Faltan credenciales de Supabase.' },
+    };
+  }
+
+  const storage = supabase.storage.from(OUTPUT_BUCKET);
+  console.info('outputs_search_start', { diagId, query: rawQuery, limit, offset });
+
+  const months = buildRecentMonths(MAX_MONTHS);
+  const matches = [];
+
+  for (const month of months) {
+    const { data, error } = await storage.list(month.key, {
+      limit: 1000,
+      sortBy: { column: 'created_at', order: 'desc' },
+    });
+    if (error) {
+      console.error('outputs_search_list_error', {
+        diagId,
+        prefix: month.key,
+        status: error?.status || error?.statusCode || null,
+        message: error?.message,
+      });
+      return {
+        status: 502,
+        body: { error: 'storage_unavailable', message: 'No se pudo acceder a Supabase Storage.' },
+      };
+    }
+    if (!Array.isArray(data) || !data.length) continue;
+    for (const entry of data) {
+      if (!entry || typeof entry.name !== 'string') continue;
+      const normalizedName = normalizeForSearch(entry.name);
+      const altName = normalizeForSearch(`${month.year}${month.month}-${entry.name}`);
+      const combined = `${normalizedName}-${altName}`;
+      if (!combined.includes(normalizedQuery) && !entry.name.toLowerCase().includes(rawQuery.toLowerCase())) {
+        continue;
+      }
+      matches.push({
+        name: entry.name,
+        path: `${month.key}/${entry.name}`,
+        createdAt: entry.created_at || entry.updated_at || entry.last_accessed_at || null,
+        size: entry.metadata?.size ?? null,
+        normalized: normalizedName,
+      });
+    }
+  }
+
+  matches.sort((a, b) => toTimestamp(b.createdAt) - toTimestamp(a.createdAt));
+
+  const total = matches.length;
+  const paginated = matches.slice(offset, offset + limit);
+
+  const items = await Promise.all(
+    paginated.map(async (item) => {
+      const { data, error } = await storage.createSignedUrl(item.path, SIGNED_URL_TTL_SECONDS, {
+        download: item.name,
+      });
+      if (error) {
+        console.error('outputs_search_signed_url_error', {
+          diagId,
+          path: item.path,
+          status: error?.status || error?.statusCode || null,
+          message: error?.message,
+        });
+      }
+      return {
+        name: item.name,
+        size: item.size,
+        createdAt: item.createdAt,
+        path: item.path,
+        downloadUrl: data?.signedUrl || null,
+        expiresIn: SIGNED_URL_TTL_SECONDS,
+      };
+    }),
+  );
+
+  console.info('outputs_search_ok', { diagId, query: rawQuery, limit, offset, total, returned: items.length });
+
+  return {
+    status: 200,
+    body: {
+      items,
+      pagination: {
+        limit,
+        offset,
+        total,
+      },
+    },
+  };
+}
+
+export default searchOutputFiles;

--- a/mgm-front/src/pages/Busqueda.module.css
+++ b/mgm-front/src/pages/Busqueda.module.css
@@ -1,61 +1,67 @@
 .page {
   max-width: 960px;
   margin: 0 auto;
-  padding: 24px 16px 48px;
+  padding: 48px 16px 80px;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 32px;
+  color: #f9fafb;
 }
 
-.heading {
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.title {
   font-size: 2rem;
   font-weight: 700;
   margin: 0;
 }
 
-.card {
-  background: #111827;
-  border: 1px solid #1f2937;
+.description {
+  margin: 0;
+  color: #cbd5f5;
+  font-size: 1rem;
+}
+
+.searchCard {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(59, 130, 246, 0.2);
   border-radius: 16px;
   padding: 24px;
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.4);
   display: flex;
   flex-direction: column;
   gap: 20px;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.35);
 }
 
-.description {
-  margin: 0;
-  color: #d1d5db;
-  line-height: 1.5;
+.searchForm {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
 }
 
-.passwordHint {
-  margin: 0;
-  font-size: 0.9rem;
-  color: #facc15;
-}
-
-.passwordNote {
-  margin: 0;
-  font-size: 0.9rem;
-  color: #94a3b8;
+.inputWrapper {
+  flex: 1 1 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .label {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
   font-weight: 600;
-  color: #e5e7eb;
+  color: #e0e7ff;
 }
 
 .input {
+  border: 1px solid rgba(148, 163, 184, 0.4);
   border-radius: 10px;
-  border: 1px solid #334155;
-  background: #0f172a;
-  color: #f8fafc;
   padding: 12px 14px;
+  background: rgba(15, 23, 42, 0.75);
+  color: #f8fafc;
   font-size: 1rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
@@ -66,198 +72,156 @@
   box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.25);
 }
 
-.primaryButton {
-  align-self: flex-start;
+.searchButton {
   background: linear-gradient(135deg, #2563eb, #7c3aed);
   color: #f8fafc;
   border: none;
   border-radius: 10px;
-  padding: 12px 20px;
-  font-size: 1rem;
+  padding: 12px 24px;
   font-weight: 600;
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-.primaryButton:hover:not(:disabled) {
+.searchButton:hover:not(:disabled) {
   transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.35);
+  box-shadow: 0 12px 24px rgba(59, 130, 246, 0.35);
 }
 
-.primaryButton:disabled {
+.searchButton:disabled {
   opacity: 0.6;
   cursor: wait;
 }
 
-.searchForm {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-  align-items: flex-end;
+.feedback {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #cbd5f5;
 }
 
 .error {
   color: #f87171;
-  margin: 0;
 }
 
-.summary {
-  margin: 0;
+.resultsCard {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 12px 36px rgba(15, 23, 42, 0.35);
+}
+
+.resultsTableWrapper {
+  overflow-x: auto;
+}
+
+.resultsTable {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 560px;
+}
+
+.resultsTable thead th {
+  text-align: left;
+  font-weight: 600;
+  color: #cbd5f5;
+  padding: 12px 10px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.resultsTable tbody td {
+  padding: 12px 10px;
+  border-bottom: 1px solid rgba(30, 41, 59, 0.6);
+  font-size: 0.95rem;
+  color: #e2e8f0;
+}
+
+.resultsTable tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.fileCell {
+  font-family: 'SFMono-Regular', 'Consolas', 'Liberation Mono', monospace;
+  font-size: 0.9rem;
+  color: #bfdbfe;
+  word-break: break-all;
+}
+
+.sizeCell {
+  white-space: nowrap;
+}
+
+.dateCell {
+  white-space: nowrap;
   color: #cbd5f5;
 }
 
-.term {
-  background: rgba(59, 130, 246, 0.2);
-  color: #e0e7ff;
-  padding: 2px 6px;
-  border-radius: 6px;
-}
-
-.resultsList {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.resultItem {
-  border: 1px solid #1f2937;
-  border-radius: 14px;
-  padding: 16px 18px;
-  background: rgba(17, 24, 39, 0.7);
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.resultHeader {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.resultTitleBlock {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.jobId {
-  font-family: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Courier New', monospace;
-  font-size: 0.85rem;
-  color: #a5b4fc;
-  background: rgba(76, 29, 149, 0.35);
-  border: 1px solid rgba(165, 180, 252, 0.4);
-  padding: 2px 8px;
-  border-radius: 999px;
-  width: fit-content;
-}
-
-.resultTitle {
-  font-size: 1.15rem;
-  margin: 0;
+.downloadLink {
+  color: #60a5fa;
+  text-decoration: none;
   font-weight: 600;
 }
 
-.resultMeta {
-  margin: 0;
-  color: #cbd5f5;
-  font-size: 0.95rem;
-}
-
-.customerInfo {
-  margin: 0;
-  color: #e2e8f0;
-  font-size: 0.9rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  align-items: center;
-}
-
-.customerEmail {
-  color: #93c5fd;
-  text-decoration: none;
-}
-
-.customerEmail:hover {
+.downloadLink:hover {
   text-decoration: underline;
 }
 
-.resultDate {
-  color: #94a3b8;
-  font-size: 0.9rem;
-  display: flex;
-  align-items: flex-start;
-}
-
-.linksRow {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.preview {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: #0f172a;
-  border: 1px solid #1f2937;
-  border-radius: 12px;
-  padding: 12px;
-  overflow: hidden;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.preview:hover {
-  border-color: rgba(96, 165, 250, 0.6);
-  box-shadow: 0 8px 20px rgba(96, 165, 250, 0.18);
-}
-
-.previewImage {
-  max-width: 100%;
-  max-height: 220px;
-  border-radius: 8px;
-  object-fit: contain;
-  display: block;
-}
-
-.link {
-  text-decoration: none;
-  font-weight: 500;
-  color: #bfdbfe;
-  background: rgba(37, 99, 235, 0.18);
-  border: 1px solid rgba(59, 130, 246, 0.35);
-  padding: 8px 12px;
-  border-radius: 10px;
-  transition: background 0.2s ease, border-color 0.2s ease;
-}
-
-.link:hover {
-  background: rgba(37, 99, 235, 0.32);
-  border-color: rgba(96, 165, 250, 0.6);
-}
-
-.emptyState {
+.noResults {
   margin: 0;
-  color: #9ca3af;
-  font-style: italic;
+  padding: 24px;
+  text-align: center;
+  color: #94a3b8;
+}
+
+.pagination {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.pagination button {
+  background: rgba(30, 64, 175, 0.6);
+  border: 1px solid rgba(59, 130, 246, 0.4);
+  color: #e0f2fe;
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.pagination button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.pagination button:not(:disabled):hover {
+  background: rgba(30, 64, 175, 0.8);
+}
+
+.paginationStatus {
+  margin: 0;
+  color: #cbd5f5;
+  font-size: 0.9rem;
 }
 
 @media (max-width: 640px) {
-  .card {
-    padding: 20px;
-  }
-
   .searchForm {
     flex-direction: column;
     align-items: stretch;
   }
 
-  .primaryButton {
+  .searchButton {
+    width: 100%;
+  }
+
+  .pagination {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .pagination button {
     width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- add a reusable helper that stores printable PDFs in Supabase using the service role and returns a signed URL
- update the Shopify product creator to save only the printable PDF to Supabase with the expected metadata
- expose a GET /api/outputs/search endpoint and a new /busqueda UI to find and download PDFs by filename

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6f37d6f948327b2f93563df82003f