### PR TITLE
Ensure public products activate and improve cart fallback handling

### DIFF
--- a/lib/handlers/cartStart.js
+++ b/lib/handlers/cartStart.js
@@ -130,6 +130,25 @@ export default async function cartStart(req, res) {
     });
   }
 
+  try {
+    console.warn('cart_start_storefront_failed', {
+      reason: storefrontResult?.reason || 'storefront_failed',
+      status: typeof storefrontResult?.status === 'number' ? storefrontResult.status : undefined,
+      userErrors: Array.isArray(storefrontResult?.userErrors) && storefrontResult.userErrors.length
+        ? storefrontResult.userErrors
+        : undefined,
+      errors: Array.isArray(storefrontResult?.errors) && storefrontResult.errors.length
+        ? storefrontResult.errors
+        : undefined,
+      detail: typeof storefrontResult?.body === 'string' && storefrontResult.body
+        ? storefrontResult.body
+        : typeof storefrontResult?.detail === 'string' && storefrontResult.detail
+          ? storefrontResult.detail
+          : undefined,
+      requestId: storefrontResult?.requestId || undefined,
+    });
+  } catch {}
+
   const jar = new SimpleCookieJar();
   const fallbackResult = await fallbackCartAdd({
     variantNumericId,
@@ -143,8 +162,8 @@ export default async function cartStart(req, res) {
     const fallbackPlainUrl = typeof fallbackResult.fallbackCartUrl === 'string'
       ? fallbackResult.fallbackCartUrl.trim()
       : '';
-    const finalUrl = fallbackPlainUrl
-      || fallbackCartUrl
+    const finalUrl = fallbackCartUrl
+      || fallbackPlainUrl
       || buildCartPermalink(variantNumericId, normalizedQuantity);
     console.info('cart_start_return_fallback', {
       url: finalUrl,
@@ -154,12 +173,16 @@ export default async function cartStart(req, res) {
     return respond(res, 200, {
       ok: true,
       url: finalUrl,
-      cartUrl: finalUrl || undefined,
+      cartUrl: fallbackCartUrl || finalUrl || undefined,
       cartWebUrl: finalUrl || undefined,
       cartPlain: fallbackPlainUrl || undefined,
       fallbackUrl: fallbackCartUrl || undefined,
+      fallbackPlainUrl: fallbackPlainUrl || undefined,
       usedFallback: true,
       requestId: storefrontResult?.requestId || undefined,
+      storefrontUserErrors: Array.isArray(storefrontResult?.userErrors) && storefrontResult.userErrors.length
+        ? storefrontResult.userErrors
+        : undefined,
     });
   }
 

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -512,6 +512,71 @@ async function executeProductCreate({ input, filename, maxAttempts = 3 }) {
   return attempts[attempts.length - 1];
 }
 
+async function executeProductStatusUpdate({ productId, status = 'ACTIVE', maxAttempts = 2 }) {
+  const attempts = [];
+  let lastError = null;
+  const normalizedId = typeof productId === 'string' ? productId : '';
+  if (!normalizedId) {
+    throw new Error('product_status_update_missing_id');
+  }
+  const normalizedStatus = typeof status === 'string' && status
+    ? status.toUpperCase()
+    : 'ACTIVE';
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      const variables = { input: { id: normalizedId, status: normalizedStatus } };
+      const resp = await shopifyAdminGraphQL(PRODUCT_STATUS_UPDATE_MUTATION, variables);
+      const requestId = logRequestId('product_status_update_request', resp, {
+        attempt: attempt + 1,
+        productId: normalizedId,
+      });
+      const json = await resp.json().catch(() => null);
+      const attemptInfo = { resp, json, requestId };
+      attempts.push(attemptInfo);
+
+      if (resp.ok) {
+        return { ...attemptInfo, attempts };
+      }
+
+      if (!RETRYABLE_SHOPIFY_STATUS.has(resp.status) || attempt === maxAttempts - 1) {
+        return { ...attemptInfo, attempts };
+      }
+
+      try {
+        console.warn('product_status_update_retry', {
+          attempt: attempt + 1,
+          status: resp.status,
+          requestId: requestId || null,
+          productId: normalizedId,
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    } catch (err) {
+      lastError = err;
+      attempts.push({ error: err });
+
+      if (attempt === maxAttempts - 1) {
+        throw err;
+      }
+
+      try {
+        console.warn('product_status_update_retry_error', {
+          attempt: attempt + 1,
+          message: err?.message || String(err),
+          productId: normalizedId,
+        });
+      } catch {}
+
+      await sleep(200 * 2 ** attempt);
+    }
+  }
+
+  if (lastError) throw lastError;
+  return attempts[attempts.length - 1];
+}
+
 function shouldUseBulkVariantUpdate(json) {
   const errors = Array.isArray(json?.errors) ? json.errors : [];
   return errors.some((error) => {
@@ -1128,6 +1193,21 @@ const PRODUCT_CREATE_MUTATION = `mutation ProductCreate($input: ProductInput!) {
           }
         }
       }
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}`;
+
+const PRODUCT_STATUS_UPDATE_MUTATION = `mutation ProductStatusUpdate($input: ProductInput!) {
+  productUpdate(input: $input) {
+    product {
+      id
+      legacyResourceId
+      handle
+      status
     }
     userErrors {
       field
@@ -2032,6 +2112,8 @@ export async function publishProduct(req, res) {
     }
     const product = productPayload.product || {};
     let meta = buildProductMeta(product, {});
+    let statusRequestId = null;
+    let statusRequestIds = [];
     try {
       console.info('product_create_success', { requestId: productRequestId || null, productId: meta.productAdminId || null });
     } catch {}
@@ -2907,12 +2989,168 @@ export async function publishProduct(req, res) {
     }
 
     if (!isPrivate && !isActiveStatus(product)) {
+      const {
+        resp: statusResp,
+        json: statusJson,
+        requestId: statusUpdateRequestId,
+        attempts: statusAttempts,
+      } = await executeProductStatusUpdate({ productId: productIdForVariants, status: 'ACTIVE' });
+
+      statusRequestId = statusUpdateRequestId || null;
+      statusRequestIds = Array.isArray(statusAttempts)
+        ? statusAttempts.map((entry) => entry?.requestId).filter(Boolean)
+        : [];
+
+      const statusErrors = Array.isArray(statusJson?.errors) ? statusJson.errors : [];
+      const formattedStatusErrors = formatGraphQLErrors(statusErrors);
+      const statusPayload = statusJson?.data?.productUpdate;
+
+      if (!statusResp.ok) {
+        return res.status(502).json({
+          ok: false,
+          reason: 'product_status_update_failed',
+          status: statusResp.status,
+          body: statusJson,
+          requestId: statusRequestId,
+          ...(statusRequestIds.length ? { requestIds: statusRequestIds } : {}),
+          message: 'Shopify devolvió un error al activar el producto.',
+          ...meta,
+          visibility,
+        });
+      }
+
+      if (statusErrors.length && !statusPayload) {
+        if (detectMissingScope(statusErrors)) {
+          const missingScopes = collectMissingScopes(statusErrors);
+          const missing = missingScopes.length ? missingScopes : ['write_products'];
+          const friendlyMessage = missing.length
+            ? `La app de Shopify no tiene permisos suficientes. Faltan los scopes: ${missing.join(', ')}.`
+            : 'La app de Shopify no tiene permisos suficientes para actualizar el producto.';
+          return res.status(400).json({
+            ok: false,
+            reason: 'shopify_scope_missing',
+            errors: formattedStatusErrors,
+            requestId: statusRequestId,
+            missing,
+            message: friendlyMessage,
+            ...meta,
+            visibility,
+          });
+        }
+        const statusErrorMessages = collectGraphQLErrorMessages(statusErrors);
+        try {
+          console.error('product_status_update_graphql_errors', {
+            requestId: statusRequestId,
+            messages: statusErrorMessages,
+            errors: formattedStatusErrors,
+          });
+        } catch {}
+        return res.status(502).json({
+          ok: false,
+          reason: 'shopify_graphql_errors',
+          errors: formattedStatusErrors,
+          requestId: statusRequestId,
+          message: statusErrorMessages.length
+            ? `Shopify devolvió errores: ${statusErrorMessages.join(' | ')}`
+            : 'Shopify devolvió un error al activar el producto.',
+          ...(statusErrorMessages.length ? { messages: statusErrorMessages } : {}),
+          ...meta,
+          visibility,
+        });
+      }
+
+      if (!statusPayload || typeof statusPayload !== 'object') {
+        return res.status(502).json({
+          ok: false,
+          reason: 'product_status_update_invalid_response',
+          detail: statusJson,
+          requestId: statusRequestId,
+          message: 'Shopify no devolvió un resultado válido al activar el producto.',
+          ...meta,
+          visibility,
+        });
+      }
+
+      const statusUserErrors = sanitizeUserErrors(statusPayload.userErrors);
+      if (statusUserErrors.length) {
+        const statusUserErrorMessages = statusUserErrors
+          .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
+          .filter(Boolean);
+        const friendlyStatusMessage = statusUserErrorMessages.length
+          ? statusUserErrorMessages[0]
+          : 'Shopify rechazó el cambio de estado del producto.';
+        try {
+          console.error('product_status_update_user_errors', {
+            requestId: statusRequestId,
+            userErrors: statusUserErrors.map((error) => ({
+              field: Array.isArray(error?.field) ? error.field.join('.') : undefined,
+              message: typeof error?.message === 'string' ? error.message : '',
+            })),
+          });
+        } catch {}
+        return res.status(400).json({
+          ok: false,
+          reason: 'product_status_update_user_errors',
+          message: friendlyStatusMessage,
+          detail: statusUserErrors,
+          requestId: statusRequestId,
+          ...(statusUserErrorMessages.length ? { messages: statusUserErrorMessages } : {}),
+          ...meta,
+          visibility,
+        });
+      }
+
+      if (statusErrors.length) {
+        const statusErrorMessages = collectGraphQLErrorMessages(statusErrors);
+        const warningMessage = statusErrorMessages.length
+          ? `Shopify devolvió advertencias al activar el producto: ${statusErrorMessages.join(' | ')}`
+          : 'Shopify devolvió advertencias al activar el producto.';
+        const warningPayload = {
+          code: 'product_status_update_warning',
+          message: warningMessage,
+          detail: formattedStatusErrors,
+          requestId: statusRequestId,
+          ...(statusErrorMessages.length ? { messages: statusErrorMessages } : {}),
+        };
+        warnings.push(warningPayload);
+        try {
+          console.warn('product_status_update_graphql_warning', {
+            requestId: statusRequestId,
+            messages: statusErrorMessages,
+            errors: formattedStatusErrors,
+          });
+        } catch {}
+      }
+
+      const updatedProduct = statusPayload.product && typeof statusPayload.product === 'object'
+        ? statusPayload.product
+        : null;
+
+      if (updatedProduct) {
+        product = { ...product, ...updatedProduct };
+      } else {
+        product = { ...product, status: 'ACTIVE' };
+      }
+
+      meta = buildProductMeta(product, {});
+
+      try {
+        console.info('product_status_update_success', {
+          requestId: statusRequestId,
+          productId: meta.productAdminId || meta.productId || null,
+        });
+      } catch {}
+    }
+
+    if (!isPrivate && !isActiveStatus(product)) {
       return res.status(400).json({
         ok: false,
         reason: 'product_not_active',
         message: 'El producto creado no quedó activo en Shopify. Revisá la visibilidad configurada y volvé a intentarlo.',
         ...meta,
         visibility,
+        requestId: statusRequestId,
+        ...(statusRequestIds.length ? { requestIds: statusRequestIds } : {}),
       });
     }
 


### PR DESCRIPTION
## Summary
- log Storefront API cart creation failures and return the permalink when falling back to the legacy cart endpoint
- add a Shopify productUpdate call to promote newly created public products to ACTIVE with detailed error handling and warnings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da9e07dde48327bf0fc34d47d2cb9d