### PR TITLE
Ensure print uploads only store validated PDFs

### DIFF
--- a/lib/_lib/generatePrintPdf.js
+++ b/lib/_lib/generatePrintPdf.js
@@ -1,15 +1,30 @@
 import sharp from 'sharp';
+import { PDFDocument, rgb } from 'pdf-lib';
 
 const CM_PER_INCH = 2.54;
 const DEFAULT_DPI = 300;
 const MARGIN_CM = 2;
+const POINTS_PER_CM = 72 / CM_PER_INCH;
+const PIXELS_PER_CM = DEFAULT_DPI / CM_PER_INCH;
 
 function cmToPixels(valueCm) {
   const numeric = Number(valueCm);
   if (!Number.isFinite(numeric) || numeric <= 0) {
-    throw new Error('invalid_dimension');
+    const error = new Error('invalid_dimension');
+    error.code = 'invalid_dimension';
+    throw error;
   }
-  return Math.max(1, Math.round((numeric / CM_PER_INCH) * DEFAULT_DPI));
+  return Math.max(1, Math.round(numeric * PIXELS_PER_CM));
+}
+
+function cmToPoints(valueCm) {
+  const numeric = Number(valueCm);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    const error = new Error('invalid_dimension');
+    error.code = 'invalid_dimension';
+    throw error;
+  }
+  return numeric * POINTS_PER_CM;
 }
 
 function normalizeColor(input) {
@@ -22,6 +37,15 @@ function normalizeColor(input) {
     return `#${value.split('').map((ch) => ch + ch).join('')}`;
   }
   return `#${value}`;
+}
+
+function hexToRgb(hexColor) {
+  const normalized = normalizeColor(hexColor);
+  const value = normalized.replace('#', '');
+  const r = Number.parseInt(value.slice(0, 2), 16);
+  const g = Number.parseInt(value.slice(2, 4), 16);
+  const b = Number.parseInt(value.slice(4, 6), 16);
+  return { r, g, b };
 }
 
 export async function generatePrintPdf({
@@ -52,13 +76,11 @@ export async function generatePrintPdf({
   const pageWidthCm = areaWidthCm + MARGIN_CM * 2;
   const pageHeightCm = areaHeightCm + MARGIN_CM * 2;
 
-  const pageWidthPx = cmToPixels(pageWidthCm);
-  const pageHeightPx = cmToPixels(pageHeightCm);
-  const marginPx = cmToPixels(MARGIN_CM);
-  const areaWidthPx = pageWidthPx - marginPx * 2;
-  const areaHeightPx = pageHeightPx - marginPx * 2;
+  const areaWidthPx = cmToPixels(areaWidthCm);
+  const areaHeightPx = cmToPixels(areaHeightCm);
 
   const normalizedColor = normalizeColor(backgroundColor);
+  const { r, g, b } = hexToRgb(normalizedColor);
 
   let artworkBuffer;
   let artworkMetadata;
@@ -71,9 +93,12 @@ export async function generatePrintPdf({
         fit: 'cover',
         position: 'centre',
         withoutEnlargement: true,
+        background: { r, g, b, alpha: 1 },
       })
-      .png();
-    artworkBuffer = await pipeline.toBuffer();
+      .toColourspace('srgb');
+    artworkBuffer = await pipeline
+      .png({ compressionLevel: 9, adaptiveFiltering: true })
+      .toBuffer();
     artworkMetadata = await sharp(artworkBuffer).metadata();
   } catch (err) {
     const error = new Error('artwork_processing_failed');
@@ -84,30 +109,61 @@ export async function generatePrintPdf({
 
   const artworkWidthPx = Math.min(areaWidthPx, artworkMetadata?.width || areaWidthPx);
   const artworkHeightPx = Math.min(areaHeightPx, artworkMetadata?.height || areaHeightPx);
-  const offsetLeft = Math.round(marginPx + Math.max(0, (areaWidthPx - artworkWidthPx) / 2));
-  const offsetTop = Math.round(marginPx + Math.max(0, (areaHeightPx - artworkHeightPx) / 2));
+  const offsetLeftPx = Math.max(0, Math.round((areaWidthPx - artworkWidthPx) / 2));
+  const offsetTopPx = Math.max(0, Math.round((areaHeightPx - artworkHeightPx) / 2));
 
-  let pdfBuffer;
+  let areaCompositeBuffer;
   try {
-    const canvas = sharp({
+    areaCompositeBuffer = await sharp({
       create: {
-        width: pageWidthPx,
-        height: pageHeightPx,
-        channels: 3,
-        background: normalizedColor,
+        width: areaWidthPx,
+        height: areaHeightPx,
+        channels: 4,
+        background: { r, g, b, alpha: 1 },
       },
-    });
-    pdfBuffer = await canvas
+    })
       .composite([
         {
           input: artworkBuffer,
-          left: offsetLeft,
-          top: offsetTop,
+          left: offsetLeftPx,
+          top: offsetTopPx,
         },
       ])
-      .withMetadata({ density: DEFAULT_DPI })
-      .toFormat('pdf')
+      .toColourspace('srgb')
+      .png({ compressionLevel: 9, adaptiveFiltering: true })
       .toBuffer();
+  } catch (err) {
+    const error = new Error('area_composite_failed');
+    error.code = 'area_composite_failed';
+    error.cause = err;
+    throw error;
+  }
+
+  let pdfBuffer;
+  try {
+    const pdfDoc = await PDFDocument.create();
+    const pageWidthPt = cmToPoints(pageWidthCm);
+    const pageHeightPt = cmToPoints(pageHeightCm);
+    const marginPt = cmToPoints(MARGIN_CM);
+    const page = pdfDoc.addPage([pageWidthPt, pageHeightPt]);
+    page.drawRectangle({
+      x: 0,
+      y: 0,
+      width: pageWidthPt,
+      height: pageHeightPt,
+      color: rgb(r / 255, g / 255, b / 255),
+    });
+    const embedded = await pdfDoc.embedPng(areaCompositeBuffer);
+    const areaWidthPt = cmToPoints(areaWidthCm);
+    const areaHeightPt = cmToPoints(areaHeightCm);
+    page.drawImage(embedded, {
+      x: marginPt,
+      y: marginPt,
+      width: areaWidthPt,
+      height: areaHeightPt,
+    });
+    const uint8 = await pdfDoc.save();
+    pdfBuffer = Buffer.from(uint8);
   } catch (err) {
     const error = new Error('pdf_generation_failed');
     error.code = 'pdf_generation_failed';
@@ -131,8 +187,90 @@ export async function generatePrintPdf({
       artwork: {
         widthPx: artworkWidthPx,
         heightPx: artworkHeightPx,
+        offsetLeftPx,
+        offsetTopPx,
       },
       backgroundColor: normalizedColor,
+    },
+  };
+}
+
+export async function validatePrintPdf({
+  buffer,
+  expectedPageWidthCm,
+  expectedPageHeightCm,
+  expectedAreaWidthCm,
+  expectedAreaHeightCm,
+  marginCm = MARGIN_CM,
+  toleranceMm = 1,
+}) {
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+    const error = new Error('pdf_buffer_empty');
+    error.code = 'pdf_buffer_empty';
+    throw error;
+  }
+
+  let doc;
+  try {
+    doc = await PDFDocument.load(buffer);
+  } catch (err) {
+    const error = new Error('pdf_parse_failed');
+    error.code = 'pdf_parse_failed';
+    error.cause = err;
+    throw error;
+  }
+
+  const [page] = doc.getPages();
+  if (!page) {
+    const error = new Error('pdf_page_missing');
+    error.code = 'pdf_page_missing';
+    throw error;
+  }
+
+  const { width: pageWidthPt, height: pageHeightPt } = page.getSize();
+  const measuredPageWidthCm = pageWidthPt / POINTS_PER_CM;
+  const measuredPageHeightCm = pageHeightPt / POINTS_PER_CM;
+  const measuredAreaWidthCm = measuredPageWidthCm - marginCm * 2;
+  const measuredAreaHeightCm = measuredPageHeightCm - marginCm * 2;
+
+  const expectedPageWidth = Number(expectedPageWidthCm);
+  const expectedPageHeight = Number(expectedPageHeightCm);
+  const expectedAreaWidth = Number(expectedAreaWidthCm);
+  const expectedAreaHeight = Number(expectedAreaHeightCm);
+
+  const deltaPageWidthMm = Math.abs(measuredPageWidthCm - expectedPageWidth) * 10;
+  const deltaPageHeightMm = Math.abs(measuredPageHeightCm - expectedPageHeight) * 10;
+  const deltaAreaWidthMm = Math.abs(measuredAreaWidthCm - expectedAreaWidth) * 10;
+  const deltaAreaHeightMm = Math.abs(measuredAreaHeightCm - expectedAreaHeight) * 10;
+
+  const ok = [
+    deltaPageWidthMm,
+    deltaPageHeightMm,
+    deltaAreaWidthMm,
+    deltaAreaHeightMm,
+  ].every((delta) => delta <= toleranceMm + 1e-6);
+
+  return {
+    ok,
+    toleranceMm,
+    expected: {
+      pageWidthCm: expectedPageWidth,
+      pageHeightCm: expectedPageHeight,
+      areaWidthCm: expectedAreaWidth,
+      areaHeightCm: expectedAreaHeight,
+      marginCm,
+    },
+    measured: {
+      pageWidthCm: measuredPageWidthCm,
+      pageHeightCm: measuredPageHeightCm,
+      areaWidthCm: measuredAreaWidthCm,
+      areaHeightCm: measuredAreaHeightCm,
+    },
+    deltasMm: {
+      pageWidth: deltaPageWidthMm,
+      pageHeight: deltaPageHeightMm,
+      areaWidth: deltaAreaWidthMm,
+      areaHeight: deltaAreaHeightMm,
     },
   };
 }

--- a/lib/_lib/savePrintPdfToSupabase.js
+++ b/lib/_lib/savePrintPdfToSupabase.js
@@ -21,7 +21,7 @@ function buildPdfPath(filename) {
   const now = new Date();
   const year = now.getFullYear();
   const month = String(now.getMonth() + 1).padStart(2, '0');
-  return `pdf/${year}/${month}/${filename}`;
+  return `print/${year}/${month}/${filename}`;
 }
 
 function normalizeMetadata(meta = {}) {

--- a/lib/_lib/uploadPrintPdf.js
+++ b/lib/_lib/uploadPrintPdf.js
@@ -45,6 +45,38 @@ export async function uploadPrintPdf({ buffer, filename, metadata = {}, diagId }
 
   const localDiag = diagId || randomUUID();
 
+  const originalName = typeof filename === 'string' ? filename.trim() : '';
+  if (originalName && /\.(png|jpe?g)$/i.test(originalName)) {
+    console.warn('png_upload_blocked', {
+      diagId: localDiag,
+      bucket: OUTPUT_BUCKET,
+      filename: originalName,
+      reason: 'filename_extension',
+    });
+    const error = new Error('png_upload_blocked');
+    error.code = 'png_upload_blocked';
+    throw error;
+  }
+
+  const header = buffer.subarray(0, 8);
+  const isPng = header.length >= 8
+    && header[0] === 0x89
+    && header[1] === 0x50
+    && header[2] === 0x4e
+    && header[3] === 0x47;
+  const isJpeg = header.length >= 2 && header[0] === 0xff && header[1] === 0xd8;
+  if (isPng || isJpeg) {
+    console.warn('png_upload_blocked', {
+      diagId: localDiag,
+      bucket: OUTPUT_BUCKET,
+      filename: originalName || null,
+      reason: isPng ? 'buffer_png_signature' : 'buffer_jpeg_signature',
+    });
+    const error = new Error('png_upload_blocked');
+    error.code = 'png_upload_blocked';
+    throw error;
+  }
+
   let supabase;
   try {
     supabase = getSupabaseAdmin();

--- a/lib/api/handlers/outputsSearch.js
+++ b/lib/api/handlers/outputsSearch.js
@@ -38,7 +38,7 @@ function buildRecentMonths(count) {
     const date = new Date(now.getFullYear(), now.getMonth() - idx, 1);
     const year = date.getFullYear();
     const month = String(date.getMonth() + 1).padStart(2, '0');
-    results.push({ year, month, key: `pdf/${year}/${month}` });
+    results.push({ year, month, key: `print/${year}/${month}` });
   }
   return results;
 }
@@ -106,6 +106,7 @@ export async function searchOutputFiles({ query } = {}) {
     if (!Array.isArray(data) || !data.length) continue;
     for (const entry of data) {
       if (!entry || typeof entry.name !== 'string') continue;
+      if (!entry.name.toLowerCase().endsWith('.pdf')) continue;
       const normalizedName = normalizeForSearch(entry.name);
       const altName = normalizeForSearch(`${month.year}${month.month}-${entry.name}`);
       const combined = `${normalizedName}-${altName}`;

--- a/lib/api/handlers/printsUpload.js
+++ b/lib/api/handlers/printsUpload.js
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { slugifyName } from '../../_lib/slug.js';
-import generatePrintPdf from '../../_lib/generatePrintPdf.js';
+import generatePrintPdf, { validatePrintPdf } from '../../_lib/generatePrintPdf.js';
 import uploadPrintPdf from '../../_lib/uploadPrintPdf.js';
 
 function toObject(input) {
@@ -64,6 +64,10 @@ function normalizeColor(input) {
   }
   return `#${value}`;
 }
+
+const MAX_GENERATE_ATTEMPTS = 2;
+const VALIDATION_TOLERANCE_MM = 1;
+const BLEED_MARGIN_CM = 2;
 
 async function readRawBody(req) {
   return new Promise((resolve, reject) => {
@@ -191,43 +195,140 @@ export async function uploadPrintHandler(req, res) {
     jobId,
   });
 
-  console.info('pdf_generate_start', {
-    diagId,
-    requestId,
-    jobId,
-    slug: slug || null,
-    material: material || null,
-    widthCm,
-    heightCm,
-  });
+  const expectedPageWidthCm = widthCm + BLEED_MARGIN_CM * 2;
+  const expectedPageHeightCm = heightCm + BLEED_MARGIN_CM * 2;
 
-  let pdfResult;
-  try {
-    pdfResult = await generatePrintPdf({
-      widthCm,
-      heightCm,
-      backgroundColor,
-      imageBuffer,
-    });
-  } catch (err) {
-    console.error('pdf_generate_error', {
+  let pdfResult = null;
+  let validationResult = null;
+
+  for (let attempt = 1; attempt <= MAX_GENERATE_ATTEMPTS; attempt += 1) {
+    console.info('pdf_generate_start', {
       diagId,
       requestId,
-      error: err?.code || err?.message || 'pdf_generate_error',
-      message: err?.message || err,
+      jobId,
+      slug: slug || null,
+      material: material || null,
+      widthCm,
+      heightCm,
+      attempt,
+      pageCm: { widthCm: expectedPageWidthCm, heightCm: expectedPageHeightCm },
+      artCm: { widthCm, heightCm },
+      marginsCm: {
+        left: BLEED_MARGIN_CM,
+        right: BLEED_MARGIN_CM,
+        top: BLEED_MARGIN_CM,
+        bottom: BLEED_MARGIN_CM,
+      },
     });
-    return res.status(500).json({ ok: false, diagId, requestId, error: 'pdf_generation_failed' });
+
+    try {
+      pdfResult = await generatePrintPdf({
+        widthCm,
+        heightCm,
+        backgroundColor,
+        imageBuffer,
+      });
+    } catch (err) {
+      console.error('pdf_generate_error', {
+        diagId,
+        requestId,
+        attempt,
+        error: err?.code || err?.message || 'pdf_generate_error',
+        message: err?.message || err,
+      });
+      if (attempt >= MAX_GENERATE_ATTEMPTS) {
+        return res.status(500).json({ ok: false, diagId, requestId, error: 'pdf_generation_failed' });
+      }
+      continue;
+    }
+
+    console.info('pdf_generate_end', {
+      diagId,
+      requestId,
+      jobId,
+      filename,
+      attempt,
+      size: pdfResult.buffer.length,
+      pageCm: {
+        widthCm: pdfResult.info.pageWidthCm,
+        heightCm: pdfResult.info.pageHeightCm,
+      },
+      artCm: {
+        widthCm: pdfResult.info.area.widthCm,
+        heightCm: pdfResult.info.area.heightCm,
+      },
+      marginCm: pdfResult.info.marginCm,
+      areaWidthPx: pdfResult.info.area.widthPx,
+      areaHeightPx: pdfResult.info.area.heightPx,
+      artworkWidthPx: pdfResult.info.artwork.widthPx,
+      artworkHeightPx: pdfResult.info.artwork.heightPx,
+      artworkOffsetLeftPx: pdfResult.info.artwork.offsetLeftPx,
+      artworkOffsetTopPx: pdfResult.info.artwork.offsetTopPx,
+    });
+
+    try {
+      validationResult = await validatePrintPdf({
+        buffer: pdfResult.buffer,
+        expectedPageWidthCm,
+        expectedPageHeightCm,
+        expectedAreaWidthCm: widthCm,
+        expectedAreaHeightCm: heightCm,
+        marginCm: pdfResult.info.marginCm,
+        toleranceMm: VALIDATION_TOLERANCE_MM,
+      });
+    } catch (err) {
+      console.error('pdf_validate_fail', {
+        diagId,
+        requestId,
+        attempt,
+        filename,
+        error: err?.code || err?.message || 'pdf_validate_error',
+        message: err?.message || err,
+      });
+      pdfResult = null;
+      validationResult = null;
+      if (attempt >= MAX_GENERATE_ATTEMPTS) {
+        return res.status(500).json({ ok: false, diagId, requestId, error: 'pdf_validation_failed' });
+      }
+      continue;
+    }
+
+    if (!validationResult.ok) {
+      console.error('pdf_validate_fail', {
+        diagId,
+        requestId,
+        attempt,
+        filename,
+        measured: validationResult.measured,
+        expected: validationResult.expected,
+        deltasMm: validationResult.deltasMm,
+        toleranceMm: validationResult.toleranceMm,
+      });
+      pdfResult = null;
+      validationResult = null;
+      if (attempt >= MAX_GENERATE_ATTEMPTS) {
+        return res.status(500).json({ ok: false, diagId, requestId, error: 'pdf_validation_failed' });
+      }
+      continue;
+    }
+
+    console.info('pdf_validate_ok', {
+      diagId,
+      requestId,
+      attempt,
+      filename,
+      measured: validationResult.measured,
+      expected: validationResult.expected,
+      deltasMm: validationResult.deltasMm,
+      toleranceMm: validationResult.toleranceMm,
+    });
+
+    break;
   }
 
-  console.info('pdf_generate_end', {
-    diagId,
-    requestId,
-    jobId,
-    filename,
-    size: pdfResult.buffer.length,
-    pageWidthCm: pdfResult.info.pageWidthCm,
-    pageHeightCm: pdfResult.info.pageHeightCm,
-  });
+  if (!pdfResult || !validationResult?.ok) {
+    return res.status(500).json({ ok: false, diagId, requestId, error: 'pdf_validation_failed' });
+  }
 
   console.info('pdf_upload_start', {
     diagId,
@@ -262,13 +363,14 @@ export async function uploadPrintHandler(req, res) {
     return res.status(502).json({ ok: false, diagId, requestId, error: 'pdf_upload_failed' });
   }
 
-  console.info('pdf_upload_end', {
+  console.info('pdf_upload_ok', {
     diagId,
     requestId,
     jobId,
     filename,
     bucket: uploadResult.bucket,
     path: uploadResult.path,
+    contentType: 'application/pdf',
   });
 
   return res.status(200).json({

--- a/mgm-front/src/pages/Busqueda.jsx
+++ b/mgm-front/src/pages/Busqueda.jsx
@@ -193,7 +193,7 @@ export default function Busqueda() {
                           target="_blank"
                           rel="noreferrer"
                         >
-                          Descargar
+                          Descargar PDF
                         </a>
                       ) : (
                         '—'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.54.0",
+        "pdf-lib": "^1.17.1",
         "sharp": "^0.33.5",
         "tesseract.js": "^5.1.1",
         "zod": "^3.25.76"
@@ -401,6 +402,24 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
+      }
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.71.1",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
@@ -777,6 +796,30 @@
       "bin": {
         "opencollective-postinstall": "index.js"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.54.0",
+    "pdf-lib": "^1.17.1",
     "sharp": "^0.33.5",
     "tesseract.js": "^5.1.1",
     "zod": "^3.25.76"


### PR DESCRIPTION
## Summary
- generate print-ready PDFs with pdf-lib so bleed, background, and sRGB artwork placement are precise
- validate each PDF before upload, log diagnostic details, and block any JPG/PNG attempts while searching the new outputs/print path
- add pdf-lib dependency, update storage helpers and the search UI label to reflect PDF-only downloads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6fcee98d4832792286c5cd25354af