### PR TITLE
feat: upload print pdfs to supabase outputs bucket

### DIFF
--- a/api/[...slug].js
+++ b/api/[...slug].js
@@ -24,6 +24,8 @@ const RATE_LIMITS = {
   'POST variant-status': { limit: 90, windowMs: 60_000 },
   'GET search-assets': { limit: 30, windowMs: 60_000 },
   'GET outputs/search': { limit: 30, windowMs: 60_000 },
+  'POST prints/upload': { limit: 12, windowMs: 60_000 },
+  'GET prints/search': { limit: 30, windowMs: 60_000 },
   'POST shopify-webhook': { limit: 60, windowMs: 60_000 },
 };
 
@@ -107,6 +109,17 @@ export default withCors(async function handler(req, res) {
       case 'GET outputs/search': {
         const { searchOutputFiles } = await import('../lib/api/handlers/outputsSearch.js');
         const { status, body } = await searchOutputFiles({ query: req.query });
+        res.statusCode = status;
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        return res.end(JSON.stringify(body));
+      }
+      case 'POST prints/upload': {
+        const { uploadPrintHandler } = await import('../lib/api/handlers/printsUpload.js');
+        return uploadPrintHandler(req, res);
+      }
+      case 'GET prints/search': {
+        const { searchPrintsHandler } = await import('../lib/api/handlers/printsSearch.js');
+        const { status, body } = await searchPrintsHandler({ query: req.query });
         res.statusCode = status;
         res.setHeader('Content-Type', 'application/json; charset=utf-8');
         return res.end(JSON.stringify(body));

--- a/lib/_lib/generatePrintPdf.js
+++ b/lib/_lib/generatePrintPdf.js
@@ -1,0 +1,140 @@
+import sharp from 'sharp';
+
+const CM_PER_INCH = 2.54;
+const DEFAULT_DPI = 300;
+const MARGIN_CM = 2;
+
+function cmToPixels(valueCm) {
+  const numeric = Number(valueCm);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    throw new Error('invalid_dimension');
+  }
+  return Math.max(1, Math.round((numeric / CM_PER_INCH) * DEFAULT_DPI));
+}
+
+function normalizeColor(input) {
+  const raw = String(input || '').trim().toLowerCase();
+  if (!raw) return '#ffffff';
+  const hexMatch = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(raw);
+  if (!hexMatch) return '#ffffff';
+  const [, value] = hexMatch;
+  if (value.length === 3) {
+    return `#${value.split('').map((ch) => ch + ch).join('')}`;
+  }
+  return `#${value}`;
+}
+
+export async function generatePrintPdf({
+  widthCm,
+  heightCm,
+  backgroundColor,
+  imageBuffer,
+}) {
+  if (!Buffer.isBuffer(imageBuffer) || imageBuffer.length === 0) {
+    const error = new Error('invalid_image_buffer');
+    error.code = 'invalid_image_buffer';
+    throw error;
+  }
+
+  const areaWidthCm = Number(widthCm);
+  const areaHeightCm = Number(heightCm);
+  if (!Number.isFinite(areaWidthCm) || areaWidthCm <= 0) {
+    const error = new Error('invalid_width_cm');
+    error.code = 'invalid_width_cm';
+    throw error;
+  }
+  if (!Number.isFinite(areaHeightCm) || areaHeightCm <= 0) {
+    const error = new Error('invalid_height_cm');
+    error.code = 'invalid_height_cm';
+    throw error;
+  }
+
+  const pageWidthCm = areaWidthCm + MARGIN_CM * 2;
+  const pageHeightCm = areaHeightCm + MARGIN_CM * 2;
+
+  const pageWidthPx = cmToPixels(pageWidthCm);
+  const pageHeightPx = cmToPixels(pageHeightCm);
+  const marginPx = cmToPixels(MARGIN_CM);
+  const areaWidthPx = pageWidthPx - marginPx * 2;
+  const areaHeightPx = pageHeightPx - marginPx * 2;
+
+  const normalizedColor = normalizeColor(backgroundColor);
+
+  let artworkBuffer;
+  let artworkMetadata;
+  try {
+    const pipeline = sharp(imageBuffer)
+      .rotate()
+      .resize({
+        width: areaWidthPx,
+        height: areaHeightPx,
+        fit: 'cover',
+        position: 'centre',
+        withoutEnlargement: true,
+      })
+      .png();
+    artworkBuffer = await pipeline.toBuffer();
+    artworkMetadata = await sharp(artworkBuffer).metadata();
+  } catch (err) {
+    const error = new Error('artwork_processing_failed');
+    error.code = 'artwork_processing_failed';
+    error.cause = err;
+    throw error;
+  }
+
+  const artworkWidthPx = Math.min(areaWidthPx, artworkMetadata?.width || areaWidthPx);
+  const artworkHeightPx = Math.min(areaHeightPx, artworkMetadata?.height || areaHeightPx);
+  const offsetLeft = Math.round(marginPx + Math.max(0, (areaWidthPx - artworkWidthPx) / 2));
+  const offsetTop = Math.round(marginPx + Math.max(0, (areaHeightPx - artworkHeightPx) / 2));
+
+  let pdfBuffer;
+  try {
+    const canvas = sharp({
+      create: {
+        width: pageWidthPx,
+        height: pageHeightPx,
+        channels: 3,
+        background: normalizedColor,
+      },
+    });
+    pdfBuffer = await canvas
+      .composite([
+        {
+          input: artworkBuffer,
+          left: offsetLeft,
+          top: offsetTop,
+        },
+      ])
+      .withMetadata({ density: DEFAULT_DPI })
+      .toFormat('pdf')
+      .toBuffer();
+  } catch (err) {
+    const error = new Error('pdf_generation_failed');
+    error.code = 'pdf_generation_failed';
+    error.cause = err;
+    throw error;
+  }
+
+  return {
+    buffer: pdfBuffer,
+    info: {
+      pageWidthCm,
+      pageHeightCm,
+      marginCm: MARGIN_CM,
+      dpi: DEFAULT_DPI,
+      area: {
+        widthCm: areaWidthCm,
+        heightCm: areaHeightCm,
+        widthPx: areaWidthPx,
+        heightPx: areaHeightPx,
+      },
+      artwork: {
+        widthPx: artworkWidthPx,
+        heightPx: artworkHeightPx,
+      },
+      backgroundColor: normalizedColor,
+    },
+  };
+}
+
+export default generatePrintPdf;

--- a/lib/_lib/uploadPrintPdf.js
+++ b/lib/_lib/uploadPrintPdf.js
@@ -1,0 +1,114 @@
+import { randomUUID } from 'node:crypto';
+import getSupabaseAdmin from './supabaseAdmin.js';
+
+const OUTPUT_BUCKET = 'outputs';
+const SIGNED_URL_TTL_SECONDS = 86_400; // 24 horas
+
+function ensureFilename(input) {
+  const raw = String(input || '').trim().toLowerCase();
+  if (!raw) {
+    return `${randomUUID().replace(/[^a-z0-9]/gi, '').slice(0, 12)}.pdf`;
+  }
+  const lastSegment = raw.split(/[\\/]/).pop() || raw;
+  const ensured = lastSegment.endsWith('.pdf') ? lastSegment : `${lastSegment}.pdf`;
+  return ensured.replace(/[^a-z0-9._-]+/gi, '-');
+}
+
+function buildPdfPath(filename) {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  return `print/${year}/${month}/${filename}`;
+}
+
+function normalizeMetadata(meta = {}) {
+  const base = { createdBy: 'prints-upload', private: 'false' };
+  const output = { ...base };
+  for (const [key, value] of Object.entries(meta)) {
+    if (value == null) continue;
+    if (typeof value === 'boolean') {
+      output[key] = value ? 'true' : 'false';
+    } else {
+      output[key] = typeof value === 'string' ? value : String(value);
+    }
+  }
+  if (!('createdBy' in output)) output.createdBy = 'prints-upload';
+  return output;
+}
+
+export async function uploadPrintPdf({ buffer, filename, metadata = {}, diagId }) {
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+    const error = new Error('pdf_buffer_empty');
+    error.code = 'pdf_buffer_empty';
+    throw error;
+  }
+
+  const localDiag = diagId || randomUUID();
+
+  let supabase;
+  try {
+    supabase = getSupabaseAdmin();
+  } catch (err) {
+    console.error('pdf_upload_env_error', { diagId: localDiag, message: err?.message || err });
+    const error = new Error('supabase_credentials_missing');
+    error.code = 'supabase_credentials_missing';
+    error.cause = err;
+    throw error;
+  }
+
+  const safeFilename = ensureFilename(filename);
+  const path = buildPdfPath(safeFilename);
+  const size = buffer.length;
+
+  const storage = supabase.storage.from(OUTPUT_BUCKET);
+  const { error: uploadError } = await storage.upload(path, buffer, {
+    contentType: 'application/pdf',
+    upsert: true,
+    cacheControl: '3600',
+    metadata: normalizeMetadata(metadata),
+  });
+
+  if (uploadError) {
+    console.error('pdf_upload_error', {
+      diagId: localDiag,
+      path,
+      size,
+      status: uploadError?.status || uploadError?.statusCode || null,
+      message: uploadError?.message,
+      name: uploadError?.name,
+    });
+    const error = new Error('supabase_upload_failed');
+    error.code = 'supabase_upload_failed';
+    error.cause = uploadError;
+    throw error;
+  }
+
+  const { data: publicData } = storage.getPublicUrl(path);
+  const publicUrl = publicData?.publicUrl || null;
+
+  const { data: signedData, error: signedError } = await storage.createSignedUrl(path, SIGNED_URL_TTL_SECONDS, {
+    download: safeFilename,
+  });
+
+  if (signedError) {
+    console.error('pdf_upload_signed_url_error', {
+      diagId: localDiag,
+      path,
+      size,
+      status: signedError?.status || signedError?.statusCode || null,
+      message: signedError?.message,
+      name: signedError?.name,
+    });
+  }
+
+  return {
+    bucket: OUTPUT_BUCKET,
+    path,
+    publicUrl,
+    signedUrl: signedData?.signedUrl || null,
+    expiresIn: SIGNED_URL_TTL_SECONDS,
+    diagId: localDiag,
+  };
+}
+
+export default uploadPrintPdf;

--- a/lib/api/handlers/printsSearch.js
+++ b/lib/api/handlers/printsSearch.js
@@ -1,0 +1,167 @@
+import { randomUUID } from 'node:crypto';
+import getSupabaseAdmin from '../../_lib/supabaseAdmin.js';
+
+const OUTPUT_BUCKET = 'outputs';
+const SIGNED_URL_TTL_SECONDS = 86_400;
+const MIN_QUERY_LENGTH = 2;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const MAX_MONTHS = 12;
+
+function parseLimit(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return DEFAULT_LIMIT;
+  return Math.min(Math.max(Math.floor(num), 1), MAX_LIMIT);
+}
+
+function parseOffset(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num < 0) return 0;
+  return Math.floor(num);
+}
+
+function normalizeName(input) {
+  return String(input || '')
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase();
+}
+
+function monthPrefixes(count) {
+  const now = new Date();
+  const entries = [];
+  for (let idx = 0; idx < count; idx += 1) {
+    const date = new Date(now.getFullYear(), now.getMonth() - idx, 1);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    entries.push({ year, month, key: `print/${year}/${month}` });
+  }
+  return entries;
+}
+
+function toTimestamp(value) {
+  if (!value) return 0;
+  const ts = Date.parse(value);
+  return Number.isFinite(ts) ? ts : 0;
+}
+
+export async function searchPrintsHandler({ query } = {}) {
+  const diagId = randomUUID();
+  const rawQuery = typeof query?.query === 'string' ? query.query.trim() : '';
+
+  if (!rawQuery) {
+    return {
+      status: 400,
+      body: { ok: false, diagId, error: 'missing_query', message: 'Ingresá al menos 2 caracteres para buscar.' },
+    };
+  }
+
+  if (rawQuery.length < MIN_QUERY_LENGTH) {
+    return {
+      status: 400,
+      body: { ok: false, diagId, error: 'query_too_short', message: 'Ingresá al menos 2 caracteres para buscar.' },
+    };
+  }
+
+  const limit = parseLimit(query?.limit);
+  const offset = parseOffset(query?.offset);
+  const normalizedQuery = normalizeName(rawQuery.replace(/\.pdf$/i, ''));
+
+  let supabase;
+  try {
+    supabase = getSupabaseAdmin();
+  } catch (err) {
+    console.error('search_env_error', { diagId, message: err?.message || err });
+    return {
+      status: 500,
+      body: { ok: false, diagId, error: 'supabase_credentials_missing', message: 'Faltan credenciales de Supabase.' },
+    };
+  }
+
+  const storage = supabase.storage.from(OUTPUT_BUCKET);
+
+  console.info('search_request', { diagId, query: rawQuery, limit, offset });
+
+  const months = monthPrefixes(MAX_MONTHS);
+  const matches = [];
+
+  for (const month of months) {
+    const { data, error } = await storage.list(month.key, {
+      limit: 1000,
+      sortBy: { column: 'created_at', order: 'desc' },
+    });
+    if (error) {
+      console.error('search_list_error', {
+        diagId,
+        prefix: month.key,
+        status: error?.status || error?.statusCode || null,
+        message: error?.message,
+      });
+      return {
+        status: 502,
+        body: { ok: false, diagId, error: 'storage_unavailable', message: 'No se pudo acceder a Supabase Storage.' },
+      };
+    }
+    if (!Array.isArray(data) || !data.length) continue;
+    for (const entry of data) {
+      if (!entry || typeof entry.name !== 'string') continue;
+      if (!entry.name.toLowerCase().endsWith('.pdf')) continue;
+      const baseName = entry.name.replace(/\.pdf$/i, '');
+      const normalizedName = normalizeName(baseName);
+      if (!normalizedName.startsWith(normalizedQuery) && !baseName.toLowerCase().startsWith(rawQuery.toLowerCase())) {
+        continue;
+      }
+      matches.push({
+        name: entry.name,
+        path: `${month.key}/${entry.name}`,
+        createdAt: entry.created_at || entry.updated_at || entry.last_accessed_at || null,
+        size: entry.metadata?.size ?? null,
+      });
+    }
+  }
+
+  matches.sort((a, b) => toTimestamp(b.createdAt) - toTimestamp(a.createdAt));
+
+  const total = matches.length;
+  const slice = matches.slice(offset, offset + limit);
+
+  const items = await Promise.all(
+    slice.map(async (item) => {
+      const { data, error } = await storage.createSignedUrl(item.path, SIGNED_URL_TTL_SECONDS, { download: item.name });
+      if (error) {
+        console.error('search_signed_url_error', {
+          diagId,
+          path: item.path,
+          status: error?.status || error?.statusCode || null,
+          message: error?.message,
+        });
+      }
+      return {
+        name: item.name,
+        path: item.path,
+        size: item.size,
+        createdAt: item.createdAt,
+        downloadUrl: data?.signedUrl || null,
+        expiresIn: SIGNED_URL_TTL_SECONDS,
+      };
+    }),
+  );
+
+  console.info('search_result_count', { diagId, query: rawQuery, total, returned: items.length });
+
+  return {
+    status: 200,
+    body: {
+      ok: true,
+      diagId,
+      items,
+      pagination: {
+        limit,
+        offset,
+        total,
+      },
+    },
+  };
+}
+
+export default searchPrintsHandler;

--- a/lib/api/handlers/printsUpload.js
+++ b/lib/api/handlers/printsUpload.js
@@ -1,0 +1,287 @@
+import { randomUUID } from 'node:crypto';
+import { slugifyName } from '../../_lib/slug.js';
+import generatePrintPdf from '../../_lib/generatePrintPdf.js';
+import uploadPrintPdf from '../../_lib/uploadPrintPdf.js';
+
+function toObject(input) {
+  if (!input) return {};
+  if (typeof input === 'object') return input;
+  if (typeof input === 'string') {
+    try { return JSON.parse(input); } catch { return {}; }
+  }
+  return {};
+}
+
+function parseNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function formatDimensionSegment(value) {
+  const rounded = Math.round(value * 10) / 10;
+  if (Math.abs(rounded - Math.round(rounded)) < 1e-6) {
+    return String(Math.round(rounded));
+  }
+  return rounded
+    .toFixed(1)
+    .replace(/\.0$/, '')
+    .replace('.', 'p')
+    .replace(/[^0-9p]+/gi, '');
+}
+
+function sanitizeMaterial(input) {
+  const raw = String(input || '').trim();
+  if (!raw) return 'material';
+  return slugifyName(raw) || 'material';
+}
+
+function sanitizeJobId(input) {
+  const raw = String(input || '').trim();
+  if (!raw) return randomUUID().replace(/[^a-z0-9]/gi, '').slice(0, 8);
+  const slug = slugifyName(raw);
+  if (slug) return slug;
+  return randomUUID().replace(/[^a-z0-9]/gi, '').slice(0, 8);
+}
+
+function buildFilename({ slug, widthCm, heightCm, material, jobId }) {
+  const safeSlug = slugifyName(slug) || 'diseno';
+  const widthSegment = formatDimensionSegment(widthCm);
+  const heightSegment = formatDimensionSegment(heightCm);
+  const size = `${widthSegment}x${heightSegment}`;
+  const materialSegment = sanitizeMaterial(material);
+  const jobSegment = sanitizeJobId(jobId);
+  return `${[safeSlug, size, materialSegment, jobSegment].join('-')}.pdf`;
+}
+
+function normalizeColor(input) {
+  const raw = String(input || '').trim().toLowerCase();
+  if (!raw) return '#ffffff';
+  const match = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(raw);
+  if (!match) return '#ffffff';
+  const [, value] = match;
+  if (value.length === 3) {
+    return `#${value.split('').map((ch) => ch + ch).join('')}`;
+  }
+  return `#${value}`;
+}
+
+async function readRawBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk) => { data += chunk; });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+function parseDataUrl(value) {
+  const match = /^data:([^;,]+);base64,(.+)$/i.exec(String(value || ''));
+  if (!match) return null;
+  const [, mime, data] = match;
+  if (!mime || !data) return null;
+  try {
+    const buffer = Buffer.from(data, 'base64');
+    return buffer.length ? buffer : null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveImageBuffer(source) {
+  const trimmed = String(source || '').trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('data:')) {
+    return parseDataUrl(trimmed);
+  }
+  if (/^https?:\/\//i.test(trimmed)) {
+    const response = await fetch(trimmed);
+    if (!response.ok) {
+      const error = new Error(`download_failed_${response.status}`);
+      error.status = response.status;
+      throw error;
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    return buffer.length ? buffer : null;
+  }
+  return null;
+}
+
+function extractImageSource(payload) {
+  const candidates = [
+    payload?.imageUrl,
+    payload?.image_url,
+    payload?.image,
+    payload?.imageBlob,
+    payload?.image_blob,
+    payload?.dataUrl,
+    payload?.data_url,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return null;
+}
+
+export async function uploadPrintHandler(req, res) {
+  const diagId = randomUUID();
+  const requestIdHeader = req.headers['x-request-id'];
+  const requestId = Array.isArray(requestIdHeader)
+    ? requestIdHeader[0]
+    : typeof requestIdHeader === 'string'
+      ? requestIdHeader
+      : undefined;
+  res.setHeader('X-Diag-Id', diagId);
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ ok: false, diagId, requestId, error: 'method_not_allowed' });
+  }
+
+  let payload = toObject(req.body);
+  if (!payload || !Object.keys(payload).length) {
+    try {
+      const raw = await readRawBody(req);
+      payload = toObject(raw);
+    } catch (err) {
+      console.error('pdf_upload_parse_error', { diagId, requestId, message: err?.message || err });
+      return res.status(400).json({ ok: false, diagId, requestId, error: 'invalid_body' });
+    }
+  }
+
+  const jobId = typeof payload.jobId === 'string' ? payload.jobId.trim() : '';
+  const slug = typeof payload.slug === 'string' ? payload.slug.trim() : '';
+  const material = typeof payload.material === 'string' ? payload.material.trim() : '';
+  const backgroundColor = normalizeColor(payload.backgroundColor || payload.background_color);
+
+  const widthCm = parseNumber(payload.largoCm ?? payload.widthCm ?? payload.width_cm);
+  const heightCm = parseNumber(payload.anchoCm ?? payload.heightCm ?? payload.height_cm);
+
+  if (!widthCm || widthCm <= 0 || !heightCm || heightCm <= 0) {
+    return res.status(400).json({ ok: false, diagId, requestId, error: 'invalid_dimensions' });
+  }
+
+  const imageSource = extractImageSource(payload);
+  if (!imageSource) {
+    return res.status(400).json({ ok: false, diagId, requestId, error: 'missing_image_source' });
+  }
+
+  let imageBuffer;
+  try {
+    imageBuffer = await resolveImageBuffer(imageSource);
+  } catch (err) {
+    console.error('pdf_image_download_error', {
+      diagId,
+      requestId,
+      message: err?.message || err,
+      status: err?.status || err?.statusCode || null,
+    });
+    return res.status(400).json({ ok: false, diagId, requestId, error: 'image_download_failed' });
+  }
+
+  if (!imageBuffer || !imageBuffer.length) {
+    return res.status(400).json({ ok: false, diagId, requestId, error: 'empty_image' });
+  }
+
+  const filename = buildFilename({
+    slug,
+    widthCm,
+    heightCm,
+    material,
+    jobId,
+  });
+
+  console.info('pdf_generate_start', {
+    diagId,
+    requestId,
+    jobId,
+    slug: slug || null,
+    material: material || null,
+    widthCm,
+    heightCm,
+  });
+
+  let pdfResult;
+  try {
+    pdfResult = await generatePrintPdf({
+      widthCm,
+      heightCm,
+      backgroundColor,
+      imageBuffer,
+    });
+  } catch (err) {
+    console.error('pdf_generate_error', {
+      diagId,
+      requestId,
+      error: err?.code || err?.message || 'pdf_generate_error',
+      message: err?.message || err,
+    });
+    return res.status(500).json({ ok: false, diagId, requestId, error: 'pdf_generation_failed' });
+  }
+
+  console.info('pdf_generate_end', {
+    diagId,
+    requestId,
+    jobId,
+    filename,
+    size: pdfResult.buffer.length,
+    pageWidthCm: pdfResult.info.pageWidthCm,
+    pageHeightCm: pdfResult.info.pageHeightCm,
+  });
+
+  console.info('pdf_upload_start', {
+    diagId,
+    requestId,
+    jobId,
+    filename,
+    size: pdfResult.buffer.length,
+  });
+
+  let uploadResult;
+  try {
+    uploadResult = await uploadPrintPdf({
+      buffer: pdfResult.buffer,
+      filename,
+      metadata: {
+        jobId: jobId || undefined,
+        slug: slug || undefined,
+        widthCm,
+        heightCm,
+        material: material || undefined,
+        backgroundColor: pdfResult.info.backgroundColor,
+      },
+      diagId,
+    });
+  } catch (err) {
+    console.error('pdf_upload_failure', {
+      diagId,
+      requestId,
+      error: err?.code || err?.message || 'pdf_upload_failure',
+      message: err?.message || err,
+    });
+    return res.status(502).json({ ok: false, diagId, requestId, error: 'pdf_upload_failed' });
+  }
+
+  console.info('pdf_upload_end', {
+    diagId,
+    requestId,
+    jobId,
+    filename,
+    bucket: uploadResult.bucket,
+    path: uploadResult.path,
+  });
+
+  return res.status(200).json({
+    ok: true,
+    diagId,
+    requestId,
+    bucket: uploadResult.bucket,
+    path: uploadResult.path,
+    publicUrl: uploadResult.publicUrl,
+    signedUrl: uploadResult.signedUrl,
+    expiresIn: uploadResult.expiresIn,
+    filename,
+  });
+}
+
+export default uploadPrintHandler;

--- a/mgm-front/src/pages/Busqueda.jsx
+++ b/mgm-front/src/pages/Busqueda.jsx
@@ -69,9 +69,9 @@ export default function Busqueda() {
         limit: String(PAGE_LIMIT),
         offset: String(Math.max(0, nextOffset)),
       });
-      const response = await apiFetch(`/api/outputs/search?${params.toString()}`);
+      const response = await apiFetch(`/api/prints/search?${params.toString()}`);
       const payload = await response.json().catch(() => ({}));
-      if (!response.ok) {
+      if (!response.ok || payload?.ok === false) {
         const message = typeof payload?.message === 'string'
           ? payload.message
           : typeof payload?.error === 'string'


### PR DESCRIPTION
## Summary
- add a server-side PDF generator with bleed support and a Supabase upload helper dedicated to print outputs
- expose POST `/api/prints/upload` for PDF creation/upload and GET `/api/prints/search` to list downloadable files
- update the `/busqueda` page to query the new search endpoint and handle API errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6f8885e0c83279b0a824e6843c025