### PR TITLE
Improve Shopify cart resilience for delayed variants

### DIFF
--- a/lib/handlers/cartStart.js
+++ b/lib/handlers/cartStart.js
@@ -4,6 +4,7 @@ import {
   createStorefrontCartServer,
   fallbackCartAdd,
   SimpleCookieJar,
+  waitForVariantAvailability,
 } from '../shopify/storefrontCartServer.js';
 
 const BodySchema = z
@@ -51,14 +52,49 @@ function respond(res, status, payload, logLabel = 'cart_start_response') {
   } catch {}
 }
 
+function hasVariantInvalidUserError(result) {
+  if (!result || result.reason !== 'user_errors') return false;
+  if (!Array.isArray(result.userErrors)) return false;
+  return result.userErrors.some((err) => {
+    if (!err || typeof err !== 'object') return false;
+    const message = typeof err.message === 'string' ? err.message : '';
+    const code = typeof err.code === 'string' ? err.code : '';
+    if (code && code.toUpperCase() === 'INVALID') return true;
+    if (message && /does not exist/i.test(message)) return true;
+    if (message && /no existe/i.test(message)) return true;
+    return false;
+  });
+}
+
 async function attemptStorefrontCreate({ variantGid, quantity, buyerIp, attempts = 2 }) {
   let lastError = null;
+  let availabilityChecked = false;
   for (let i = 0; i < attempts; i += 1) {
     const result = await createStorefrontCartServer({ variantGid, quantity, buyerIp });
     if (result.ok) {
       return result;
     }
     lastError = result;
+    if (!availabilityChecked && hasVariantInvalidUserError(result)) {
+      availabilityChecked = true;
+      const availability = await waitForVariantAvailability({
+        variantGid,
+        buyerIp,
+        attempts: 5,
+        delayMs: 2000,
+      });
+      if (!availability.ok) {
+        return {
+          ok: false,
+          reason: availability.reason || 'variant_not_ready',
+          availability,
+          userErrors: result.userErrors,
+          requestId: result.requestId,
+        };
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      continue;
+    }
     if (result.reason === 'user_errors' || result.reason === 'http_error' || result.reason === 'graphql_errors') {
       await new Promise((resolve) => setTimeout(resolve, 200));
       continue;

--- a/lib/shopify/storefrontCartServer.js
+++ b/lib/shopify/storefrontCartServer.js
@@ -37,6 +37,15 @@ const CART_LINES_ADD_MUTATION = `
   }
 `;
 
+const VARIANT_AVAILABILITY_QUERY = `
+  query VariantAvailability($id: ID!) {
+    productVariant(id: $id) {
+      id
+      availableForSale
+    }
+  }
+`;
+
 function buildFallbackPermalink(variantNumericId, quantity) {
   const id = variantNumericId ? String(variantNumericId).trim() : '';
   if (!id) return FALLBACK_CART_URL;
@@ -192,6 +201,69 @@ async function executeStorefrontMutation(query, variables, { buyerIp } = {}) {
   return { ok: true, json, requestId };
 }
 
+function buildVariantAvailabilitySummary(variant) {
+  if (!variant || typeof variant !== 'object') {
+    return { exists: false };
+  }
+  return {
+    exists: true,
+    availableForSale: Boolean(variant.availableForSale),
+  };
+}
+
+async function wait(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function waitForVariantAvailability({
+  variantGid,
+  buyerIp,
+  attempts = 5,
+  delayMs = 2000,
+} = {}) {
+  if (!variantGid) {
+    return { ok: false, reason: 'missing_variant_gid' };
+  }
+  let lastSummary = null;
+  let lastError = null;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const result = await executeStorefrontMutation(
+      VARIANT_AVAILABILITY_QUERY,
+      { id: variantGid },
+      buyerIp ? { buyerIp } : {},
+    );
+    if (!result.ok) {
+      if (result.reason === 'storefront_env_missing') {
+        return result;
+      }
+      lastError = result;
+    } else {
+      const variant = result.json?.data?.productVariant;
+      const summary = buildVariantAvailabilitySummary(variant);
+      lastSummary = summary;
+      if (summary.exists && summary.availableForSale) {
+        return {
+          ok: true,
+          attempts: attempt + 1,
+          availability: summary,
+          requestId: result.requestId,
+        };
+      }
+    }
+    if (attempt < attempts - 1) {
+      await wait(delayMs);
+    }
+  }
+  return {
+    ok: false,
+    reason: 'variant_not_ready',
+    attempts,
+    availability: lastSummary || undefined,
+    lastError: lastError || undefined,
+  };
+}
+
 function normalizeUserErrors(rawErrors) {
   if (!Array.isArray(rawErrors)) return [];
   return rawErrors
@@ -298,9 +370,15 @@ export async function fallbackCartAdd({ variantNumericId, quantity, jar = new Si
   }
   const qty = Number.isFinite(quantity) && quantity > 0 ? Math.max(1, Math.floor(quantity)) : 1;
   const cartPermalink = buildFallbackPermalink(normalizedId, qty);
+  const itemId = Number.isFinite(Number(normalizedId)) ? Number(normalizedId) : normalizedId;
   const payload = {
-    id: Number.isFinite(Number(normalizedId)) ? Number(normalizedId) : normalizedId,
-    quantity: qty,
+    items: [
+      {
+        id: itemId,
+        quantity: qty,
+        properties: {},
+      },
+    ],
   };
   const headers = {
     'Content-Type': 'application/json',
@@ -335,24 +413,55 @@ export async function fallbackCartAdd({ variantNumericId, quantity, jar = new Si
     }
   }
   if (!resp.ok) {
+    const detail = json ? JSON.stringify(json).slice(0, 2000) : text ? text.slice(0, 2000) : '';
     try {
       console.error('[storefront_cart] ajax_cart_http_error', {
         status: resp.status,
         contentType,
         bodyPreview: text ? text.slice(0, 200) : '',
         payload,
+        detail,
       });
     } catch {}
     return {
       ok: false,
       reason: 'ajax_cart_failed',
       status: resp.status,
-      detail: json ? JSON.stringify(json).slice(0, 2000) : text ? text.slice(0, 2000) : '',
+      detail,
     };
   }
   const token = typeof json?.token === 'string' ? json.token.trim() : '';
-  const cartUrl = token ? `${DEFAULT_CART_ORIGIN}/cart/c/${token}` : cartPermalink || FALLBACK_CART_URL;
+  const items = Array.isArray(json?.items) ? json.items : [];
+  const matchedItem = items.find((item) => {
+    if (!item || typeof item !== 'object') return false;
+    const variantId =
+      item.variant_id !== undefined
+        ? String(item.variant_id)
+        : item.id !== undefined
+          ? String(item.id)
+          : '';
+    return variantId && variantId === String(itemId);
+  });
   const detail = json ? JSON.stringify(json).slice(0, 2000) : text ? text.slice(0, 2000) : '';
+  if (!token || !matchedItem) {
+    try {
+      console.error('[storefront_cart] ajax_cart_silent_failure', {
+        status: resp.status,
+        contentType,
+        payload,
+        detail,
+        hasToken: Boolean(token),
+        matchedItem: Boolean(matchedItem),
+      });
+    } catch {}
+    return {
+      ok: false,
+      reason: 'ajax_cart_silent_failure',
+      detail,
+      status: resp.status,
+    };
+  }
+  const cartUrl = `${DEFAULT_CART_ORIGIN}/cart/c/${token}`;
   try {
     console.info('[storefront_cart] ajax_cart_success', {
       status: resp.status,

--- a/mgm-front/src/lib/pollJobAndCreateCart.ts
+++ b/mgm-front/src/lib/pollJobAndCreateCart.ts
@@ -76,8 +76,8 @@ export async function pollJobAndCreateCart(
             ? j.cartPlain.trim()
             : typeof j?.url === "string" && j.url.trim()
               ? j.url.trim()
-              : typeof j?.webUrl === "string" && j.webUrl.trim()
-                ? j.webUrl.trim()
+              : typeof j?.checkoutUrl === "string" && j.checkoutUrl.trim()
+                ? j.checkoutUrl.trim()
                 : null;
       if (!res.ok || !cartUrl) {
         // Si falta algo, seguir esperando si hay intentos restantes

--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -942,7 +942,7 @@ interface StorefrontCartUserError {
 }
 
 interface StorefrontCartPayload {
-  cart?: { id?: string | null; webUrl?: string | null } | null;
+  cart?: { id?: string | null; checkoutUrl?: string | null } | null;
   userErrors?: StorefrontCartUserError[] | null;
 }
 
@@ -993,14 +993,14 @@ async function performStorefrontCartMutation(
 
 const CART_CREATE_MUTATION = `mutation CartCreate($lines: [CartLineInput!]!, $discountCodes: [String!]) {
   cartCreate(input: { lines: $lines, discountCodes: $discountCodes }) {
-    cart { id webUrl }
+    cart { id checkoutUrl }
     userErrors { message code field }
   }
 }`;
 
 const CART_LINES_ADD_MUTATION = `mutation CartLinesAdd($cartId: ID!, $lines: [CartLineInput!]!) {
   cartLinesAdd(cartId: $cartId, lines: $lines) {
-    cart { id webUrl }
+    cart { id checkoutUrl }
     userErrors { message code field }
   }
 }`;
@@ -1017,7 +1017,7 @@ const VARIANT_AVAILABILITY_QUERY = `query WaitVariant($id: ID!) {
 
 export interface StorefrontCartSuccess {
   cartId: string;
-  webUrl: string;
+  checkoutUrl: string;
 }
 
 export async function addVariantToCartStorefront(
@@ -1113,15 +1113,15 @@ export async function addVariantToCartStorefront(
     const userErrors = extractUserErrors(data);
     const payloadErrors = Array.isArray(payload?.errors) ? payload.errors.filter(Boolean) : [];
     const resolvedCartId = data?.cart?.id ? String(data.cart.id) : cartId;
-    const resolvedWebUrl = data?.cart?.webUrl ? String(data.cart.webUrl) : '';
-    if (response.ok && !payloadErrors.length && !userErrors.length && resolvedCartId && resolvedWebUrl) {
+    const resolvedCheckoutUrl = data?.cart?.checkoutUrl ? String(data.cart.checkoutUrl) : '';
+    if (response.ok && !payloadErrors.length && !userErrors.length && resolvedCartId && resolvedCheckoutUrl) {
       setStoredCartId(resolvedCartId);
       try {
-        console.info('[cart-flow] cart_lines_add_ok', { cartId: resolvedCartId, webUrl: resolvedWebUrl });
+        console.info('[cart-flow] cart_lines_add_ok', { cartId: resolvedCartId, checkoutUrl: resolvedCheckoutUrl });
       } catch (logErr) {
         console.warn?.('[cart-flow] cart_lines_add_log_failed', logErr);
       }
-      return { ok: true, value: { cartId: resolvedCartId, webUrl: resolvedWebUrl } };
+      return { ok: true, value: { cartId: resolvedCartId, checkoutUrl: resolvedCheckoutUrl } };
     }
 
     try {
@@ -1157,15 +1157,15 @@ export async function addVariantToCartStorefront(
     const userErrors = extractUserErrors(data);
     const payloadErrors = Array.isArray(payload?.errors) ? payload.errors.filter(Boolean) : [];
     const createdCartId = data?.cart?.id ? String(data.cart.id) : '';
-    const createdWebUrl = data?.cart?.webUrl ? String(data.cart.webUrl) : '';
-    if (response.ok && !payloadErrors.length && !userErrors.length && createdCartId && createdWebUrl) {
+    const createdCheckoutUrl = data?.cart?.checkoutUrl ? String(data.cart.checkoutUrl) : '';
+    if (response.ok && !payloadErrors.length && !userErrors.length && createdCartId && createdCheckoutUrl) {
       setStoredCartId(createdCartId);
       try {
-        console.info('[cart-flow] cart_create_ok', { cartId: createdCartId, webUrl: createdWebUrl });
+        console.info('[cart-flow] cart_create_ok', { cartId: createdCartId, checkoutUrl: createdCheckoutUrl });
       } catch (logErr) {
         console.warn?.('[cart-flow] cart_create_log_failed', logErr);
       }
-      return { ok: true, value: { cartId: createdCartId, webUrl: createdWebUrl } };
+      return { ok: true, value: { cartId: createdCartId, checkoutUrl: createdCheckoutUrl } };
     }
 
     try {

--- a/mgm-front/src/pages/Creating.jsx
+++ b/mgm-front/src/pages/Creating.jsx
@@ -57,7 +57,7 @@ export default function Creating() {
           (typeof res?.raw?.cartUrl === "string" && res.raw.cartUrl.trim())
             || (typeof res?.raw?.cartPlain === "string" && res.raw.cartPlain.trim())
             || (typeof res?.raw?.url === "string" && res.raw.url.trim())
-            || (typeof res?.raw?.webUrl === "string" && res.raw.webUrl.trim())
+            || (typeof res?.raw?.checkoutUrl === "string" && res.raw.checkoutUrl.trim())
             || null;
         const cartPlainCandidate =
           (typeof res?.raw?.cartPlain === "string" && res.raw.cartPlain.trim())

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -349,7 +349,7 @@ export default function Mockup() {
     const useFallback = Boolean(options.useFallback);
     let link = url;
     if (!link) {
-      link = useFallback ? cart.fallbackUrl : cart.webUrl;
+      link = useFallback ? cart.fallbackUrl : cart.cartUrl;
     }
     if (!link) return;
     const fallbackUrl = useFallback
@@ -572,7 +572,10 @@ export default function Mockup() {
           variantIdNumeric: variantNumericId,
           variantIdGid: variantGidForCart,
           ...(normalizedResponseUrl ? { url: normalizedResponseUrl } : {}),
-          ...(normalizedCartUrlFromServer ? { webUrl: normalizedCartUrlFromServer } : {}),
+          ...(normalizedCartUrlFromServer ? { cartUrl: normalizedCartUrlFromServer } : {}),
+          ...(typeof json?.checkoutUrl === 'string' && json.checkoutUrl.trim()
+            ? { checkoutUrl: json.checkoutUrl.trim() }
+            : {}),
           ...(json?.cartPlain ? { cartPlain: json.cartPlain } : {}),
           ...(json?.cartId ? { cartId: json.cartId } : {}),
           ...(fallbackProductUrl ? { fallbackUrl: fallbackProductUrl } : {}),

--- a/mgm-front/src/pages/Result.jsx
+++ b/mgm-front/src/pages/Result.jsx
@@ -74,7 +74,7 @@ export default function Result() {
           normalize(j?.cartUrl)
             || normalize(j?.cartPlain)
             || normalize(j?.url)
-            || normalize(j?.webUrl);
+            || normalize(j?.checkoutUrl);
 
         if (res.ok && cartUrl && !cancelled) {
           setUrls({

--- a/tests/storefront-cart-server.test.js
+++ b/tests/storefront-cart-server.test.js
@@ -1,0 +1,274 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createStorefrontCartServer,
+  fallbackCartAdd,
+  SimpleCookieJar,
+  waitForVariantAvailability,
+} from '../lib/shopify/storefrontCartServer.js';
+
+function createResponse(body, { status = 200, ok = true, headers = {} } = {}) {
+  const text = JSON.stringify(body);
+  const headerMap = new Map();
+  for (const [key, value] of Object.entries(headers)) {
+    headerMap.set(String(key).toLowerCase(), value);
+  }
+  return {
+    ok,
+    status,
+    headers: {
+      get(name) {
+        return headerMap.get(String(name || '').toLowerCase()) ?? null;
+      },
+    },
+    async text() {
+      return text;
+    },
+  };
+}
+
+test('createStorefrontCartServer requests checkoutUrl', async () => {
+  const prevEnv = {
+    SHOPIFY_STOREFRONT_TOKEN: process.env.SHOPIFY_STOREFRONT_TOKEN,
+    SHOPIFY_STOREFRONT_DOMAIN: process.env.SHOPIFY_STOREFRONT_DOMAIN,
+    SHOPIFY_STORE_DOMAIN: process.env.SHOPIFY_STORE_DOMAIN,
+  };
+  process.env.SHOPIFY_STOREFRONT_TOKEN = 'test-token';
+  process.env.SHOPIFY_STOREFRONT_DOMAIN = 'https://store.example';
+  process.env.SHOPIFY_STORE_DOMAIN = 'store.example';
+
+  const calls = [];
+  const fetchStub = mock.method(global, 'fetch', async (url, init) => {
+    calls.push({ url, init });
+    return createResponse(
+      {
+        data: {
+          cartCreate: {
+            cart: {
+              id: 'gid://shopify/Cart/test-cart',
+              checkoutUrl: 'https://store.example/checkout/test-cart',
+            },
+            userErrors: [],
+          },
+        },
+      },
+      { headers: { 'content-type': 'application/json' } },
+    );
+  });
+
+  try {
+    const result = await createStorefrontCartServer({
+      variantGid: 'gid://shopify/ProductVariant/123456789',
+      quantity: 1,
+      buyerIp: '1.2.3.4',
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.checkoutUrl, 'https://store.example/checkout/test-cart');
+    assert.equal(result.cartUrl, 'https://store.example/cart/c/test-cart');
+    assert.equal(calls.length, 1);
+    const [{ init }] = calls;
+    const payload = JSON.parse(init.body);
+    assert.match(payload.query, /checkoutUrl/);
+    assert.doesNotMatch(payload.query, /webUrl/);
+    assert.equal(payload.variables.lines[0].merchandiseId, 'gid://shopify/ProductVariant/123456789');
+  } finally {
+    fetchStub.mock.restore();
+    if (prevEnv.SHOPIFY_STOREFRONT_TOKEN === undefined) {
+      delete process.env.SHOPIFY_STOREFRONT_TOKEN;
+    } else {
+      process.env.SHOPIFY_STOREFRONT_TOKEN = prevEnv.SHOPIFY_STOREFRONT_TOKEN;
+    }
+    if (prevEnv.SHOPIFY_STOREFRONT_DOMAIN === undefined) {
+      delete process.env.SHOPIFY_STOREFRONT_DOMAIN;
+    } else {
+      process.env.SHOPIFY_STOREFRONT_DOMAIN = prevEnv.SHOPIFY_STOREFRONT_DOMAIN;
+    }
+    if (prevEnv.SHOPIFY_STORE_DOMAIN === undefined) {
+      delete process.env.SHOPIFY_STORE_DOMAIN;
+    } else {
+      process.env.SHOPIFY_STORE_DOMAIN = prevEnv.SHOPIFY_STORE_DOMAIN;
+    }
+  }
+});
+
+test('fallbackCartAdd posts JSON items payload and returns cart url on success', async () => {
+  const fetchCalls = [];
+  const fetchStub = mock.method(global, 'fetch', async (url, init) => {
+    fetchCalls.push({ url, init });
+    return createResponse(
+      {
+        token: 'abcdef',
+        items: [
+          {
+            id: 987654321,
+            variant_id: 987654321,
+            quantity: 2,
+          },
+        ],
+      },
+      { headers: { 'content-type': 'application/json' } },
+    );
+  });
+
+  try {
+    const jar = new SimpleCookieJar();
+    const result = await fallbackCartAdd({ variantNumericId: '987654321', quantity: 2, jar });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.cartUrl, 'https://www.mgmgamers.store/cart/c/abcdef');
+    assert.equal(fetchCalls.length, 1);
+    const { init } = fetchCalls[0];
+    assert.equal(init.method, 'POST');
+    assert.equal(init.headers['Content-Type'], 'application/json');
+    const parsed = JSON.parse(init.body);
+    assert(Array.isArray(parsed.items));
+    assert.equal(parsed.items[0].id, 987654321);
+    assert.equal(parsed.items[0].quantity, 2);
+    assert.deepEqual(parsed.items[0].properties, {});
+  } finally {
+    fetchStub.mock.restore();
+  }
+});
+
+test('fallbackCartAdd surfaces detail when Shopify AJAX cart fails', async () => {
+  const fetchStub = mock.method(global, 'fetch', async () =>
+    createResponse(
+      {
+        status: 422,
+        description: 'Variant unavailable',
+      },
+      { status: 422, ok: false, headers: { 'content-type': 'application/json' } },
+    ),
+  );
+
+  try {
+    const result = await fallbackCartAdd({ variantNumericId: '123456789', quantity: 1 });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'ajax_cart_failed');
+    assert.equal(result.status, 422);
+    assert.match(result.detail, /Variant unavailable/);
+  } finally {
+    fetchStub.mock.restore();
+  }
+});
+
+test('fallbackCartAdd fails when Shopify returns 200 without matching item', async () => {
+  const fetchStub = mock.method(global, 'fetch', async () =>
+    createResponse(
+      {
+        token: '',
+        items: [],
+      },
+      { headers: { 'content-type': 'application/json' } },
+    ),
+  );
+
+  try {
+    const result = await fallbackCartAdd({ variantNumericId: '123456789', quantity: 1 });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'ajax_cart_silent_failure');
+    assert.match(result.detail, /"items":\[]/);
+  } finally {
+    fetchStub.mock.restore();
+  }
+});
+
+test('waitForVariantAvailability resolves once the variant is available', async () => {
+  const prevEnv = {
+    SHOPIFY_STOREFRONT_TOKEN: process.env.SHOPIFY_STOREFRONT_TOKEN,
+    SHOPIFY_STOREFRONT_DOMAIN: process.env.SHOPIFY_STOREFRONT_DOMAIN,
+    SHOPIFY_STORE_DOMAIN: process.env.SHOPIFY_STORE_DOMAIN,
+  };
+  process.env.SHOPIFY_STOREFRONT_TOKEN = 'test-token';
+  process.env.SHOPIFY_STOREFRONT_DOMAIN = 'https://store.example';
+  process.env.SHOPIFY_STORE_DOMAIN = 'store.example';
+
+  const responses = [
+    { data: { productVariant: { id: 'gid://shopify/ProductVariant/1', availableForSale: false } } },
+    { data: { productVariant: { id: 'gid://shopify/ProductVariant/1', availableForSale: true } } },
+  ];
+
+  const fetchStub = mock.method(global, 'fetch', async () =>
+    createResponse(responses.shift() ?? responses[responses.length - 1], {
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+
+  try {
+    const result = await waitForVariantAvailability({
+      variantGid: 'gid://shopify/ProductVariant/1',
+      attempts: 3,
+      delayMs: 1,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.attempts, 2);
+  } finally {
+    fetchStub.mock.restore();
+    if (prevEnv.SHOPIFY_STOREFRONT_TOKEN === undefined) {
+      delete process.env.SHOPIFY_STOREFRONT_TOKEN;
+    } else {
+      process.env.SHOPIFY_STOREFRONT_TOKEN = prevEnv.SHOPIFY_STOREFRONT_TOKEN;
+    }
+    if (prevEnv.SHOPIFY_STOREFRONT_DOMAIN === undefined) {
+      delete process.env.SHOPIFY_STOREFRONT_DOMAIN;
+    } else {
+      process.env.SHOPIFY_STOREFRONT_DOMAIN = prevEnv.SHOPIFY_STOREFRONT_DOMAIN;
+    }
+    if (prevEnv.SHOPIFY_STORE_DOMAIN === undefined) {
+      delete process.env.SHOPIFY_STORE_DOMAIN;
+    } else {
+      process.env.SHOPIFY_STORE_DOMAIN = prevEnv.SHOPIFY_STORE_DOMAIN;
+    }
+  }
+});
+
+test('waitForVariantAvailability times out when variant never appears', async () => {
+  const prevEnv = {
+    SHOPIFY_STOREFRONT_TOKEN: process.env.SHOPIFY_STOREFRONT_TOKEN,
+    SHOPIFY_STOREFRONT_DOMAIN: process.env.SHOPIFY_STOREFRONT_DOMAIN,
+    SHOPIFY_STORE_DOMAIN: process.env.SHOPIFY_STORE_DOMAIN,
+  };
+  process.env.SHOPIFY_STOREFRONT_TOKEN = 'test-token';
+  process.env.SHOPIFY_STOREFRONT_DOMAIN = 'https://store.example';
+  process.env.SHOPIFY_STORE_DOMAIN = 'store.example';
+
+  const fetchStub = mock.method(global, 'fetch', async () =>
+    createResponse(
+      { data: { productVariant: null } },
+      { headers: { 'content-type': 'application/json' } },
+    ),
+  );
+
+  try {
+    const result = await waitForVariantAvailability({
+      variantGid: 'gid://shopify/ProductVariant/2',
+      attempts: 2,
+      delayMs: 1,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'variant_not_ready');
+    assert.equal(result.attempts, 2);
+  } finally {
+    fetchStub.mock.restore();
+    if (prevEnv.SHOPIFY_STOREFRONT_TOKEN === undefined) {
+      delete process.env.SHOPIFY_STOREFRONT_TOKEN;
+    } else {
+      process.env.SHOPIFY_STOREFRONT_TOKEN = prevEnv.SHOPIFY_STOREFRONT_TOKEN;
+    }
+    if (prevEnv.SHOPIFY_STOREFRONT_DOMAIN === undefined) {
+      delete process.env.SHOPIFY_STOREFRONT_DOMAIN;
+    } else {
+      process.env.SHOPIFY_STOREFRONT_DOMAIN = prevEnv.SHOPIFY_STOREFRONT_DOMAIN;
+    }
+    if (prevEnv.SHOPIFY_STORE_DOMAIN === undefined) {
+      delete process.env.SHOPIFY_STORE_DOMAIN;
+    } else {
+      process.env.SHOPIFY_STORE_DOMAIN = prevEnv.SHOPIFY_STORE_DOMAIN;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add Storefront variant availability polling and hook cart start into it when Shopify reports INVALID merchandise errors
- tighten the AJAX fallback by verifying the returned token/items and surfacing silent failures
- cover the new availability polling and fallback behaviors with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68dadd6ba87083279f3a42ed96615b1a