### PR TITLE
Fix syntax error in Creating page finalize flow

### DIFF
--- a/mgm-front/src/pages/Creating.jsx
+++ b/mgm-front/src/pages/Creating.jsx
@@ -72,7 +72,6 @@ export default function Creating() {
             strategy: res?.raw?.strategy,
           },
         });
-        });
       } else {
         setNeedsRetry(true);
       }


### PR DESCRIPTION
## Summary
- remove the stray closing parenthesis after the navigate call in Creating.jsx to fix the Vite build failure

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da8ea25dd88327af24a65be9cb15db