### PR TITLE
Switch private checkout to Shopify draft orders

### DIFF
--- a/lib/handlers/privateCheckout.js
+++ b/lib/handlers/privateCheckout.js
@@ -1,9 +1,7 @@
 import { z } from 'zod';
-import { parseJsonBody, getClientIp } from '../_lib/http.js';
+import { parseJsonBody } from '../_lib/http.js';
 import {
   resolveVariantIds,
-  precheckVariantAvailability,
-  createStorefrontCart,
   normalizeCartAttributes,
   normalizeCartNote,
 } from '../shopify/cartHelpers.js';
@@ -28,11 +26,7 @@ function normalizeQuantity(value) {
 }
 
 function resolveMode() {
-  const envRaw = typeof process.env.PRIVATE_CHECKOUT_MODE === 'string'
-    ? process.env.PRIVATE_CHECKOUT_MODE.trim().toLowerCase()
-    : '';
-  if (envRaw === 'draft_order') return 'draft_order';
-  return 'storefront';
+  return 'draft_order';
 }
 
 const DRAFT_ORDER_CREATE_MUTATION = `
@@ -41,6 +35,22 @@ const DRAFT_ORDER_CREATE_MUTATION = `
       draftOrder {
         id
         name
+        invoiceUrl
+      }
+      userErrors {
+        field
+        message
+        code
+      }
+    }
+  }
+`;
+
+const DRAFT_ORDER_INVOICE_SEND_MUTATION = `
+  mutation DraftOrderInvoiceSend($id: ID!, $input: DraftOrderInvoiceInput!) {
+    draftOrderInvoiceSend(id: $id, input: $input) {
+      draftOrder {
+        id
         invoiceUrl
       }
       userErrors {
@@ -64,7 +74,7 @@ async function createDraftOrder({ variantGid, quantity, note, attributes, email 
         quantity: qty,
       },
     ],
-    tags: ['private'],
+    tags: ['private', 'custom-mockup'],
     allowPartialPayments: false,
   };
   const noteValue = normalizeCartNote(note);
@@ -75,7 +85,8 @@ async function createDraftOrder({ variantGid, quantity, note, attributes, email 
     input.email = email;
   }
   if (Array.isArray(attributes) && attributes.length) {
-    input.customAttributes = attributes.map((attr) => ({ key: attr.key, value: attr.value }));
+    const normalized = attributes.map((attr) => ({ key: attr.key, value: attr.value }));
+    input.customAttributes = normalized;
   }
   let resp;
   try {
@@ -125,14 +136,77 @@ async function createDraftOrder({ variantGid, quantity, note, attributes, email 
   if (!draftOrder || typeof draftOrder !== 'object') {
     return { ok: false, reason: 'missing_draft_order' };
   }
-  const invoiceUrl = typeof draftOrder.invoiceUrl === 'string' ? draftOrder.invoiceUrl.trim() : '';
+  let invoiceUrl = typeof draftOrder.invoiceUrl === 'string' ? draftOrder.invoiceUrl.trim() : '';
+  const draftOrderId = typeof draftOrder.id === 'string' ? draftOrder.id : '';
+  if (!invoiceUrl && draftOrderId) {
+    let invoiceResp;
+    try {
+      invoiceResp = await shopifyAdminGraphQL(DRAFT_ORDER_INVOICE_SEND_MUTATION, {
+        id: draftOrderId,
+        input: email ? { to: email } : {},
+      });
+    } catch (err) {
+      if (err?.message === 'SHOPIFY_ENV_MISSING') {
+        return { ok: false, reason: 'shopify_env_missing', missing: err.missing };
+      }
+      throw err;
+    }
+    const invoiceText = await invoiceResp.text();
+    let invoiceJson;
+    try {
+      invoiceJson = invoiceText ? JSON.parse(invoiceText) : null;
+    } catch {
+      invoiceJson = null;
+    }
+    if (!invoiceResp.ok) {
+      return {
+        ok: false,
+        reason: 'invoice_http_error',
+        status: invoiceResp.status,
+        body: invoiceText?.slice(0, 2000),
+      };
+    }
+    if (!invoiceJson || typeof invoiceJson !== 'object') {
+      return { ok: false, reason: 'invoice_invalid_response' };
+    }
+    if (Array.isArray(invoiceJson.errors) && invoiceJson.errors.length) {
+      return { ok: false, reason: 'invoice_graphql_errors', errors: invoiceJson.errors };
+    }
+    const invoicePayload = invoiceJson?.data?.draftOrderInvoiceSend;
+    if (!invoicePayload || typeof invoicePayload !== 'object') {
+      return { ok: false, reason: 'invoice_invalid_response' };
+    }
+    const invoiceUserErrors = Array.isArray(invoicePayload.userErrors)
+      ? invoicePayload.userErrors
+          .map((entry) => {
+            if (!entry || typeof entry !== 'object') return null;
+            const message = typeof entry.message === 'string' ? entry.message.trim() : '';
+            if (!message) return null;
+            const code = typeof entry.code === 'string' ? entry.code : undefined;
+            const field = Array.isArray(entry.field)
+              ? entry.field.map((item) => String(item)).filter(Boolean)
+              : undefined;
+            return { message, ...(code ? { code } : {}), ...(field && field.length ? { field } : {}) };
+          })
+          .filter(Boolean)
+      : [];
+    if (invoiceUserErrors.length) {
+      return { ok: false, reason: 'invoice_user_errors', userErrors: invoiceUserErrors };
+    }
+    const invoiceDraftOrder = invoicePayload.draftOrder;
+    if (invoiceDraftOrder && typeof invoiceDraftOrder === 'object') {
+      invoiceUrl = typeof invoiceDraftOrder.invoiceUrl === 'string'
+        ? invoiceDraftOrder.invoiceUrl.trim()
+        : invoiceUrl;
+    }
+  }
   if (!invoiceUrl) {
     return { ok: false, reason: 'missing_invoice_url' };
   }
   return {
     ok: true,
     checkoutUrl: invoiceUrl,
-    draftOrderId: draftOrder.id || null,
+    draftOrderId: draftOrderId || null,
     draftOrderName: draftOrder.name || null,
   };
 }
@@ -234,86 +308,8 @@ export default async function privateCheckout(req, res) {
       return true;
     }
 
-    if (mode === 'draft_order') {
-      await handleDraftOrder();
-      return;
-    }
-
-    const buyerIp = getClientIp(req);
-    const precheck = await precheckVariantAvailability(resolvedVariantGid, { maxAttempts: 3 });
-    if (!precheck.ok || precheck.available === false) {
-      logResult('warn', {
-        mode,
-        variantGid: resolvedVariantGid,
-        variantNumericId,
-        reason: precheck.reason || 'precheck_failed',
-      });
-      await handleDraftOrder('precheck');
-      return;
-    }
-
-    let storefrontAttempt;
-    try {
-      storefrontAttempt = await createStorefrontCart({
-        variantGid: resolvedVariantGid,
-        quantity: qty,
-        buyerIp,
-        attributes: normalizedAttributes,
-        note,
-      });
-    } catch (err) {
-      console.error?.('[private-checkout] storefront_error', err);
-      await handleDraftOrder('storefront_exception');
-      return;
-    }
-    if (!storefrontAttempt.ok) {
-      logResult('warn', {
-        mode,
-        variantGid: resolvedVariantGid,
-        variantNumericId,
-        reason: storefrontAttempt.reason,
-        userErrors: storefrontAttempt.userErrors || null,
-      });
-      if (storefrontAttempt.reason === 'storefront_env_missing') {
-        await handleDraftOrder('storefront_env_missing');
-        return;
-      }
-      if (storefrontAttempt.reason === 'user_errors') {
-        await handleDraftOrder('storefront_user_errors');
-        return;
-      }
-      await handleDraftOrder(storefrontAttempt.reason || 'storefront_failed');
-      return;
-    }
-
-    let checkoutUrl = storefrontAttempt.checkoutUrl || '';
-    if (checkoutUrl && email) {
-      try {
-        const checkoutObj = new URL(checkoutUrl);
-        checkoutObj.searchParams.set('checkout[email]', email);
-        checkoutUrl = checkoutObj.toString();
-      } catch {}
-    }
-
-    if (!checkoutUrl) {
-      await handleDraftOrder('missing_checkout_url');
-      return;
-    }
-
-    logResult('info', {
-      mode,
-      variantGid: resolvedVariantGid,
-      variantNumericId,
-      strategy: 'storefront',
-      requestId: storefrontAttempt.requestId || precheck.requestId || null,
-    });
-
-    return res.status(200).json({
-      checkoutUrl: checkoutUrl || null,
-      cartUrl: storefrontAttempt.cartUrl || null,
-      cartPlain: storefrontAttempt.cartPlain || null,
-      strategy: 'storefront',
-    });
+    await handleDraftOrder();
+    return;
   } catch (err) {
     if (res.statusCode === 413) {
       return res.json({ reason: 'payload_too_large' });

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1906,10 +1906,10 @@ export async function publishProduct(req, res) {
 
     const productInput = {
       title,
-      // Keep private products out of sales channels by skipping publication, but
-      // leave the product status as ACTIVE so Shopify considers the variant
-      // sellable from the Storefront checkout flow.
-      status: 'ACTIVE',
+      // Private checkouts rely on draft products + draft orders, while the public
+      // flow still expects active products available on the storefront. Switch
+      // the status depending on the visibility that was requested.
+      status: isPrivate ? 'DRAFT' : 'ACTIVE',
       vendor: DEFAULT_VENDOR,
       templateSuffix: 'mousepads',
     };


### PR DESCRIPTION
## Summary
- create private products as Shopify drafts so they remain unpublished
- rework the private checkout handler to always create draft orders and request the invoice URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7feec83348327b833ef9f1d0a439b