### PR TITLE
Fix private checkout flow to call backend JSON endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -38,12 +38,12 @@ Creates a Shopify cart that includes a single product variant and returns `{ url
 
 ### `POST /api/private/checkout`
 
-Produces a checkout link for the private flow based on `PRIVATE_CHECKOUT_MODE`.
+Creates a Shopify draft order for the private flow and always responds with JSON:
 
-- `storefront` (default): creates a Storefront cart and responds with `{ checkoutUrl, cartUrl?, strategy: 'storefront' }`, preserving Shopify's coupon UI. When the storefront path fails (variant unavailable, Storefront credentials missing, etc.) the handler transparently falls back to the draft-order flow.
-- `draft_order`: creates an Admin draft order and returns `{ checkoutUrl, strategy: 'draft_order' }` pointing to the invoice URL. Draft orders now accept optional `discount` payloads (percentage or fixed-amount) which are applied with `draftOrderUpdate`, keeping Shopify's discount input available on the invoice checkout. Responses include `requestIds` for traceability when Shopify returns a `requestId` header.
+- Success → `{ ok: true, invoiceUrl, draftOrderId?, draftOrderName?, requestIds?, strategy: 'draft_order' }`. The frontend opens `invoiceUrl` in a new tab.
+- Handled failure → `{ ok: false, reason, userErrors?, status?, detail?, requestId?, requestIds?, missing? }` using HTTP 4xx/5xx codes depending on the failure (validation errors → `400`, Shopify errors → `502`, missing env → `500`).
 
-The request accepts `variantId`, optional `quantity`, `email`, `note`, `noteAttributes` and `discount`. Missing or invalid payloads yield `400 { reason: 'bad_request' }`. Shopify failures return `502` with a `reason` field and, when available, `userErrors` plus `requestId(s)`.
+The request accepts `variantId`, optional `quantity`, `email`, `note`, `noteAttributes` and `discount`. Missing or invalid payloads yield `400 { ok: false, reason: 'bad_request' }`. Shopify failures include diagnostic fields (user errors, `requestId(s)`) to aid debugging.
 
 ### `POST /api/create-checkout`
 

--- a/lib/handlers/privateCheckout.js
+++ b/lib/handlers/privateCheckout.js
@@ -7,6 +7,22 @@ import {
 } from '../shopify/cartHelpers.js';
 import { shopifyAdminGraphQL } from '../shopify.js';
 
+function safeInfo(label, payload) {
+  try {
+    console.info(label, payload);
+  } catch {}
+}
+
+function sendJson(res, status, body) {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  safeInfo('private_checkout_response', {
+    status,
+    contentType: res.getHeader('Content-Type') || 'application/json; charset=utf-8',
+  });
+  res.end(JSON.stringify(body));
+}
+
 const BodySchema = z
   .object({
     variantId: z.union([z.string(), z.number()]).optional(),
@@ -447,16 +463,20 @@ async function createDraftOrder({ variantGid, quantity, note, attributes, email,
       invoiceUrl = discountResult.invoiceUrl.trim();
     }
   }
-  const invoiceResult = await ensureInvoiceUrl({
-    draftOrderId,
-    invoiceUrl,
-    email,
-  });
-  if (!invoiceResult.ok) {
-    const combinedIds = invoiceResult.requestId ? requestIds.concat(invoiceResult.requestId) : requestIds;
-    return {
-      ok: false,
-      reason: invoiceResult.reason || 'invoice_failed',
+    const invoiceResult = await ensureInvoiceUrl({
+      draftOrderId,
+      invoiceUrl,
+      email,
+    });
+    safeInfo('draft_order_invoice', {
+      requestId: invoiceResult.requestId || null,
+      invoiceUrl: typeof invoiceResult.invoiceUrl === 'string' ? invoiceResult.invoiceUrl : null,
+    });
+    if (!invoiceResult.ok) {
+      const combinedIds = invoiceResult.requestId ? requestIds.concat(invoiceResult.requestId) : requestIds;
+      return {
+        ok: false,
+        reason: invoiceResult.reason || 'invoice_failed',
       userErrors: invoiceResult.userErrors,
       status: invoiceResult.status,
       body: invoiceResult.body,
@@ -487,9 +507,10 @@ function logResult(level, payload) {
 }
 
 export default async function privateCheckout(req, res) {
+  safeInfo('private_checkout_request', { method: req.method, path: req.url || '' });
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
-    return res.status(405).json({ reason: 'method_not_allowed' });
+    return sendJson(res, 405, { ok: false, reason: 'method_not_allowed' });
   }
   try {
     const body = await parseJsonBody(req).catch((err) => {
@@ -505,12 +526,12 @@ export default async function privateCheckout(req, res) {
     });
     const parsed = BodySchema.safeParse(body || {});
     if (!parsed.success) {
-      return res.status(400).json({ reason: 'bad_request' });
+      return sendJson(res, 400, { ok: false, reason: 'bad_request' });
     }
     const { variantId, variantGid, quantity, email, note, attributes, noteAttributes, discount } = parsed.data;
     let { variantNumericId, variantGid: resolvedVariantGid } = resolveVariantIds({ variantId, variantGid });
     if (!variantNumericId) {
-      return res.status(400).json({ reason: 'bad_request' });
+      return sendJson(res, 400, { ok: false, reason: 'bad_request' });
     }
     if (!resolvedVariantGid || !resolvedVariantGid.startsWith('gid://shopify/ProductVariant/')) {
       resolvedVariantGid = `gid://shopify/ProductVariant/${variantNumericId}`;
@@ -534,9 +555,13 @@ export default async function privateCheckout(req, res) {
         });
       } catch (err) {
         console.error?.('[private-checkout] draft_order_error', err);
-        res.status(502).json({ reason: 'shopify_unreachable' });
+        sendJson(res, 502, { ok: false, reason: 'shopify_unreachable' });
         return true;
       }
+      const firstRequestId = Array.isArray(draftAttempt?.requestIds) && draftAttempt.requestIds.length
+        ? draftAttempt.requestIds[0]
+        : draftAttempt?.requestId || null;
+      safeInfo('draft_order_create', { requestId: firstRequestId || null });
       if (!draftAttempt.ok) {
         logResult('warn', {
           mode,
@@ -550,11 +575,18 @@ export default async function privateCheckout(req, res) {
           requestIds: draftAttempt.requestIds || null,
         });
         if (draftAttempt.reason === 'shopify_env_missing') {
-          res.status(500).json({ reason: 'shopify_env_missing', missing: draftAttempt.missing });
+          sendJson(res, 500, {
+            ok: false,
+            reason: 'shopify_env_missing',
+            missing: draftAttempt.missing,
+            ...(draftAttempt.requestId ? { requestId: draftAttempt.requestId } : {}),
+            ...(Array.isArray(draftAttempt.requestIds) ? { requestIds: draftAttempt.requestIds } : {}),
+          });
           return true;
         }
         if (draftAttempt.reason === 'user_errors') {
-          res.status(502).json({
+          sendJson(res, 502, {
+            ok: false,
             reason: 'shopify_user_errors',
             userErrors: draftAttempt.userErrors,
             ...(draftAttempt.requestId ? { requestId: draftAttempt.requestId } : {}),
@@ -562,7 +594,8 @@ export default async function privateCheckout(req, res) {
           });
           return true;
         }
-        res.status(502).json({
+        sendJson(res, 502, {
+          ok: false,
           reason: draftAttempt.reason || 'draft_order_failed',
           ...(draftAttempt.status ? { status: draftAttempt.status } : {}),
           ...(draftAttempt.body ? { detail: draftAttempt.body } : {}),
@@ -580,7 +613,9 @@ export default async function privateCheckout(req, res) {
         fallbackFrom: trigger,
         requestIds: draftAttempt.requestIds || null,
       });
-      res.status(200).json({
+      sendJson(res, 200, {
+        ok: true,
+        invoiceUrl: draftAttempt.checkoutUrl,
         checkoutUrl: draftAttempt.checkoutUrl,
         draftOrderId: draftAttempt.draftOrderId || undefined,
         draftOrderName: draftAttempt.draftOrderName || undefined,
@@ -597,12 +632,12 @@ export default async function privateCheckout(req, res) {
     return;
   } catch (err) {
     if (res.statusCode === 413) {
-      return res.json({ reason: 'payload_too_large' });
+      return sendJson(res, 413, { ok: false, reason: 'payload_too_large' });
     }
     if (res.statusCode === 400 && err?.code === 'invalid_json') {
-      return res.json({ reason: 'bad_request' });
+      return sendJson(res, 400, { ok: false, reason: 'bad_request' });
     }
     console.error?.('[private-checkout] unhandled_error', err);
-    return res.status(500).json({ reason: 'internal_error' });
+    return sendJson(res, 500, { ok: false, reason: 'internal_error' });
   }
 }


### PR DESCRIPTION
## Summary
- update the frontend private checkout flow to call the configured API URL, validate JSON responses, and surface toast messaging on failure
- ensure the private purchase handler opens invoice URLs in a new tab and logs diagnostics for non-JSON responses
- return structured JSON with invoice URLs from the private checkout API, add logging hooks, and document the contract

## Testing
- npm run build (from mgm-front)


------
https://chatgpt.com/codex/tasks/task_e_68d8207bebbc83278432552fcd298135