### PR TITLE
Add Supabase prints index and search API

### DIFF
--- a/lib/_lib/generatePrintPdf.js
+++ b/lib/_lib/generatePrintPdf.js
@@ -2,10 +2,10 @@ import sharp from 'sharp';
 import { PDFDocument, rgb } from 'pdf-lib';
 
 const CM_PER_INCH = 2.54;
-const DEFAULT_DPI = 300;
+export const DEFAULT_DPI = 300;
 const MARGIN_CM = 2;
 const POINTS_PER_CM = 72 / CM_PER_INCH;
-const PIXELS_PER_CM = DEFAULT_DPI / CM_PER_INCH;
+export const PIXELS_PER_CM = DEFAULT_DPI / CM_PER_INCH;
 
 function cmToPixels(valueCm) {
   const numeric = Number(valueCm);
@@ -107,8 +107,10 @@ export async function generatePrintPdf({
     throw error;
   }
 
-  const artworkWidthPx = Math.min(areaWidthPx, artworkMetadata?.width || areaWidthPx);
-  const artworkHeightPx = Math.min(areaHeightPx, artworkMetadata?.height || areaHeightPx);
+  const metadataWidthPx = Math.max(1, Math.round(artworkMetadata?.width || areaWidthPx));
+  const metadataHeightPx = Math.max(1, Math.round(artworkMetadata?.height || areaHeightPx));
+  const artworkWidthPx = Math.min(areaWidthPx, metadataWidthPx);
+  const artworkHeightPx = Math.min(areaHeightPx, metadataHeightPx);
   const offsetLeftPx = Math.max(0, Math.round((areaWidthPx - artworkWidthPx) / 2));
   const offsetTopPx = Math.max(0, Math.round((areaHeightPx - artworkHeightPx) / 2));
 

--- a/lib/_lib/uploadPrintPdf.js
+++ b/lib/_lib/uploadPrintPdf.js
@@ -2,7 +2,11 @@ import { randomUUID } from 'node:crypto';
 import getSupabaseAdmin from './supabaseAdmin.js';
 
 const OUTPUT_BUCKET = 'outputs';
-const SIGNED_URL_TTL_SECONDS = 86_400; // 24 horas
+export const SIGNED_URL_TTL_SECONDS = 86_400; // 24 horas
+const MAX_PDF_BYTES = 150 * 1024 * 1024; // 150 MB límite duro
+const UPLOAD_PREFIX = 'pdf';
+const MAX_UPLOAD_ATTEMPTS = 2;
+const RETRY_BACKOFF_MS = 800;
 
 function ensureFilename(input) {
   const raw = String(input || '').trim().toLowerCase();
@@ -18,7 +22,7 @@ function buildPdfPath(filename) {
   const now = new Date();
   const year = now.getFullYear();
   const month = String(now.getMonth() + 1).padStart(2, '0');
-  return `print/${year}/${month}/${filename}`;
+  return `${UPLOAD_PREFIX}/${year}/${month}/${filename}`;
 }
 
 function normalizeMetadata(meta = {}) {
@@ -34,6 +38,15 @@ function normalizeMetadata(meta = {}) {
   }
   if (!('createdBy' in output)) output.createdBy = 'prints-upload';
   return output;
+}
+
+function shouldRetryUpload(error) {
+  const status = error?.status || error?.statusCode || error?.originalError?.statusCode || 0;
+  return status >= 500 && status < 600;
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export async function uploadPrintPdf({ buffer, filename, metadata = {}, diagId }) {
@@ -92,37 +105,64 @@ export async function uploadPrintPdf({ buffer, filename, metadata = {}, diagId }
   const path = buildPdfPath(safeFilename);
   const size = buffer.length;
 
-  const storage = supabase.storage.from(OUTPUT_BUCKET);
-  const { error: uploadError } = await storage.upload(path, buffer, {
-    contentType: 'application/pdf',
-    upsert: true,
-    cacheControl: '3600',
-    metadata: normalizeMetadata(metadata),
-  });
+  if (size > MAX_PDF_BYTES) {
+    console.error('pdf_upload_too_large', { diagId: localDiag, path, size });
+    const error = new Error('pdf_too_large');
+    error.code = 'pdf_too_large';
+    error.diagId = localDiag;
+    throw error;
+  }
 
-  if (uploadError) {
+  const storage = supabase.storage.from(OUTPUT_BUCKET);
+
+  let uploadError = null;
+  for (let attempt = 1; attempt <= MAX_UPLOAD_ATTEMPTS; attempt += 1) {
+    const { error } = await storage.upload(path, buffer, {
+      contentType: 'application/pdf',
+      upsert: true,
+      cacheControl: '3600',
+      metadata: normalizeMetadata(metadata),
+    });
+
+    if (!error) {
+      uploadError = null;
+      break;
+    }
+
+    uploadError = error;
+    const status = error?.status || error?.statusCode || null;
+    const retryable = shouldRetryUpload(error) && attempt < MAX_UPLOAD_ATTEMPTS;
     console.error('pdf_upload_error', {
       diagId: localDiag,
       path,
       size,
-      status: uploadError?.status || uploadError?.statusCode || null,
-      message: uploadError?.message,
-      name: uploadError?.name,
+      attempt,
+      status,
+      retryable,
+      message: error?.message,
+      name: error?.name,
     });
+
+    if (retryable) {
+      await wait(RETRY_BACKOFF_MS);
+      continue;
+    }
+    break;
+  }
+
+  if (uploadError) {
     const error = new Error('supabase_upload_failed');
     error.code = 'supabase_upload_failed';
     error.cause = uploadError;
+    error.diagId = localDiag;
     throw error;
   }
-
-  const { data: publicData } = storage.getPublicUrl(path);
-  const publicUrl = publicData?.publicUrl || null;
 
   const { data: signedData, error: signedError } = await storage.createSignedUrl(path, SIGNED_URL_TTL_SECONDS, {
     download: safeFilename,
   });
 
-  if (signedError) {
+  if (signedError || !signedData?.signedUrl) {
     console.error('pdf_upload_signed_url_error', {
       diagId: localDiag,
       path,
@@ -131,13 +171,17 @@ export async function uploadPrintPdf({ buffer, filename, metadata = {}, diagId }
       message: signedError?.message,
       name: signedError?.name,
     });
+    const error = new Error('supabase_signed_url_failed');
+    error.code = 'supabase_signed_url_failed';
+    error.cause = signedError;
+    error.diagId = localDiag;
+    throw error;
   }
 
   return {
     bucket: OUTPUT_BUCKET,
     path,
-    publicUrl,
-    signedUrl: signedData?.signedUrl || null,
+    signedUrl: signedData.signedUrl,
     expiresIn: SIGNED_URL_TTL_SECONDS,
     diagId: localDiag,
   };

--- a/lib/api/handlers/printsSearch.js
+++ b/lib/api/handlers/printsSearch.js
@@ -1,32 +1,12 @@
 import { randomUUID } from 'node:crypto';
 import getSupabaseAdmin from '../../_lib/supabaseAdmin.js';
+import { SIGNED_URL_TTL_SECONDS as UPLOAD_SIGNED_URL_TTL_SECONDS } from '../../_lib/uploadPrintPdf.js';
 
 const OUTPUT_BUCKET = 'outputs';
-const ROOT_PREFIX = 'pdf';
-const SIGNED_URL_TTL_SECONDS = 900; // 15 minutes
+const SEARCH_SIGNED_URL_TTL_SECONDS = 900; // 15 minutos
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 100;
-const MAX_DEPTH = 5;
-const LIST_PAGE_SIZE = 1000;
-const PREVIEW_EXTENSIONS = ['.png', '.jpg', '.jpeg'];
-
-function normalizePathPrefix(prefix) {
-  return String(prefix || '')
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '');
-}
-
-function normalizeString(input) {
-  return String(input || '')
-    .normalize('NFD')
-    .replace(/\p{Diacritic}/gu, '')
-    .toLowerCase();
-}
-
-function normalizeQuery(input) {
-  const withoutExtension = String(input || '').replace(/\.pdf$/i, '');
-  return normalizeString(withoutExtension);
-}
+const PRINTS_TABLE = 'prints';
 
 function parseLimit(value) {
   if (value === undefined || value === null || value === '') return DEFAULT_LIMIT;
@@ -55,142 +35,17 @@ function parseOffset(value) {
   return num;
 }
 
-function toTimestamp(value) {
-  if (!value) return 0;
-  const ts = Date.parse(value);
-  return Number.isFinite(ts) ? ts : 0;
+function escapeIlikeTerm(term) {
+  return term.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
 }
 
-function isFolder(entry) {
-  return !entry?.id && !entry?.metadata;
-}
-
-function getExtension(name) {
-  const match = /\.([^.]+)$/.exec(name || '');
-  return match ? `.${match[1].toLowerCase()}` : '';
-}
-
-async function listAllEntries(storage, prefix) {
-  const sanitized = normalizePathPrefix(prefix);
-  const results = [];
-  let page = 0;
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const { data, error } = await storage.list(sanitized, {
-      limit: LIST_PAGE_SIZE,
-      offset: page * LIST_PAGE_SIZE,
-      sortBy: { column: 'name', order: 'asc' },
-    });
-    if (error) {
-      const status = error?.status || error?.statusCode || 0;
-      if (status === 404) {
-        return results;
-      }
-      const err = new Error(error?.message || 'No se pudo listar el directorio.');
-      err.type = 'storage_list_failed';
-      err.detail = error?.message;
-      err.status = status;
-      err.prefix = sanitized;
-      throw err;
-    }
-    if (!Array.isArray(data) || data.length === 0) {
-      break;
-    }
-    results.push(...data);
-    if (data.length < LIST_PAGE_SIZE) {
-      break;
-    }
-    page += 1;
-    if (page >= 1000) {
-      const err = new Error('Se alcanzó el límite de paginación al listar archivos.');
-      err.type = 'storage_pagination_limit';
-      err.prefix = sanitized;
-      throw err;
-    }
-  }
-  return results;
-}
-
-function pickPreviewCandidate(prefix, entry, previewMap) {
-  const fullBase = `${normalizePathPrefix(prefix)}/${entry.name.replace(/\.[^.]+$/u, '')}`;
-  return previewMap.get(fullBase) || null;
-}
-
-function registerPreview(prefix, entry, previewMap) {
-  const base = `${normalizePathPrefix(prefix)}/${entry.name.replace(/\.[^.]+$/u, '')}`;
-  const extension = getExtension(entry.name);
-  const existing = previewMap.get(base);
-  if (!existing || (existing.extension !== '.png' && extension === '.png')) {
-    previewMap.set(base, {
-      path: prefix ? `${normalizePathPrefix(prefix)}/${entry.name}` : entry.name,
-      extension,
-      createdAt: entry.created_at || entry.updated_at || entry.last_accessed_at || null,
-      updatedAt: entry.updated_at || entry.created_at || entry.last_accessed_at || null,
-    });
-  }
-}
-
-async function collectPdfFiles(storage, requestId) {
-  const matches = [];
-  const queue = [{ prefix: ROOT_PREFIX, depth: 0 }];
-
-  while (queue.length > 0) {
-    const { prefix, depth } = queue.shift();
-    const entries = await listAllEntries(storage, prefix);
-    if (!entries.length) continue;
-
-    const previewMap = new Map();
-    const folders = [];
-    const sanitizedPrefix = normalizePathPrefix(prefix);
-
-    for (const entry of entries) {
-      if (!entry || typeof entry.name !== 'string' || !entry.name) continue;
-      if (isFolder(entry)) {
-        if (depth + 1 <= MAX_DEPTH) {
-          const childPrefix = sanitizedPrefix ? `${sanitizedPrefix}/${entry.name}` : entry.name;
-          folders.push(childPrefix);
-        }
-        continue;
-      }
-
-      const extension = getExtension(entry.name);
-      if (PREVIEW_EXTENSIONS.includes(extension)) {
-        registerPreview(sanitizedPrefix, entry, previewMap);
-      }
-    }
-
-    for (const entry of entries) {
-      if (!entry || typeof entry.name !== 'string' || !entry.name) continue;
-      if (isFolder(entry)) continue;
-      const extension = getExtension(entry.name);
-      if (extension !== '.pdf') continue;
-      const baseName = entry.name.replace(/\.pdf$/i, '');
-      const previewCandidate = pickPreviewCandidate(sanitizedPrefix, entry, previewMap);
-      const path = sanitizedPrefix ? `${sanitizedPrefix}/${entry.name}` : entry.name;
-      matches.push({
-        name: entry.name,
-        baseName,
-        path,
-        size: entry.metadata?.size ?? null,
-        contentType: entry.metadata?.mimetype || 'application/pdf',
-        createdAt: entry.created_at || entry.updated_at || entry.last_accessed_at || null,
-        updatedAt: entry.updated_at || entry.created_at || entry.last_accessed_at || null,
-        previewPath: previewCandidate?.path || null,
-      });
-    }
-
-    if (folders.length > 0) {
-      for (const folder of folders) {
-        queue.push({ prefix: folder, depth: depth + 1 });
-      }
-    }
-  }
-
-  return matches;
+function normalizeNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
 }
 
 export async function searchPrintsHandler({ query } = {}) {
-  const requestId = randomUUID();
+  const diagId = randomUUID();
   const rawQuery = typeof query?.query === 'string' ? query.query.trim() : '';
 
   let limit;
@@ -201,163 +56,190 @@ export async function searchPrintsHandler({ query } = {}) {
     offset = parseOffset(query?.offset);
   } catch (err) {
     console.error('prints_search_error', {
-      requestId,
+      diagId,
       type: 'bad_request',
       message: err?.message || 'Parámetros inválidos.',
     });
     return {
       status: 400,
-      body: { error: 'bad_request', message: err?.message || 'Parámetros inválidos.' },
+      body: {
+        ok: false,
+        diagId,
+        reason: 'bad_request',
+        message: err?.message || 'Parámetros inválidos.',
+      },
     };
   }
 
-  const normalizedQuery = normalizeQuery(rawQuery);
-  const rawQueryLower = rawQuery ? rawQuery.toLowerCase() : '';
+  if (!rawQuery) {
+    console.error('prints_search_error', {
+      diagId,
+      type: 'missing_query',
+      message: 'Se requiere un término de búsqueda.',
+    });
+    return {
+      status: 400,
+      body: {
+        ok: false,
+        diagId,
+        reason: 'missing_query',
+        message: 'Ingresá un término para buscar.',
+      },
+    };
+  }
 
   let supabase;
   try {
     supabase = getSupabaseAdmin();
   } catch (err) {
     console.error('prints_search_error', {
-      requestId,
-      type: 'supabase_credentials_missing',
+      diagId,
+      type: 'supabase_init_failed',
       message: err?.message || err,
     });
     return {
       status: 502,
       body: {
-        error: 'supabase_error',
-        requestId,
-        detail: 'Faltan credenciales de Supabase.',
+        ok: false,
+        diagId,
+        reason: 'supabase_init_failed',
+        message: 'Faltan credenciales de Supabase.',
       },
     };
   }
 
-  console.info('prints_search_request', { requestId, query: rawQuery || null, limit, offset });
+  const normalizedQuery = rawQuery.normalize('NFKC');
+  const compactQuery = normalizedQuery.replace(/\s+/g, ' ').trim();
+  const commaStrippedQuery = compactQuery.replace(/[;,]+/g, ' ').trim();
+  const effectiveQuery = commaStrippedQuery || compactQuery;
 
-  const storage = supabase.storage.from(OUTPUT_BUCKET);
-  let files;
+  if (!effectiveQuery) {
+    console.error('prints_search_error', {
+      diagId,
+      type: 'missing_query',
+      message: 'Se requiere un término de búsqueda válido.',
+    });
+    return {
+      status: 400,
+      body: {
+        ok: false,
+        diagId,
+        reason: 'missing_query',
+        message: 'Ingresá un término para buscar.',
+      },
+    };
+  }
+
+  console.info('prints_search_request', { diagId, query: rawQuery, limit, offset });
+
+  const pattern = `%${escapeIlikeTerm(effectiveQuery)}%`;
+
+  let builder = supabase
+    .from(PRINTS_TABLE)
+    .select(
+      'id, job_key, bucket, file_path, file_name, slug, width_cm, height_cm, material, bg_color, job_id, file_size_bytes, created_at',
+      { count: 'exact' },
+    )
+    .order('created_at', { ascending: false })
+    .order('file_name', { ascending: true })
+    .range(offset, offset + limit - 1);
+
+  builder = builder.or(`file_name.ilike.${pattern},slug.ilike.${pattern}`);
+
+  let rows;
+  let totalCount;
   try {
-    files = await collectPdfFiles(storage, requestId);
+    const { data, count, error } = await builder;
+    if (error) throw error;
+    rows = Array.isArray(data) ? data : [];
+    totalCount = typeof count === 'number' ? count : rows.length;
   } catch (err) {
     console.error('prints_search_error', {
-      requestId,
-      type: err?.type || 'supabase_error',
-      message: err?.message || 'No se pudo obtener la lista de archivos.',
-      detail: err?.detail || null,
-      prefix: err?.prefix || ROOT_PREFIX,
+      diagId,
+      type: 'db_query_failed',
+      message: err?.message || 'No se pudo consultar la base de datos.',
     });
     return {
       status: 502,
       body: {
-        error: 'supabase_error',
-        requestId,
-        detail: err?.message || 'No se pudo obtener la lista de archivos desde Supabase.',
+        ok: false,
+        diagId,
+        reason: 'db_query_failed',
+        message: 'No se pudo realizar la búsqueda en la base de datos.',
       },
     };
   }
 
-  const hasQuery = normalizedQuery.length > 0;
-  const filtered = hasQuery
-    ? files.filter((file) => {
-        const normalizedName = normalizeString(file.baseName);
-        return (
-          normalizedName.includes(normalizedQuery) ||
-          (rawQueryLower ? file.baseName.toLowerCase().includes(rawQueryLower) : false)
-        );
-      })
-    : files;
-
-  filtered.sort((a, b) => {
-    const tsDiff = toTimestamp(b.createdAt) - toTimestamp(a.createdAt);
-    if (tsDiff !== 0) return tsDiff;
-    return a.name.localeCompare(b.name);
-  });
-
-  const total = filtered.length;
-  const slice = filtered.slice(offset, offset + limit);
+  const storage = supabase.storage.from(OUTPUT_BUCKET);
 
   const items = await Promise.all(
-    slice.map(async (item) => {
+    rows.map(async (row) => {
       let downloadUrl = null;
-      let previewImageUrl = null;
-
       try {
-        const signed = await storage.createSignedUrl(item.path, SIGNED_URL_TTL_SECONDS, {
-          download: item.name,
-        });
-        if (signed?.data?.signedUrl) {
-          downloadUrl = signed.data.signedUrl;
-        } else if (signed?.error) {
+        const { data, error } = await storage.createSignedUrl(
+          row.file_path,
+          SEARCH_SIGNED_URL_TTL_SECONDS,
+          { download: row.file_name || undefined },
+        );
+        if (error) {
           console.error('prints_search_error', {
-            requestId,
+            diagId,
             type: 'signed_url_error',
-            message: signed.error?.message || 'No se pudo firmar la URL del PDF.',
-            path: item.path,
+            path: row.file_path,
+            message: error?.message || 'No se pudo firmar la URL del PDF.',
           });
+        } else {
+          downloadUrl = data?.signedUrl || null;
         }
       } catch (err) {
         console.error('prints_search_error', {
-          requestId,
+          diagId,
           type: 'signed_url_error',
-          message: err?.message || 'Fallo al firmar la URL del PDF.',
-          path: item.path,
+          path: row.file_path,
+          message: err?.message || err,
         });
       }
 
-      if (item.previewPath) {
-        try {
-          const previewSigned = await storage.createSignedUrl(item.previewPath, SIGNED_URL_TTL_SECONDS, {
-            download: item.previewPath.split('/').pop() || undefined,
-          });
-          if (previewSigned?.data?.signedUrl) {
-            previewImageUrl = previewSigned.data.signedUrl;
-          } else if (previewSigned?.error && previewSigned.error?.status !== 404) {
-            console.error('prints_search_error', {
-              requestId,
-              type: 'signed_url_error',
-              message: previewSigned.error?.message || 'No se pudo firmar la URL de preview.',
-              path: item.previewPath,
-            });
-          }
-        } catch (err) {
-          console.error('prints_search_error', {
-            requestId,
-            type: 'signed_url_error',
-            message: err?.message || 'Fallo al firmar la URL de preview.',
-            path: item.previewPath,
-          });
-        }
-      }
-
       return {
-        name: item.name,
-        path: item.path,
-        size: item.size,
-        contentType: item.contentType,
-        createdAt: item.createdAt,
-        updatedAt: item.updatedAt,
+        id: row.id,
+        jobKey: row.job_key,
+        bucket: row.bucket || OUTPUT_BUCKET,
+        fileName: row.file_name,
+        path: row.file_path,
+        widthCm: normalizeNumber(row.width_cm),
+        heightCm: normalizeNumber(row.height_cm),
+        material: row.material,
+        bgColor: row.bg_color,
+        jobId: row.job_id,
+        sizeBytes: normalizeNumber(row.file_size_bytes),
+        createdAt: row.created_at,
         downloadUrl,
-        previewImageUrl: previewImageUrl || undefined,
+        expiresIn: SEARCH_SIGNED_URL_TTL_SECONDS,
       };
     }),
   );
 
   console.info('prints_search_results', {
-    requestId,
-    query: rawQuery || null,
-    total,
+    diagId,
+    query: rawQuery,
+    limit,
+    offset,
+    total: totalCount,
     returned: items.length,
   });
 
   return {
     status: 200,
     body: {
-      query: rawQuery || null,
+      ok: true,
+      diagId,
+      query: rawQuery,
       limit,
       offset,
-      total,
+      total: totalCount,
       items,
+      signedUrlTtlSeconds: SEARCH_SIGNED_URL_TTL_SECONDS,
+      uploadSignedUrlTtlSeconds: UPLOAD_SIGNED_URL_TTL_SECONDS,
     },
   };
 }

--- a/lib/api/handlers/printsUpload.js
+++ b/lib/api/handlers/printsUpload.js
@@ -1,7 +1,8 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { slugifyName } from '../../_lib/slug.js';
 import generatePrintPdf, { validatePrintPdf } from '../../_lib/generatePrintPdf.js';
-import uploadPrintPdf from '../../_lib/uploadPrintPdf.js';
+import uploadPrintPdf, { SIGNED_URL_TTL_SECONDS as UPLOAD_SIGNED_URL_TTL_SECONDS } from '../../_lib/uploadPrintPdf.js';
+import getSupabaseAdmin from '../../_lib/supabaseAdmin.js';
 
 function toObject(input) {
   if (!input) return {};
@@ -65,9 +66,34 @@ function normalizeColor(input) {
   return `#${value}`;
 }
 
+function computeImageHash(buffer) {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
 const MAX_GENERATE_ATTEMPTS = 2;
 const VALIDATION_TOLERANCE_MM = 1;
 const BLEED_MARGIN_CM = 2;
+const OUTPUT_BUCKET = 'outputs';
+const PRINTS_TABLE = 'prints';
+
+function formatNumberForKey(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '0';
+  return num
+    .toFixed(2)
+    .replace(/\.00$/, '')
+    .replace(/0$/, '');
+}
+
+function buildJobKey({ slug, widthCm, heightCm, material, backgroundColor, imageHash }) {
+  const widthSegment = formatNumberForKey(widthCm);
+  const heightSegment = formatNumberForKey(heightCm);
+  return [slug, widthSegment, heightSegment, material, backgroundColor, imageHash].join('|');
+}
+
+function safeSlug(input) {
+  return slugifyName(input) || 'diseno';
+}
 
 async function readRawBody(req) {
   return new Promise((resolve, reject) => {
@@ -139,7 +165,7 @@ export async function uploadPrintHandler(req, res) {
 
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
-    return res.status(405).json({ ok: false, diagId, requestId, error: 'method_not_allowed' });
+    return res.status(405).json({ ok: false, diagId, requestId, reason: 'method_not_allowed' });
   }
 
   let payload = toObject(req.body);
@@ -149,7 +175,7 @@ export async function uploadPrintHandler(req, res) {
       payload = toObject(raw);
     } catch (err) {
       console.error('pdf_upload_parse_error', { diagId, requestId, message: err?.message || err });
-      return res.status(400).json({ ok: false, diagId, requestId, error: 'invalid_body' });
+      return res.status(400).json({ ok: false, diagId, requestId, reason: 'invalid_body' });
     }
   }
 
@@ -162,12 +188,12 @@ export async function uploadPrintHandler(req, res) {
   const heightCm = parseNumber(payload.anchoCm ?? payload.heightCm ?? payload.height_cm);
 
   if (!widthCm || widthCm <= 0 || !heightCm || heightCm <= 0) {
-    return res.status(400).json({ ok: false, diagId, requestId, error: 'invalid_dimensions' });
+    return res.status(400).json({ ok: false, diagId, requestId, reason: 'invalid_dimensions' });
   }
 
   const imageSource = extractImageSource(payload);
   if (!imageSource) {
-    return res.status(400).json({ ok: false, diagId, requestId, error: 'missing_image_source' });
+    return res.status(400).json({ ok: false, diagId, requestId, reason: 'missing_image_source' });
   }
 
   let imageBuffer;
@@ -180,20 +206,114 @@ export async function uploadPrintHandler(req, res) {
       message: err?.message || err,
       status: err?.status || err?.statusCode || null,
     });
-    return res.status(400).json({ ok: false, diagId, requestId, error: 'image_download_failed' });
+    return res.status(400).json({ ok: false, diagId, requestId, reason: 'image_download_failed' });
   }
 
   if (!imageBuffer || !imageBuffer.length) {
-    return res.status(400).json({ ok: false, diagId, requestId, error: 'empty_image' });
+    return res.status(400).json({ ok: false, diagId, requestId, reason: 'empty_image' });
   }
 
+  const safeSlugValue = safeSlug(slug);
+  const safeMaterial = sanitizeMaterial(material);
+  const safeJobId = sanitizeJobId(jobId);
   const filename = buildFilename({
-    slug,
+    slug: safeSlugValue,
     widthCm,
     heightCm,
-    material,
-    jobId,
+    material: safeMaterial,
+    jobId: safeJobId,
   });
+
+  const imageHash = computeImageHash(imageBuffer);
+  const jobKey = buildJobKey({
+    slug: safeSlugValue,
+    widthCm,
+    heightCm,
+    material: safeMaterial,
+    backgroundColor,
+    imageHash,
+  });
+
+  res.setHeader('X-Job-Key', jobKey);
+
+  let supabase;
+  try {
+    supabase = getSupabaseAdmin();
+  } catch (err) {
+    console.error('prints_supabase_init_error', { diagId, requestId, message: err?.message || err });
+    return res.status(500).json({ ok: false, diagId, requestId, reason: 'supabase_init_failed' });
+  }
+
+  const storage = supabase.storage.from(OUTPUT_BUCKET);
+
+  let existingRecord = null;
+  try {
+    const { data, error } = await supabase
+      .from(PRINTS_TABLE)
+      .select('*')
+      .eq('job_key', jobKey)
+      .maybeSingle();
+    if (error) throw error;
+    existingRecord = data || null;
+  } catch (err) {
+    console.error('prints_lookup_error', {
+      diagId,
+      requestId,
+      jobKey,
+      message: err?.message || err,
+      code: err?.code || null,
+    });
+    return res.status(502).json({ ok: false, diagId, requestId, reason: 'db_lookup_failed' });
+  }
+
+  if (existingRecord?.file_path) {
+    try {
+      const { data: signedData, error: signedError } = await storage.createSignedUrl(
+        existingRecord.file_path,
+        UPLOAD_SIGNED_URL_TTL_SECONDS,
+        { download: existingRecord.file_name || filename },
+      );
+      if (!signedError && signedData?.signedUrl) {
+        console.info('prints_idempotent_hit', {
+          diagId,
+          requestId,
+          jobKey,
+          path: existingRecord.file_path,
+          sizeBytes: existingRecord.file_size_bytes || null,
+        });
+        return res.status(200).json({
+          ok: true,
+          diagId,
+          requestId,
+          jobKey,
+          bucket: existingRecord.bucket || OUTPUT_BUCKET,
+          path: existingRecord.file_path,
+          fileName: existingRecord.file_name || filename,
+          sizeBytes: existingRecord.file_size_bytes || null,
+          signedUrl: signedData.signedUrl,
+          expiresIn: UPLOAD_SIGNED_URL_TTL_SECONDS,
+        });
+      }
+      if (signedError) {
+        console.error('prints_idempotent_signed_url_error', {
+          diagId,
+          requestId,
+          jobKey,
+          path: existingRecord.file_path,
+          message: signedError?.message || 'signed_url_failed',
+          status: signedError?.status || signedError?.statusCode || null,
+        });
+      }
+    } catch (err) {
+      console.error('prints_idempotent_signed_url_error', {
+        diagId,
+        requestId,
+        jobKey,
+        path: existingRecord.file_path,
+        message: err?.message || err,
+      });
+    }
+  }
 
   const expectedPageWidthCm = widthCm + BLEED_MARGIN_CM * 2;
   const expectedPageHeightCm = heightCm + BLEED_MARGIN_CM * 2;
@@ -205,11 +325,14 @@ export async function uploadPrintHandler(req, res) {
     console.info('pdf_generate_start', {
       diagId,
       requestId,
-      jobId,
-      slug: slug || null,
-      material: material || null,
+      jobId: safeJobId,
+      jobKey,
+      slug: safeSlugValue,
+      material: safeMaterial,
       widthCm,
       heightCm,
+      backgroundColor,
+      imageHash,
       attempt,
       pageCm: { widthCm: expectedPageWidthCm, heightCm: expectedPageHeightCm },
       artCm: { widthCm, heightCm },
@@ -232,12 +355,13 @@ export async function uploadPrintHandler(req, res) {
       console.error('pdf_generate_error', {
         diagId,
         requestId,
+        jobKey,
         attempt,
         error: err?.code || err?.message || 'pdf_generate_error',
         message: err?.message || err,
       });
       if (attempt >= MAX_GENERATE_ATTEMPTS) {
-        return res.status(500).json({ ok: false, diagId, requestId, error: 'pdf_generation_failed' });
+        return res.status(500).json({ ok: false, diagId, requestId, reason: 'pdf_generate_failed' });
       }
       continue;
     }
@@ -245,10 +369,11 @@ export async function uploadPrintHandler(req, res) {
     console.info('pdf_generate_end', {
       diagId,
       requestId,
-      jobId,
+      jobId: safeJobId,
+      jobKey,
       filename,
       attempt,
-      size: pdfResult.buffer.length,
+      sizeBytes: pdfResult.buffer.length,
       pageCm: {
         widthCm: pdfResult.info.pageWidthCm,
         heightCm: pdfResult.info.pageHeightCm,
@@ -280,6 +405,7 @@ export async function uploadPrintHandler(req, res) {
       console.error('pdf_validate_fail', {
         diagId,
         requestId,
+        jobKey,
         attempt,
         filename,
         error: err?.code || err?.message || 'pdf_validate_error',
@@ -288,7 +414,7 @@ export async function uploadPrintHandler(req, res) {
       pdfResult = null;
       validationResult = null;
       if (attempt >= MAX_GENERATE_ATTEMPTS) {
-        return res.status(500).json({ ok: false, diagId, requestId, error: 'pdf_validation_failed' });
+        return res.status(500).json({ ok: false, diagId, requestId, reason: 'pdf_validate_failed' });
       }
       continue;
     }
@@ -297,6 +423,7 @@ export async function uploadPrintHandler(req, res) {
       console.error('pdf_validate_fail', {
         diagId,
         requestId,
+        jobKey,
         attempt,
         filename,
         measured: validationResult.measured,
@@ -307,7 +434,7 @@ export async function uploadPrintHandler(req, res) {
       pdfResult = null;
       validationResult = null;
       if (attempt >= MAX_GENERATE_ATTEMPTS) {
-        return res.status(500).json({ ok: false, diagId, requestId, error: 'pdf_validation_failed' });
+        return res.status(500).json({ ok: false, diagId, requestId, reason: 'pdf_validate_failed' });
       }
       continue;
     }
@@ -315,6 +442,7 @@ export async function uploadPrintHandler(req, res) {
     console.info('pdf_validate_ok', {
       diagId,
       requestId,
+      jobKey,
       attempt,
       filename,
       measured: validationResult.measured,
@@ -327,15 +455,18 @@ export async function uploadPrintHandler(req, res) {
   }
 
   if (!pdfResult || !validationResult?.ok) {
-    return res.status(500).json({ ok: false, diagId, requestId, error: 'pdf_validation_failed' });
+    return res.status(500).json({ ok: false, diagId, requestId, reason: 'pdf_validate_failed' });
   }
+
+  const sizeBytes = pdfResult.buffer.length;
 
   console.info('pdf_upload_start', {
     diagId,
     requestId,
-    jobId,
+    jobId: safeJobId,
+    jobKey,
     filename,
-    size: pdfResult.buffer.length,
+    sizeBytes,
   });
 
   let uploadResult;
@@ -344,45 +475,99 @@ export async function uploadPrintHandler(req, res) {
       buffer: pdfResult.buffer,
       filename,
       metadata: {
-        jobId: jobId || undefined,
-        slug: slug || undefined,
+        jobId: safeJobId,
+        jobKey,
+        slug: safeSlugValue,
         widthCm,
         heightCm,
-        material: material || undefined,
+        material: safeMaterial,
         backgroundColor: pdfResult.info.backgroundColor,
+        imageHash,
       },
       diagId,
     });
   } catch (err) {
+    const reason = err?.code === 'pdf_too_large' ? 'pdf_too_large' : 'pdf_upload_failed';
+    const statusCode = reason === 'pdf_too_large' ? 413 : 502;
     console.error('pdf_upload_failure', {
       diagId,
       requestId,
+      jobKey,
+      filename,
+      sizeBytes,
       error: err?.code || err?.message || 'pdf_upload_failure',
       message: err?.message || err,
     });
-    return res.status(502).json({ ok: false, diagId, requestId, error: 'pdf_upload_failed' });
+    return res.status(statusCode).json({ ok: false, diagId, requestId, reason });
   }
 
   console.info('pdf_upload_ok', {
     diagId,
     requestId,
-    jobId,
+    jobId: safeJobId,
+    jobKey,
     filename,
     bucket: uploadResult.bucket,
     path: uploadResult.path,
+    sizeBytes,
     contentType: 'application/pdf',
+  });
+
+  const recordPayload = {
+    job_key: jobKey,
+    bucket: uploadResult.bucket,
+    file_path: uploadResult.path,
+    file_name: filename,
+    slug: safeSlugValue,
+    width_cm: widthCm,
+    height_cm: heightCm,
+    material: safeMaterial,
+    bg_color: backgroundColor,
+    job_id: safeJobId,
+    file_size_bytes: sizeBytes,
+    image_hash: imageHash,
+  };
+
+  let upsertedRecord = null;
+  try {
+    const { data, error } = await supabase
+      .from(PRINTS_TABLE)
+      .upsert(recordPayload, { onConflict: 'job_key', ignoreDuplicates: false })
+      .select()
+      .maybeSingle();
+    if (error) throw error;
+    upsertedRecord = data || null;
+  } catch (err) {
+    console.error('prints_upsert_error', {
+      diagId,
+      requestId,
+      jobKey,
+      path: uploadResult.path,
+      message: err?.message || err,
+      code: err?.code || null,
+    });
+    return res.status(502).json({ ok: false, diagId, requestId, reason: 'db_upsert_failed' });
+  }
+
+  console.info('prints_upsert_ok', {
+    diagId,
+    requestId,
+    jobKey,
+    path: uploadResult.path,
+    id: upsertedRecord?.id || null,
   });
 
   return res.status(200).json({
     ok: true,
     diagId,
     requestId,
+    jobKey,
     bucket: uploadResult.bucket,
     path: uploadResult.path,
-    publicUrl: uploadResult.publicUrl,
+    fileName: filename,
+    sizeBytes,
     signedUrl: uploadResult.signedUrl,
-    expiresIn: uploadResult.expiresIn,
-    filename,
+    expiresIn: uploadResult.expiresIn ?? UPLOAD_SIGNED_URL_TTL_SECONDS,
   });
 }
 

--- a/mgm-front/src/pages/Busqueda.jsx
+++ b/mgm-front/src/pages/Busqueda.jsx
@@ -183,16 +183,18 @@ export default function Busqueda() {
             </thead>
             <tbody>
               {hasResults ? (
-                results.map((item) => (
-                  <tr key={item.path}>
-                    <td className={styles.fileCell}>{item.name || '—'}</td>
-                    <td className={styles.sizeCell}>{formatBytes(item.size)}</td>
-                    <td className={styles.dateCell}>{formatDate(item.createdAt)}</td>
-                    <td>
-                      {item.downloadUrl ? (
-                        <a
-                          className={styles.downloadLink}
-                          href={item.downloadUrl}
+                results.map((item) => {
+                  const key = item.id || item.path || item.fileName;
+                  return (
+                    <tr key={key}>
+                      <td className={styles.fileCell}>{item.fileName || item.name || '—'}</td>
+                      <td className={styles.sizeCell}>{formatBytes(item.sizeBytes ?? item.size)}</td>
+                      <td className={styles.dateCell}>{formatDate(item.createdAt)}</td>
+                      <td>
+                        {item.downloadUrl ? (
+                          <a
+                            className={styles.downloadLink}
+                            href={item.downloadUrl}
                           target="_blank"
                           rel="noreferrer"
                         >
@@ -203,7 +205,8 @@ export default function Busqueda() {
                       )}
                     </td>
                   </tr>
-                ))
+                  );
+                })
               ) : (
                 <tr>
                   <td className={styles.noResults} colSpan={4}>

--- a/supabase/migrations/2025-09-19_create_prints_table.sql
+++ b/supabase/migrations/2025-09-19_create_prints_table.sql
@@ -1,0 +1,45 @@
+-- Crea tabla prints para indexar PDFs generados
+create extension if not exists pgcrypto;
+create extension if not exists pg_trgm;
+
+create table if not exists public.prints (
+  id uuid primary key default gen_random_uuid(),
+  job_key text not null unique,
+  bucket text not null default 'outputs',
+  file_path text not null,
+  file_name text not null,
+  slug text,
+  width_cm numeric,
+  height_cm numeric,
+  material text,
+  bg_color text,
+  job_id text,
+  image_hash text,
+  file_size_bytes bigint,
+  shopify_product_id text,
+  shopify_variant_id text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_prints_created_at_desc
+  on public.prints using btree (created_at desc, file_name asc);
+
+create index if not exists idx_prints_slug_trgm
+  on public.prints using gin (slug gin_trgm_ops);
+
+create index if not exists idx_prints_filename_trgm
+  on public.prints using gin (file_name gin_trgm_ops);
+
+create or replace function public.set_prints_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_prints_updated_at
+  before update on public.prints
+  for each row
+  execute function public.set_prints_updated_at();

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -63,3 +63,46 @@ create index if not exists job_events_job_id_idx on public.job_events(job_id);
 -- create index if not exists jobs_design_material_fts on public.jobs using gin (
 --   (to_tsvector('spanish', coalesce(design_name,'')) || to_tsvector('simple', coalesce(material,'')))
 -- );
+
+-- Table: prints
+create table if not exists public.prints (
+  id uuid primary key default gen_random_uuid(),
+  job_key text not null unique,
+  bucket text not null default 'outputs',
+  file_path text not null,
+  file_name text not null,
+  slug text,
+  width_cm numeric,
+  height_cm numeric,
+  material text,
+  bg_color text,
+  job_id text,
+  image_hash text,
+  file_size_bytes bigint,
+  shopify_product_id text,
+  shopify_variant_id text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_prints_created_at_desc
+  on public.prints using btree (created_at desc, file_name asc);
+
+create index if not exists idx_prints_slug_trgm
+  on public.prints using gin (slug gin_trgm_ops);
+
+create index if not exists idx_prints_filename_trgm
+  on public.prints using gin (file_name gin_trgm_ops);
+
+create or replace function public.set_prints_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_prints_updated_at
+  before update on public.prints
+  for each row
+  execute function public.set_prints_updated_at();


### PR DESCRIPTION
## Summary
- add deterministic job keys, stricter rounding, and metadata when generating print PDFs
- upload validated PDFs to Supabase outputs/pdf with retries, size guard, and upsert records into the new prints table
- expose a database-backed /api/prints/search endpoint and update the /busqueda UI to consume signed download URLs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8194aacd8832793fd0ee538075e09