### PR TITLE
Fix router slug parsing for prints search requests without /api prefix

### DIFF
--- a/api/[...slug].js
+++ b/api/[...slug].js
@@ -5,7 +5,8 @@ import { enforceRateLimit } from '../lib/_lib/rateLimit.js';
 function pathOf(req) {
   try {
     const url = new URL(req.url, `http://${req.headers.host}`);
-    return url.pathname.replace(/^\/api\/?/, '').replace(/\/$/, '');
+    const pathname = url.pathname || '';
+    return pathname.replace(/^\/api\/?/, '').replace(/^\/+/, '').replace(/\/$/, '');
   } catch {
     return '';
   }


### PR DESCRIPTION
## Summary
- normalize the API router slug parsing so requests like `/prints/search` are routed correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da9b3b31ac83279185067517758fac