### PR TITLE
Fix storefront cart availability polling

### DIFF
--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -464,15 +464,10 @@ export default function Mockup() {
           const verifyPublication = () => verifyProductPublicationStatus(current.productId);
           const waitOptions = {
             verifyProductPublication: verifyPublication,
+            expectedHandle: current.productHandle,
           };
-          if (!current.productHandle) {
-            const missingHandleError = new Error('missing_product_handle');
-            missingHandleError.reason = 'missing_product_handle';
-            throw missingHandleError;
-          }
           const pollResult = await waitForVariantAvailability(
             current.variantIdGid || current.variantId,
-            current.productHandle,
             waitOptions,
           );
           if (IS_DEV) {
@@ -502,8 +497,8 @@ export default function Mockup() {
           const pollProductHandle =
             typeof pollResult?.productHandle === 'string' && pollResult.productHandle
               ? pollResult.productHandle
-              : typeof pollResult?.lastResponse?.product?.handle === 'string'
-                ? pollResult.lastResponse.product.handle
+              : typeof pollResult?.lastResponse?.node?.product?.handle === 'string'
+                ? pollResult.lastResponse.node.product.handle
                 : '';
           if (pollProductHandle) {
             let nextState = current;


### PR DESCRIPTION
## Summary
- query storefront variant availability by node(id) and capture the product handle without relying on publication-specific fields
- let the cart availability poll accept a variant GID directly while preserving logging and fallback data for the cart flow
- keep the cart flow fallback opening the public mgmgamers.store cart add URL when the storefront flow cannot return a webUrl

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7fd2be4d8832787e004811ada84a3