### PR TITLE
Ensure add-to-cart redirects shoppers to mgmgamers.store with item preloaded

### DIFF
--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -798,7 +798,7 @@ export function buildCartPermalink(
 export function buildCartAddUrl(
   variantId: string | number | undefined,
   quantity = 1,
-  options?: { baseUrl?: string; discountCode?: string },
+  options?: { baseUrl?: string; discountCode?: string; returnTo?: string | null },
 ) {
   const numericId = normalizeVariantNumericId(variantId);
   if (!numericId) return '';
@@ -815,7 +815,16 @@ export function buildCartAddUrl(
   }
   cartUrl.searchParams.set('id', numericId);
   cartUrl.searchParams.set('quantity', String(qty));
-  cartUrl.searchParams.set('return_to', '/cart');
+  const rawReturn = options?.returnTo;
+  if (rawReturn !== null) {
+    const normalizedReturn = typeof rawReturn === 'string' && rawReturn.trim()
+      ? rawReturn.trim()
+      : '/cart';
+    const returnTo = normalizedReturn.startsWith('/')
+      ? normalizedReturn
+      : `/${normalizedReturn.replace(/^\/+/, '')}`;
+    cartUrl.searchParams.set('return_to', returnTo);
+  }
   const discountCode = typeof options?.discountCode === 'string' ? options.discountCode.trim() : '';
   if (discountCode) {
     cartUrl.searchParams.set('discount', discountCode);


### PR DESCRIPTION
## Summary
- allow `buildCartAddUrl` to accept a custom return path when building Shopify cart add links
- update the mockup cart flow to prefer the mgmgamers.store origin and open a `/cart/add` link that redirects shoppers to the storefront home with their item already in the cart

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da90d37d4083279420374e0b3b15c2