### PR TITLE
Fix Storefront cart URLs and improve legacy fallback

### DIFF
--- a/lib/shopify/storefrontCartServer.js
+++ b/lib/shopify/storefrontCartServer.js
@@ -1,11 +1,16 @@
 import { shopifyStorefrontGraphQL } from '../shopify.js';
 
+const STORE_ORIGIN = (process.env.SHOPIFY_CART_ORIGIN || 'https://www.mgmgamers.store').replace(/\/+$/, '');
+const FALLBACK_ADD_ENDPOINT = `${STORE_ORIGIN}/cart/add.js`;
+const FALLBACK_CART_URL = `${STORE_ORIGIN}/cart`;
+const DEFAULT_CART_ORIGIN = STORE_ORIGIN;
+
 const CART_CREATE_MUTATION = `
   mutation CartCreate($lines: [CartLineInput!]!) {
     cartCreate(input: { lines: $lines }) {
       cart {
         id
-        webUrl
+        checkoutUrl
       }
       userErrors {
         field
@@ -21,7 +26,7 @@ const CART_LINES_ADD_MUTATION = `
     cartLinesAdd(cartId: $cartId, lines: $lines) {
       cart {
         id
-        webUrl
+        checkoutUrl
       }
       userErrors {
         field
@@ -31,10 +36,6 @@ const CART_LINES_ADD_MUTATION = `
     }
   }
 `;
-
-const FALLBACK_ADD_ENDPOINT = 'https://www.mgmgamers.store/cart/add.js';
-const FALLBACK_CART_URL = 'https://www.mgmgamers.store/cart';
-const DEFAULT_CART_ORIGIN = (process.env.SHOPIFY_CART_ORIGIN || FALLBACK_CART_URL).replace(/\/+$/, '');
 
 function buildFallbackPermalink(variantNumericId, quantity) {
   const id = variantNumericId ? String(variantNumericId).trim() : '';
@@ -230,10 +231,11 @@ export async function createStorefrontCartServer({ variantGid, quantity, buyerIp
     return { ok: false, reason: 'user_errors', userErrors, requestId: result.requestId };
   }
   const cart = payload.cart;
-  if (!cart || typeof cart !== 'object' || !cart.id || !cart.webUrl) {
+  const checkoutUrl = typeof cart?.checkoutUrl === 'string' ? cart.checkoutUrl.trim() : '';
+  if (!cart || typeof cart !== 'object' || !cart.id || !checkoutUrl) {
     return { ok: false, reason: 'missing_cart', requestId: result.requestId };
   }
-  const urls = buildStorefrontCartUrls({ cartId: cart.id, checkoutUrl: cart.webUrl });
+  const urls = buildStorefrontCartUrls({ cartId: cart.id, checkoutUrl });
   return {
     ok: true,
     cartId: cart.id,
@@ -242,7 +244,7 @@ export async function createStorefrontCartServer({ variantGid, quantity, buyerIp
     cartToken: urls.cartToken || '',
     checkoutUrl: urls.checkoutUrl || '',
     checkoutPlain: urls.checkoutPlain || '',
-    cartWebUrl: cart.webUrl,
+    cartWebUrl: urls.cartUrl || '',
     requestId: result.requestId,
   };
 }
@@ -269,10 +271,11 @@ export async function addLinesToStorefrontCart({ cartId, variantGid, quantity, b
     return { ok: false, reason: 'user_errors', userErrors, requestId: result.requestId };
   }
   const cart = payload.cart;
-  if (!cart || typeof cart !== 'object' || !cart.id || !cart.webUrl) {
+  const checkoutUrl = typeof cart?.checkoutUrl === 'string' ? cart.checkoutUrl.trim() : '';
+  if (!cart || typeof cart !== 'object' || !cart.id || !checkoutUrl) {
     return { ok: false, reason: 'missing_cart', requestId: result.requestId };
   }
-  const urls = buildStorefrontCartUrls({ cartId: cart.id, checkoutUrl: cart.webUrl });
+  const urls = buildStorefrontCartUrls({ cartId: cart.id, checkoutUrl });
   return {
     ok: true,
     cartId: cart.id,
@@ -281,7 +284,7 @@ export async function addLinesToStorefrontCart({ cartId, variantGid, quantity, b
     cartToken: urls.cartToken || '',
     checkoutUrl: urls.checkoutUrl || '',
     checkoutPlain: urls.checkoutPlain || '',
-    cartWebUrl: cart.webUrl,
+    cartWebUrl: urls.cartUrl || '',
     requestId: result.requestId,
   };
 }
@@ -295,12 +298,14 @@ export async function fallbackCartAdd({ variantNumericId, quantity, jar = new Si
   }
   const qty = Number.isFinite(quantity) && quantity > 0 ? Math.max(1, Math.floor(quantity)) : 1;
   const cartPermalink = buildFallbackPermalink(normalizedId, qty);
-  const form = new URLSearchParams();
-  form.set('id', normalizedId);
-  form.set('quantity', String(qty));
+  const payload = {
+    id: Number.isFinite(Number(normalizedId)) ? Number(normalizedId) : normalizedId,
+    quantity: qty,
+  };
   const headers = {
-    'Content-Type': 'application/x-www-form-urlencoded',
+    'Content-Type': 'application/json',
     Accept: 'application/json',
+    'User-Agent': 'mgm-cart/1.0 (+https://www.mgmgamers.store)',
   };
   const cookieHeader = jar.headerValue;
   if (cookieHeader) {
@@ -309,33 +314,60 @@ export async function fallbackCartAdd({ variantNumericId, quantity, jar = new Si
   const resp = await fetch(FALLBACK_ADD_ENDPOINT, {
     method: 'POST',
     headers,
-    body: form.toString(),
+    body: JSON.stringify(payload),
     redirect: 'manual',
   });
   jar.storeFromResponse(resp);
   const contentType = (resp.headers?.get?.('content-type') || '').toLowerCase();
   const text = await resp.text();
+  let json;
+  if (text) {
+    try {
+      json = JSON.parse(text);
+    } catch (err) {
+      json = null;
+      try {
+        console.warn('[storefront_cart] ajax_cart_parse_failed', {
+          message: err?.message,
+          preview: text.slice(0, 200),
+        });
+      } catch {}
+    }
+  }
   if (!resp.ok) {
     try {
       console.error('[storefront_cart] ajax_cart_http_error', {
         status: resp.status,
         contentType,
         bodyPreview: text ? text.slice(0, 200) : '',
+        payload,
       });
     } catch {}
     return {
       ok: false,
       reason: 'ajax_cart_failed',
       status: resp.status,
-      detail: text ? text.slice(0, 2000) : '',
+      detail: json ? JSON.stringify(json).slice(0, 2000) : text ? text.slice(0, 2000) : '',
     };
   }
+  const token = typeof json?.token === 'string' ? json.token.trim() : '';
+  const cartUrl = token ? `${DEFAULT_CART_ORIGIN}/cart/c/${token}` : cartPermalink || FALLBACK_CART_URL;
+  const detail = json ? JSON.stringify(json).slice(0, 2000) : text ? text.slice(0, 2000) : '';
+  try {
+    console.info('[storefront_cart] ajax_cart_success', {
+      status: resp.status,
+      contentType,
+      cartUrl,
+      token: token ? `${token.slice(0, 6)}…` : '',
+    });
+  } catch {}
   return {
     ok: true,
-    cartUrl: cartPermalink || FALLBACK_CART_URL,
-    cartWebUrl: cartPermalink || FALLBACK_CART_URL,
+    cartUrl,
+    cartWebUrl: cartUrl,
     fallbackCartUrl: FALLBACK_CART_URL,
-    detail: text ? text.slice(0, 2000) : '',
+    detail,
+    responseJson: json || undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
- update Storefront cart mutations to request checkoutUrl and rebuild cart links from the token
- return computed cart URLs in handlers to avoid relying on the removed webUrl field
- modernize the legacy cart fallback request and logging, including JSON payloads and richer diagnostics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dad6f874388327a9e5023f48152543