### PR TITLE
Fix fallback cart URLs to open cart page

### DIFF
--- a/lib/handlers/cartAdd.js
+++ b/lib/handlers/cartAdd.js
@@ -129,12 +129,21 @@ export default async function cartAdd(req, res) {
     const fallbackCartUrl = typeof fallbackResult.cartUrl === 'string'
       ? fallbackResult.cartUrl.trim()
       : '';
+    const fallbackPlainUrl = typeof fallbackResult.fallbackCartUrl === 'string'
+      ? fallbackResult.fallbackCartUrl.trim()
+      : '';
+    const finalUrl = fallbackPlainUrl || fallbackCartUrl || undefined;
+    console.info('[cart_add_return_fallback]', {
+      url: finalUrl,
+      fallbackCartUrl,
+      fallbackPlainUrl,
+    });
     return respond(res, 200, {
       ok: true,
-      url: fallbackCartUrl || undefined,
-      cartUrl: fallbackCartUrl || undefined,
-      cartWebUrl: fallbackCartUrl || undefined,
-      cartPlain: fallbackResult.fallbackCartUrl || undefined,
+      url: finalUrl,
+      cartUrl: finalUrl || undefined,
+      cartWebUrl: finalUrl || undefined,
+      cartPlain: fallbackPlainUrl || undefined,
       fallbackUrl: fallbackCartUrl || undefined,
       fallback: true,
       usedFallback: true,

--- a/lib/handlers/cartStart.js
+++ b/lib/handlers/cartStart.js
@@ -140,14 +140,23 @@ export default async function cartStart(req, res) {
     const fallbackCartUrl = typeof fallbackResult.cartUrl === 'string'
       ? fallbackResult.cartUrl.trim()
       : '';
-    const finalUrl = fallbackCartUrl || buildCartPermalink(variantNumericId, normalizedQuantity);
-    console.info('cart_start_return_fallback', { url: finalUrl, fallbackCartUrl });
+    const fallbackPlainUrl = typeof fallbackResult.fallbackCartUrl === 'string'
+      ? fallbackResult.fallbackCartUrl.trim()
+      : '';
+    const finalUrl = fallbackPlainUrl
+      || fallbackCartUrl
+      || buildCartPermalink(variantNumericId, normalizedQuantity);
+    console.info('cart_start_return_fallback', {
+      url: finalUrl,
+      fallbackCartUrl,
+      fallbackPlainUrl,
+    });
     return respond(res, 200, {
       ok: true,
       url: finalUrl,
-      cartUrl: fallbackCartUrl || undefined,
+      cartUrl: finalUrl || undefined,
       cartWebUrl: finalUrl || undefined,
-      cartPlain: fallbackResult.fallbackCartUrl || undefined,
+      cartPlain: fallbackPlainUrl || undefined,
       fallbackUrl: fallbackCartUrl || undefined,
       usedFallback: true,
       requestId: storefrontResult?.requestId || undefined,


### PR DESCRIPTION
## Summary
- prefer the plain cart URL when the fallback cart creation path is used
- return cart and web URLs that keep shoppers on the cart instead of redirecting to checkout
- add extra logging to help diagnose which fallback URL was returned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da98e160e88327be776da724405c7d