### PR TITLE
Ensure cart endpoints always return JSON and harden cart client parsing

### DIFF
--- a/lib/handlers/cartAdd.js
+++ b/lib/handlers/cartAdd.js
@@ -21,7 +21,20 @@ function normalizeQuantity(value) {
 }
 
 function respond(res, status, payload) {
-  res.status(status).json(payload);
+  const body = JSON.stringify(payload ?? {});
+  if (typeof res.status === 'function') {
+    res.status(status);
+  } else {
+    res.statusCode = status;
+  }
+  if (typeof res.setHeader === 'function') {
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  }
+  if (typeof res.send === 'function') {
+    res.send(body);
+  } else {
+    res.end(body);
+  }
 }
 
 async function attemptStorefrontAdd({ cartId, variantGid, quantity, buyerIp, attempts = 2 }) {
@@ -74,6 +87,7 @@ export default async function cartAdd(req, res) {
       ok: true,
       cartId: storefrontResult.cartId,
       cartWebUrl: storefrontResult.cartWebUrl,
+      requestId: storefrontResult.requestId || undefined,
     });
   }
   const variantId = variantGid.split('/').pop();
@@ -87,12 +101,16 @@ export default async function cartAdd(req, res) {
     return respond(res, 200, {
       ok: true,
       cartWebUrl: fallbackResult.cartWebUrl,
+      fallbackUrl: fallbackResult.cartWebUrl,
       fallback: true,
+      requestId: storefrontResult?.requestId || undefined,
     });
   }
   return respond(res, 502, {
     ok: false,
     reason: fallbackResult.reason || storefrontResult?.reason || 'cart_add_failed',
     detail: fallbackResult.detail || storefrontResult?.detail || null,
+    userErrors: storefrontResult?.userErrors || undefined,
+    requestId: storefrontResult?.requestId || undefined,
   });
 }

--- a/lib/handlers/cartStart.js
+++ b/lib/handlers/cartStart.js
@@ -20,7 +20,20 @@ function normalizeQuantity(value) {
 }
 
 function respond(res, status, payload) {
-  res.status(status).json(payload);
+  const body = JSON.stringify(payload ?? {});
+  if (typeof res.status === 'function') {
+    res.status(status);
+  } else {
+    res.statusCode = status;
+  }
+  if (typeof res.setHeader === 'function') {
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  }
+  if (typeof res.send === 'function') {
+    res.send(body);
+  } else {
+    res.end(body);
+  }
 }
 
 async function attemptStorefrontCreate({ variantGid, quantity, buyerIp, attempts = 2 }) {
@@ -72,6 +85,7 @@ export default async function cartStart(req, res) {
       ok: true,
       cartId: storefrontResult.cartId,
       cartWebUrl: storefrontResult.cartWebUrl,
+      requestId: storefrontResult.requestId || undefined,
     });
   }
   const variantId = variantGid.split('/').pop();
@@ -85,12 +99,16 @@ export default async function cartStart(req, res) {
     return respond(res, 200, {
       ok: true,
       cartWebUrl: fallbackResult.cartWebUrl,
+      fallbackUrl: fallbackResult.cartWebUrl,
       fallback: true,
+      requestId: storefrontResult?.requestId || undefined,
     });
   }
   return respond(res, 502, {
     ok: false,
     reason: fallbackResult.reason || storefrontResult?.reason || 'cart_start_failed',
     detail: fallbackResult.detail || storefrontResult?.detail || null,
+    userErrors: storefrontResult?.userErrors || undefined,
+    requestId: storefrontResult?.requestId || undefined,
   });
 }

--- a/lib/shopify/storefrontCartServer.js
+++ b/lib/shopify/storefrontCartServer.js
@@ -109,14 +109,31 @@ async function executeStorefrontMutation(query, variables, { buyerIp } = {}) {
     throw err;
   }
   const requestId = readRequestId(resp);
+  const contentType = (resp.headers?.get?.('content-type') || '').toLowerCase();
   const text = await resp.text();
   let json;
   try {
     json = text ? JSON.parse(text) : null;
-  } catch {
+  } catch (err) {
+    try {
+      console.error('[storefront_cart] storefront_response_parse_failed', {
+        status: resp.status,
+        contentType,
+        bodyPreview: text ? text.slice(0, 200) : '',
+        requestId,
+      });
+    } catch {}
     json = null;
   }
   if (!resp.ok) {
+    try {
+      console.error('[storefront_cart] storefront_http_error', {
+        status: resp.status,
+        contentType,
+        bodyPreview: text ? text.slice(0, 200) : '',
+        requestId,
+      });
+    } catch {}
     return {
       ok: false,
       reason: 'http_error',
@@ -126,6 +143,14 @@ async function executeStorefrontMutation(query, variables, { buyerIp } = {}) {
     };
   }
   if (!json || typeof json !== 'object') {
+    try {
+      console.error('[storefront_cart] storefront_invalid_response', {
+        status: resp.status,
+        contentType,
+        bodyPreview: text ? text.slice(0, 200) : '',
+        requestId,
+      });
+    } catch {}
     return { ok: false, reason: 'invalid_response', requestId };
   }
   if (Array.isArray(json.errors) && json.errors.length) {
@@ -242,8 +267,16 @@ export async function fallbackCartAdd({ variantNumericId, quantity, jar = new Si
     redirect: 'manual',
   });
   jar.storeFromResponse(resp);
+  const contentType = (resp.headers?.get?.('content-type') || '').toLowerCase();
   const text = await resp.text();
   if (!resp.ok) {
+    try {
+      console.error('[storefront_cart] ajax_cart_http_error', {
+        status: resp.status,
+        contentType,
+        bodyPreview: text ? text.slice(0, 200) : '',
+      });
+    } catch {}
     return {
       ok: false,
       reason: 'ajax_cart_failed',


### PR DESCRIPTION
## Summary
- guarantee the cart start/add handlers set JSON content type, return request metadata, and surface fallback URLs
- add logging on storefront/ajax-cart errors to capture status, content type, and body preview for debugging HTML responses
- harden the cart button flow to parse responses defensively and show backend reasons/user errors in the toast

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d81b2ff84c8327bdcb27597784f791