### PR TITLE
Fix draft order input for private checkout

### DIFF
--- a/lib/handlers/privateCheckout.js
+++ b/lib/handlers/privateCheckout.js
@@ -369,7 +369,6 @@ async function createDraftOrder({ variantGid, quantity, note, attributes, email,
       },
     ],
     tags: ['private', 'custom-mockup'],
-    allowPartialPayments: false,
   };
   const noteValue = normalizeCartNote(note);
   if (noteValue) {


### PR DESCRIPTION
## Summary
- remove the unsupported allowPartialPayments field from the draft order creation payload so Shopify no longer returns GraphQL errors when generating private checkouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da948fa89c832780a712850b3eff25