### PR TITLE
Align cart and private checkout flows with shared API helper

### DIFF
--- a/lib/handlers/cartStart.js
+++ b/lib/handlers/cartStart.js
@@ -19,21 +19,23 @@ function normalizeQuantity(value) {
   return Math.max(1, Math.floor(raw));
 }
 
-function respond(res, status, payload, logLabel = '[cart_start_response]') {
-  const body = JSON.stringify(payload ?? {});
+function respond(res, status, payload, logLabel = 'cart_start_response') {
+  const body = payload ?? {};
+  const contentType = 'application/json; charset=utf-8';
+  if (typeof res.setHeader === 'function') {
+    res.setHeader('Content-Type', contentType);
+  }
   if (typeof res.status === 'function') {
     res.status(status);
   } else {
     res.statusCode = status;
   }
-  const contentType = 'application/json; charset=utf-8';
-  if (typeof res.setHeader === 'function') {
-    res.setHeader('Content-Type', contentType);
-  }
-  if (typeof res.send === 'function') {
-    res.send(body);
+  if (typeof res.json === 'function') {
+    res.json(body);
+  } else if (typeof res.send === 'function') {
+    res.send(JSON.stringify(body));
   } else {
-    res.end(body);
+    res.end(JSON.stringify(body));
   }
   try {
     console.info(logLabel, { status, contentType });
@@ -63,7 +65,7 @@ async function attemptStorefrontCreate({ variantGid, quantity, buyerIp, attempts
 
 export default async function cartStart(req, res) {
   try {
-    console.info('[cart_start_request]', { method: req.method, path: req.url || '' });
+    console.info('cart_start_request', { method: req.method, path: req.url || '' });
   } catch (loggingErr) {
     if (loggingErr) {
       // noop


### PR DESCRIPTION
## Summary
- ensure the cart start handler responds with JSON and standardized logging fields
- extend createJobAndProduct to optionally skip the private checkout request while exposing the payload for the UI
- update the mockup page to post cart/private actions through apiFetch and open the returned URLs just like the public checkout flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d82a72a7908327b16046da8213e4f6