### PR TITLE
Fix checkoutUrl usage in Shopify cart flow

### DIFF
--- a/lib/shopify/storefrontCartServer.js
+++ b/lib/shopify/storefrontCartServer.js
@@ -298,9 +298,15 @@ export async function fallbackCartAdd({ variantNumericId, quantity, jar = new Si
   }
   const qty = Number.isFinite(quantity) && quantity > 0 ? Math.max(1, Math.floor(quantity)) : 1;
   const cartPermalink = buildFallbackPermalink(normalizedId, qty);
+  const itemId = Number.isFinite(Number(normalizedId)) ? Number(normalizedId) : normalizedId;
   const payload = {
-    id: Number.isFinite(Number(normalizedId)) ? Number(normalizedId) : normalizedId,
-    quantity: qty,
+    items: [
+      {
+        id: itemId,
+        quantity: qty,
+        properties: {},
+      },
+    ],
   };
   const headers = {
     'Content-Type': 'application/json',
@@ -335,19 +341,21 @@ export async function fallbackCartAdd({ variantNumericId, quantity, jar = new Si
     }
   }
   if (!resp.ok) {
+    const detail = json ? JSON.stringify(json).slice(0, 2000) : text ? text.slice(0, 2000) : '';
     try {
       console.error('[storefront_cart] ajax_cart_http_error', {
         status: resp.status,
         contentType,
         bodyPreview: text ? text.slice(0, 200) : '',
         payload,
+        detail,
       });
     } catch {}
     return {
       ok: false,
       reason: 'ajax_cart_failed',
       status: resp.status,
-      detail: json ? JSON.stringify(json).slice(0, 2000) : text ? text.slice(0, 2000) : '',
+      detail,
     };
   }
   const token = typeof json?.token === 'string' ? json.token.trim() : '';

--- a/mgm-front/src/lib/pollJobAndCreateCart.ts
+++ b/mgm-front/src/lib/pollJobAndCreateCart.ts
@@ -76,8 +76,8 @@ export async function pollJobAndCreateCart(
             ? j.cartPlain.trim()
             : typeof j?.url === "string" && j.url.trim()
               ? j.url.trim()
-              : typeof j?.webUrl === "string" && j.webUrl.trim()
-                ? j.webUrl.trim()
+              : typeof j?.checkoutUrl === "string" && j.checkoutUrl.trim()
+                ? j.checkoutUrl.trim()
                 : null;
       if (!res.ok || !cartUrl) {
         // Si falta algo, seguir esperando si hay intentos restantes

--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -942,7 +942,7 @@ interface StorefrontCartUserError {
 }
 
 interface StorefrontCartPayload {
-  cart?: { id?: string | null; webUrl?: string | null } | null;
+  cart?: { id?: string | null; checkoutUrl?: string | null } | null;
   userErrors?: StorefrontCartUserError[] | null;
 }
 
@@ -993,14 +993,14 @@ async function performStorefrontCartMutation(
 
 const CART_CREATE_MUTATION = `mutation CartCreate($lines: [CartLineInput!]!, $discountCodes: [String!]) {
   cartCreate(input: { lines: $lines, discountCodes: $discountCodes }) {
-    cart { id webUrl }
+    cart { id checkoutUrl }
     userErrors { message code field }
   }
 }`;
 
 const CART_LINES_ADD_MUTATION = `mutation CartLinesAdd($cartId: ID!, $lines: [CartLineInput!]!) {
   cartLinesAdd(cartId: $cartId, lines: $lines) {
-    cart { id webUrl }
+    cart { id checkoutUrl }
     userErrors { message code field }
   }
 }`;
@@ -1017,7 +1017,7 @@ const VARIANT_AVAILABILITY_QUERY = `query WaitVariant($id: ID!) {
 
 export interface StorefrontCartSuccess {
   cartId: string;
-  webUrl: string;
+  checkoutUrl: string;
 }
 
 export async function addVariantToCartStorefront(
@@ -1113,15 +1113,15 @@ export async function addVariantToCartStorefront(
     const userErrors = extractUserErrors(data);
     const payloadErrors = Array.isArray(payload?.errors) ? payload.errors.filter(Boolean) : [];
     const resolvedCartId = data?.cart?.id ? String(data.cart.id) : cartId;
-    const resolvedWebUrl = data?.cart?.webUrl ? String(data.cart.webUrl) : '';
-    if (response.ok && !payloadErrors.length && !userErrors.length && resolvedCartId && resolvedWebUrl) {
+    const resolvedCheckoutUrl = data?.cart?.checkoutUrl ? String(data.cart.checkoutUrl) : '';
+    if (response.ok && !payloadErrors.length && !userErrors.length && resolvedCartId && resolvedCheckoutUrl) {
       setStoredCartId(resolvedCartId);
       try {
-        console.info('[cart-flow] cart_lines_add_ok', { cartId: resolvedCartId, webUrl: resolvedWebUrl });
+        console.info('[cart-flow] cart_lines_add_ok', { cartId: resolvedCartId, checkoutUrl: resolvedCheckoutUrl });
       } catch (logErr) {
         console.warn?.('[cart-flow] cart_lines_add_log_failed', logErr);
       }
-      return { ok: true, value: { cartId: resolvedCartId, webUrl: resolvedWebUrl } };
+      return { ok: true, value: { cartId: resolvedCartId, checkoutUrl: resolvedCheckoutUrl } };
     }
 
     try {
@@ -1157,15 +1157,15 @@ export async function addVariantToCartStorefront(
     const userErrors = extractUserErrors(data);
     const payloadErrors = Array.isArray(payload?.errors) ? payload.errors.filter(Boolean) : [];
     const createdCartId = data?.cart?.id ? String(data.cart.id) : '';
-    const createdWebUrl = data?.cart?.webUrl ? String(data.cart.webUrl) : '';
-    if (response.ok && !payloadErrors.length && !userErrors.length && createdCartId && createdWebUrl) {
+    const createdCheckoutUrl = data?.cart?.checkoutUrl ? String(data.cart.checkoutUrl) : '';
+    if (response.ok && !payloadErrors.length && !userErrors.length && createdCartId && createdCheckoutUrl) {
       setStoredCartId(createdCartId);
       try {
-        console.info('[cart-flow] cart_create_ok', { cartId: createdCartId, webUrl: createdWebUrl });
+        console.info('[cart-flow] cart_create_ok', { cartId: createdCartId, checkoutUrl: createdCheckoutUrl });
       } catch (logErr) {
         console.warn?.('[cart-flow] cart_create_log_failed', logErr);
       }
-      return { ok: true, value: { cartId: createdCartId, webUrl: createdWebUrl } };
+      return { ok: true, value: { cartId: createdCartId, checkoutUrl: createdCheckoutUrl } };
     }
 
     try {

--- a/mgm-front/src/pages/Creating.jsx
+++ b/mgm-front/src/pages/Creating.jsx
@@ -57,7 +57,7 @@ export default function Creating() {
           (typeof res?.raw?.cartUrl === "string" && res.raw.cartUrl.trim())
             || (typeof res?.raw?.cartPlain === "string" && res.raw.cartPlain.trim())
             || (typeof res?.raw?.url === "string" && res.raw.url.trim())
-            || (typeof res?.raw?.webUrl === "string" && res.raw.webUrl.trim())
+            || (typeof res?.raw?.checkoutUrl === "string" && res.raw.checkoutUrl.trim())
             || null;
         const cartPlainCandidate =
           (typeof res?.raw?.cartPlain === "string" && res.raw.cartPlain.trim())

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -349,7 +349,7 @@ export default function Mockup() {
     const useFallback = Boolean(options.useFallback);
     let link = url;
     if (!link) {
-      link = useFallback ? cart.fallbackUrl : cart.webUrl;
+      link = useFallback ? cart.fallbackUrl : cart.cartUrl;
     }
     if (!link) return;
     const fallbackUrl = useFallback
@@ -572,7 +572,10 @@ export default function Mockup() {
           variantIdNumeric: variantNumericId,
           variantIdGid: variantGidForCart,
           ...(normalizedResponseUrl ? { url: normalizedResponseUrl } : {}),
-          ...(normalizedCartUrlFromServer ? { webUrl: normalizedCartUrlFromServer } : {}),
+          ...(normalizedCartUrlFromServer ? { cartUrl: normalizedCartUrlFromServer } : {}),
+          ...(typeof json?.checkoutUrl === 'string' && json.checkoutUrl.trim()
+            ? { checkoutUrl: json.checkoutUrl.trim() }
+            : {}),
           ...(json?.cartPlain ? { cartPlain: json.cartPlain } : {}),
           ...(json?.cartId ? { cartId: json.cartId } : {}),
           ...(fallbackProductUrl ? { fallbackUrl: fallbackProductUrl } : {}),

--- a/mgm-front/src/pages/Result.jsx
+++ b/mgm-front/src/pages/Result.jsx
@@ -74,7 +74,7 @@ export default function Result() {
           normalize(j?.cartUrl)
             || normalize(j?.cartPlain)
             || normalize(j?.url)
-            || normalize(j?.webUrl);
+            || normalize(j?.checkoutUrl);
 
         if (res.ok && cartUrl && !cancelled) {
           setUrls({

--- a/tests/storefront-cart-server.test.js
+++ b/tests/storefront-cart-server.test.js
@@ -1,0 +1,147 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createStorefrontCartServer,
+  fallbackCartAdd,
+  SimpleCookieJar,
+} from '../lib/shopify/storefrontCartServer.js';
+
+function createResponse(body, { status = 200, ok = true, headers = {} } = {}) {
+  const text = JSON.stringify(body);
+  const headerMap = new Map();
+  for (const [key, value] of Object.entries(headers)) {
+    headerMap.set(String(key).toLowerCase(), value);
+  }
+  return {
+    ok,
+    status,
+    headers: {
+      get(name) {
+        return headerMap.get(String(name || '').toLowerCase()) ?? null;
+      },
+    },
+    async text() {
+      return text;
+    },
+  };
+}
+
+test('createStorefrontCartServer requests checkoutUrl', async () => {
+  const prevEnv = {
+    SHOPIFY_STOREFRONT_TOKEN: process.env.SHOPIFY_STOREFRONT_TOKEN,
+    SHOPIFY_STOREFRONT_DOMAIN: process.env.SHOPIFY_STOREFRONT_DOMAIN,
+    SHOPIFY_STORE_DOMAIN: process.env.SHOPIFY_STORE_DOMAIN,
+  };
+  process.env.SHOPIFY_STOREFRONT_TOKEN = 'test-token';
+  process.env.SHOPIFY_STOREFRONT_DOMAIN = 'https://store.example';
+  process.env.SHOPIFY_STORE_DOMAIN = 'store.example';
+
+  const calls = [];
+  const fetchStub = mock.method(global, 'fetch', async (url, init) => {
+    calls.push({ url, init });
+    return createResponse(
+      {
+        data: {
+          cartCreate: {
+            cart: {
+              id: 'gid://shopify/Cart/test-cart',
+              checkoutUrl: 'https://store.example/checkout/test-cart',
+            },
+            userErrors: [],
+          },
+        },
+      },
+      { headers: { 'content-type': 'application/json' } },
+    );
+  });
+
+  try {
+    const result = await createStorefrontCartServer({
+      variantGid: 'gid://shopify/ProductVariant/123456789',
+      quantity: 1,
+      buyerIp: '1.2.3.4',
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.checkoutUrl, 'https://store.example/checkout/test-cart');
+    assert.equal(result.cartUrl, 'https://store.example/cart/c/test-cart');
+    assert.equal(calls.length, 1);
+    const [{ init }] = calls;
+    const payload = JSON.parse(init.body);
+    assert.match(payload.query, /checkoutUrl/);
+    assert.doesNotMatch(payload.query, /webUrl/);
+    assert.equal(payload.variables.lines[0].merchandiseId, 'gid://shopify/ProductVariant/123456789');
+  } finally {
+    fetchStub.mock.restore();
+    if (prevEnv.SHOPIFY_STOREFRONT_TOKEN === undefined) {
+      delete process.env.SHOPIFY_STOREFRONT_TOKEN;
+    } else {
+      process.env.SHOPIFY_STOREFRONT_TOKEN = prevEnv.SHOPIFY_STOREFRONT_TOKEN;
+    }
+    if (prevEnv.SHOPIFY_STOREFRONT_DOMAIN === undefined) {
+      delete process.env.SHOPIFY_STOREFRONT_DOMAIN;
+    } else {
+      process.env.SHOPIFY_STOREFRONT_DOMAIN = prevEnv.SHOPIFY_STOREFRONT_DOMAIN;
+    }
+    if (prevEnv.SHOPIFY_STORE_DOMAIN === undefined) {
+      delete process.env.SHOPIFY_STORE_DOMAIN;
+    } else {
+      process.env.SHOPIFY_STORE_DOMAIN = prevEnv.SHOPIFY_STORE_DOMAIN;
+    }
+  }
+});
+
+test('fallbackCartAdd posts JSON items payload and returns cart url on success', async () => {
+  const fetchCalls = [];
+  const fetchStub = mock.method(global, 'fetch', async (url, init) => {
+    fetchCalls.push({ url, init });
+    return createResponse(
+      {
+        token: 'abcdef',
+      },
+      { headers: { 'content-type': 'application/json' } },
+    );
+  });
+
+  try {
+    const jar = new SimpleCookieJar();
+    const result = await fallbackCartAdd({ variantNumericId: '987654321', quantity: 2, jar });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.cartUrl, 'https://www.mgmgamers.store/cart/c/abcdef');
+    assert.equal(fetchCalls.length, 1);
+    const { init } = fetchCalls[0];
+    assert.equal(init.method, 'POST');
+    assert.equal(init.headers['Content-Type'], 'application/json');
+    const parsed = JSON.parse(init.body);
+    assert(Array.isArray(parsed.items));
+    assert.equal(parsed.items[0].id, 987654321);
+    assert.equal(parsed.items[0].quantity, 2);
+    assert.deepEqual(parsed.items[0].properties, {});
+  } finally {
+    fetchStub.mock.restore();
+  }
+});
+
+test('fallbackCartAdd surfaces detail when Shopify AJAX cart fails', async () => {
+  const fetchStub = mock.method(global, 'fetch', async () =>
+    createResponse(
+      {
+        status: 422,
+        description: 'Variant unavailable',
+      },
+      { status: 422, ok: false, headers: { 'content-type': 'application/json' } },
+    ),
+  );
+
+  try {
+    const result = await fallbackCartAdd({ variantNumericId: '123456789', quantity: 1 });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'ajax_cart_failed');
+    assert.equal(result.status, 422);
+    assert.match(result.detail, /Variant unavailable/);
+  } finally {
+    fetchStub.mock.restore();
+  }
+});


### PR DESCRIPTION
## Summary
- ensure the Storefront cart mutations request checkoutUrl and adjust the React cart flow to consume it
- fix the legacy AJAX fallback to POST the documented items payload and improve error logging
- add regression tests covering the Storefront mutation, fallback success, and fallback failure paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68dadd6ba87083279f3a42ed96615b1a