### PR TITLE
Fix cart add flow and storefront polling

### DIFF
--- a/lib/handlers/productPublicationStatus.js
+++ b/lib/handlers/productPublicationStatus.js
@@ -1,18 +1,50 @@
 import { z } from 'zod';
 import { parseJsonBody } from '../_lib/http.js';
 import { shopifyAdminGraphQL } from '../shopify.js';
-import { ensureProductGid } from '../shopify/publication.js';
+import { ensureProductGid, resolveOnlineStorePublicationId } from '../shopify/publication.js';
 
 const BodySchema = z.object({
   productId: z.union([z.string(), z.number()]),
 }).passthrough();
 
-const PRODUCT_PUBLICATION_QUERY = `query ProductPublicationStatus($id: ID!) {
-  product(id: $id) {
-    id
-    publishedOnCurrentPublication
+function buildProductPublicationQuery(publicationId) {
+  const hasPublication = Boolean(publicationId);
+  const publicationVar = hasPublication ? ', $publicationId: ID!' : '';
+  const publicationField = hasPublication ? 'publishedOnPublication(publicationId: $publicationId)' : '';
+  return `query ProductPublicationStatus($id: ID!${publicationVar}) {
+    product(id: $id) {
+      id
+      status
+      ${publicationField}
+      resourcePublications(first: 25) {
+        nodes {
+          publishStatus
+          publication { id name }
+        }
+      }
+    }
+  }`;
+}
+
+function stripAccents(value) {
+  if (typeof value !== 'string') return '';
+  try {
+    return value.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  } catch {
+    return value;
   }
-}`;
+}
+
+function isOnlineStorePublicationName(name) {
+  const normalized = stripAccents(name).toLowerCase();
+  if (!normalized) return false;
+  if (normalized.includes('online store')) return true;
+  if (normalized.includes('tienda online')) return true;
+  if (normalized.includes('tienda en linea')) return true;
+  if (normalized.includes('tiendaonline')) return true;
+  if (normalized.includes('tiendaenlinea')) return true;
+  return normalized.includes('online') && normalized.includes('store');
+}
 
 export default async function productPublicationStatus(req, res) {
   if (req.method !== 'POST') {
@@ -41,7 +73,29 @@ export default async function productPublicationStatus(req, res) {
       return res.status(400).json({ ok: false, error: 'invalid_product' });
     }
 
-    const resp = await shopifyAdminGraphQL(PRODUCT_PUBLICATION_QUERY, { id: productGid });
+    let publicationInfo = null;
+    try {
+      publicationInfo = await resolveOnlineStorePublicationId({ preferEnv: true });
+    } catch (resolveErr) {
+      try { console.warn('product_publication_status_resolve_failed', resolveErr); } catch {}
+    }
+    if (!publicationInfo?.id) {
+      try {
+        const discovered = await resolveOnlineStorePublicationId({ forceDiscover: true, preferEnv: false });
+        if (discovered?.id) {
+          publicationInfo = discovered;
+        }
+      } catch (discoverErr) {
+        try { console.warn('product_publication_status_discover_failed', discoverErr); } catch {}
+      }
+    }
+
+    const query = buildProductPublicationQuery(publicationInfo?.id);
+    const variables = publicationInfo?.id
+      ? { id: productGid, publicationId: publicationInfo.id }
+      : { id: productGid };
+
+    const resp = await shopifyAdminGraphQL(query, variables);
     const json = await resp.json().catch(() => null);
     if (!resp.ok) {
       return res.status(502).json({ ok: false, error: 'publication_status_failed', status: resp.status, detail: json });
@@ -54,12 +108,49 @@ export default async function productPublicationStatus(req, res) {
       return res.status(404).json({ ok: false, error: 'product_not_found' });
     }
 
-    const published = product?.publishedOnCurrentPublication === true;
+    const statusRaw = typeof product?.status === 'string' ? product.status : '';
+    const statusActive = statusRaw.toUpperCase() === 'ACTIVE';
+
+    let published = false;
+    if (typeof product?.publishedOnPublication === 'boolean') {
+      published = product.publishedOnPublication;
+    }
+    if (!published) {
+      const nodes = Array.isArray(product?.resourcePublications?.nodes)
+        ? product.resourcePublications.nodes
+        : [];
+      const resolvedPublicationId = publicationInfo?.id ? String(publicationInfo.id) : '';
+      const resolvedPublicationName = publicationInfo?.name ? stripAccents(String(publicationInfo.name)).toLowerCase() : '';
+      for (const node of nodes) {
+        if (!node) continue;
+        const publishStatus = typeof node.publishStatus === 'string' ? node.publishStatus : '';
+        const nodePublication = node.publication || {};
+        const nodePublicationId = nodePublication?.id ? String(nodePublication.id) : '';
+        const nodePublicationNameRaw = nodePublication?.name ? String(nodePublication.name) : '';
+        const nodePublicationName = stripAccents(nodePublicationNameRaw).toLowerCase();
+        const matchesId = resolvedPublicationId && nodePublicationId === resolvedPublicationId;
+        const matchesName = !resolvedPublicationId && resolvedPublicationName
+          ? nodePublicationName === resolvedPublicationName
+          : false;
+        const matchesFallback = !resolvedPublicationId && !resolvedPublicationName
+          ? isOnlineStorePublicationName(nodePublicationNameRaw)
+          : false;
+        if (matchesId || matchesName || matchesFallback) {
+          if (publishStatus.toUpperCase() === 'PUBLISHED') {
+            published = true;
+          }
+          break;
+        }
+      }
+    }
 
     return res.status(200).json({
       ok: true,
       published,
+      status: statusRaw || null,
+      statusActive,
       productId: product.id || productGid,
+      publicationId: publicationInfo?.id || null,
     });
   } catch (err) {
     if (res.statusCode === 413) {

--- a/mgm-front/src/state/flow.tsx
+++ b/mgm-front/src/state/flow.tsx
@@ -17,6 +17,8 @@ export type FlowState = {
   lastProduct?: {
     productId?: string;
     variantId?: string;
+    variantIdNumeric?: string;
+    variantIdGid?: string;
     cartUrl?: string;
     checkoutUrl?: string;
     productUrl?: string;


### PR DESCRIPTION
## Summary
- persist variant numeric and GID identifiers after product creation for downstream cart flows
- poll Storefront availability by handle with admin verification and updated logging
- prefer Storefront cart mutations with a /cart/add fallback, success toast, and expanded cart logging
- verify publication status via admin publication helpers to confirm ACTIVE and published state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6fe163b4c8327b2105ef781d42852