### PR TITLE
Handle missing cart URL state in result page

### DIFF
--- a/mgm-front/src/pages/Result.jsx
+++ b/mgm-front/src/pages/Result.jsx
@@ -113,9 +113,27 @@ export default function Result() {
   }, [added, autoOpened, cartEntryUrl, jobId]);
 
   if (!cartEntryUrl) {
-    added
-      ? normalizedCartUrl || normalizedCartPlain || cartEntryUrl
+    const fallbackCartUrl =
+      normalizedCartUrl || normalizedCartPlain || null;
 
+    return (
+      <div>
+        <p>Estamos preparando tu carrito…</p>
+        {fallbackCartUrl && (
+          <button
+            onClick={() => {
+              openCartUrl(fallbackCartUrl);
+              localStorage.setItem(`MGM_jobAdded:${jobId}`, "true");
+              setAdded(true);
+            }}
+          >
+            Intentar abrir el carrito
+          </button>
+        )}
+        <button onClick={() => navigate("/")}>Volver al inicio</button>
+      </div>
+    );
+  }
 
   const hrefCart =
     added && typeof urls.cartPlain === 'string' && urls.cartPlain.trim()


### PR DESCRIPTION
## Summary
- add an explicit fallback UI when the result page has not resolved a cart URL
- allow retrying the cart link manually and navigating back home while waiting

## Testing
- npm run lint *(fails: `_` is defined but never used in src/pages/Mockup.jsx:598)*

------
https://chatgpt.com/codex/tasks/task_e_68da960edf00832799948f6fcbb07995