### PR TITLE
Adjust cart start flow to wait for variant availability

### DIFF
--- a/lib/handlers/cartStart.js
+++ b/lib/handlers/cartStart.js
@@ -66,23 +66,64 @@ function hasVariantInvalidUserError(result) {
   });
 }
 
-async function attemptStorefrontCreate({ variantGid, quantity, buyerIp, attempts = 2 }) {
+async function attemptStorefrontCreate({
+  variantGid,
+  quantity,
+  buyerIp,
+  attempts = 2,
+  availabilityPrecheck = null,
+}) {
   let lastError = null;
-  let availabilityChecked = false;
+  let availabilityChecked = Boolean(availabilityPrecheck?.ok);
+  let availabilitySummary = availabilityPrecheck?.availability || null;
+  let availabilityRequestId = availabilityPrecheck?.requestId || null;
   for (let i = 0; i < attempts; i += 1) {
+    const attemptNumber = i + 1;
+    try {
+      console.info('cart_start_storefront_attempt', {
+        attempt: attemptNumber,
+        variantGid,
+        quantity,
+        prechecked: availabilityChecked,
+      });
+    } catch {}
     const result = await createStorefrontCartServer({ variantGid, quantity, buyerIp });
     if (result.ok) {
-      return result;
+      return {
+        ...result,
+        attempts: attemptNumber,
+        availability: availabilitySummary || undefined,
+        availabilityRequestId: availabilityRequestId || undefined,
+      };
     }
-    lastError = result;
+    lastError = {
+      ...result,
+      attempts: attemptNumber,
+      availability: availabilitySummary || undefined,
+      availabilityRequestId: availabilityRequestId || undefined,
+    };
     if (!availabilityChecked && hasVariantInvalidUserError(result)) {
       availabilityChecked = true;
       const availability = await waitForVariantAvailability({
         variantGid,
         buyerIp,
-        attempts: 5,
+        attempts: 12,
         delayMs: 2000,
+        initialDelayMs: 500,
       });
+      availabilitySummary = availability?.availability || availabilitySummary;
+      if (availability?.requestId) {
+        availabilityRequestId = availability.requestId;
+      }
+      if (availability?.ok) {
+        try {
+          console.info('cart_start_variant_ready_after_retry', {
+            attempts: availability.attempts,
+            requestId: availability.requestId || null,
+            productHandle: availability?.availability?.productHandle || null,
+          });
+        } catch {}
+      }
       if (!availability.ok) {
         return {
           ok: false,
@@ -90,6 +131,7 @@ async function attemptStorefrontCreate({ variantGid, quantity, buyerIp, attempts
           availability,
           userErrors: result.userErrors,
           requestId: result.requestId,
+          attempts: attemptNumber,
         };
       }
       await new Promise((resolve) => setTimeout(resolve, 200));
@@ -136,10 +178,62 @@ export default async function cartStart(req, res) {
   const buyerIp = getClientIp(req);
   const variantNumericId = variantGid.split('/').pop();
 
+  try {
+    console.info('cart_start_variant_check_begin', {
+      variantGid,
+      variantNumericId,
+      quantity: normalizedQuantity,
+    });
+  } catch {}
+
+  let availabilityPrecheck = null;
+  try {
+    availabilityPrecheck = await waitForVariantAvailability({
+      variantGid,
+      buyerIp,
+      attempts: 15,
+      delayMs: 2000,
+      initialDelayMs: 250,
+    });
+  } catch (pollErr) {
+    availabilityPrecheck = null;
+    try {
+      console.error('cart_start_variant_poll_error', pollErr);
+    } catch {}
+  }
+
+  let variantReady = Boolean(availabilityPrecheck?.ok);
+  let availabilitySummary = availabilityPrecheck?.availability || null;
+  let availabilityRequestId = availabilityPrecheck?.requestId || null;
+  const availabilityReason = availabilityPrecheck?.reason || null;
+  const availabilityAttempts = availabilityPrecheck?.attempts || null;
+
+  if (availabilityPrecheck?.ok) {
+    try {
+      console.info('cart_start_variant_ready', {
+        attempts: availabilityAttempts,
+        requestId: availabilityRequestId || null,
+        productHandle: availabilitySummary?.productHandle || null,
+        productUrl: availabilitySummary?.productOnlineStoreUrl || null,
+      });
+    } catch {}
+  } else if (availabilityPrecheck) {
+    try {
+      console.warn('cart_start_variant_pending', {
+        reason: availabilityReason || 'variant_not_ready',
+        attempts: availabilityAttempts,
+        requestId: availabilityRequestId || null,
+        productHandle: availabilitySummary?.productHandle || null,
+      });
+    } catch {}
+  }
+
   const storefrontResult = await attemptStorefrontCreate({
     variantGid,
     quantity: normalizedQuantity,
     buyerIp,
+    attempts: variantReady ? 2 : 3,
+    availabilityPrecheck,
   });
 
   if (storefrontResult?.ok) {
@@ -149,21 +243,51 @@ export default async function cartStart(req, res) {
     const checkoutUrl = typeof storefrontResult.checkoutUrl === 'string'
       ? storefrontResult.checkoutUrl.trim()
       : '';
-    const finalUrl = storefrontCartUrl || buildCartPermalink(variantNumericId, normalizedQuantity);
-    console.info('cart_start_return_storefront', { url: finalUrl, storefrontCartUrl, checkoutUrl });
+    if (!variantReady) {
+      variantReady = true;
+    }
+    if (!availabilitySummary && storefrontResult.availability) {
+      availabilitySummary = storefrontResult.availability;
+    }
+    if (!availabilityRequestId && storefrontResult.availabilityRequestId) {
+      availabilityRequestId = storefrontResult.availabilityRequestId;
+    }
+    const publicPermalink = buildCartPermalink(variantNumericId, normalizedQuantity);
+    const finalUrl = variantReady ? publicPermalink : storefrontCartUrl || publicPermalink;
+    try {
+      console.info('cart_start_return_storefront', {
+        url: finalUrl,
+        storefrontCartUrl,
+        checkoutUrl,
+        publicCartUrl: publicPermalink || null,
+        variantReady,
+        requestId: storefrontResult.requestId || availabilityRequestId || null,
+      });
+    } catch {}
     return respond(res, 200, {
       ok: true,
       url: finalUrl,
       cartId: storefrontResult.cartId || undefined,
-      cartUrl: storefrontCartUrl || undefined,
-      cartPlain: storefrontResult.cartPlain || undefined,
+      cartUrl: finalUrl || undefined,
+      cartPlain: storefrontResult.cartPlain || `${CART_ORIGIN}/cart`,
       cartToken: storefrontResult.cartToken || undefined,
       cartWebUrl: finalUrl || undefined,
       checkoutUrl: checkoutUrl || undefined,
       checkoutPlain: storefrontResult.checkoutPlain || undefined,
       usedFallback: false,
-      requestId: storefrontResult.requestId || undefined,
+      requestId: storefrontResult.requestId || availabilityRequestId || undefined,
+      storefrontCartUrl: storefrontCartUrl || undefined,
+      publicCartUrl: publicPermalink || undefined,
+      availability: availabilitySummary || undefined,
+      variantReady: true,
     });
+  }
+
+  if (!availabilitySummary && storefrontResult?.availability) {
+    availabilitySummary = storefrontResult.availability;
+  }
+  if (!availabilityRequestId && storefrontResult?.availabilityRequestId) {
+    availabilityRequestId = storefrontResult.availabilityRequestId;
   }
 
   try {
@@ -181,7 +305,7 @@ export default async function cartStart(req, res) {
         : typeof storefrontResult?.detail === 'string' && storefrontResult.detail
           ? storefrontResult.detail
           : undefined,
-      requestId: storefrontResult?.requestId || undefined,
+      requestId: storefrontResult?.requestId || availabilityRequestId || undefined,
     });
   } catch {}
 
@@ -192,33 +316,88 @@ export default async function cartStart(req, res) {
     jar,
   });
   if (fallbackResult.ok) {
+    if (!variantReady) {
+      try {
+        console.info('cart_start_variant_verify_after_fallback', {
+          variantGid,
+          variantNumericId,
+        });
+      } catch {}
+    }
+    if (!variantReady) {
+      let fallbackAvailability = null;
+      try {
+        fallbackAvailability = await waitForVariantAvailability({
+          variantGid,
+          buyerIp,
+          attempts: 8,
+          delayMs: 2000,
+        });
+      } catch (fallbackPollErr) {
+        try {
+          console.error('cart_start_variant_verify_error', fallbackPollErr);
+        } catch {}
+      }
+      if (fallbackAvailability?.ok) {
+        variantReady = true;
+        availabilitySummary = fallbackAvailability.availability || availabilitySummary;
+        if (!availabilityRequestId && fallbackAvailability.requestId) {
+          availabilityRequestId = fallbackAvailability.requestId;
+        }
+        try {
+          console.info('cart_start_variant_ready_after_fallback', {
+            attempts: fallbackAvailability.attempts,
+            requestId: fallbackAvailability.requestId || null,
+            productHandle: fallbackAvailability?.availability?.productHandle || null,
+          });
+        } catch {}
+      } else if (fallbackAvailability) {
+        try {
+          console.warn('cart_start_variant_still_pending', {
+            reason: fallbackAvailability?.reason || 'variant_not_ready',
+            attempts: fallbackAvailability?.attempts || null,
+            requestId: fallbackAvailability?.requestId || null,
+          });
+        } catch {}
+      }
+    }
     const fallbackCartUrl = typeof fallbackResult.cartUrl === 'string'
       ? fallbackResult.cartUrl.trim()
       : '';
     const fallbackPlainUrl = typeof fallbackResult.fallbackCartUrl === 'string'
       ? fallbackResult.fallbackCartUrl.trim()
       : '';
-    const finalUrl = fallbackCartUrl
-      || fallbackPlainUrl
-      || buildCartPermalink(variantNumericId, normalizedQuantity);
-    console.info('cart_start_return_fallback', {
-      url: finalUrl,
-      fallbackCartUrl,
-      fallbackPlainUrl,
-      detailPreview: typeof fallbackResult?.detail === 'string'
-        ? fallbackResult.detail.slice(0, 200)
-        : undefined,
-    });
+    const publicPermalink = buildCartPermalink(variantNumericId, normalizedQuantity);
+    const finalUrl = variantReady
+      ? publicPermalink
+      : fallbackCartUrl || fallbackPlainUrl || publicPermalink;
+    try {
+      console.info('cart_start_return_fallback', {
+        url: finalUrl,
+        fallbackCartUrl,
+        fallbackPlainUrl,
+        publicCartUrl: publicPermalink || null,
+        variantReady,
+        requestId: storefrontResult?.requestId || availabilityRequestId || null,
+        detailPreview: typeof fallbackResult?.detail === 'string'
+          ? fallbackResult.detail.slice(0, 200)
+          : undefined,
+      });
+    } catch {}
     return respond(res, 200, {
       ok: true,
       url: finalUrl,
-      cartUrl: fallbackCartUrl || finalUrl || undefined,
+      cartUrl: finalUrl || undefined,
       cartWebUrl: finalUrl || undefined,
-      cartPlain: fallbackPlainUrl || undefined,
+      cartPlain: fallbackPlainUrl || `${CART_ORIGIN}/cart`,
       fallbackUrl: fallbackCartUrl || undefined,
       fallbackPlainUrl: fallbackPlainUrl || undefined,
       usedFallback: true,
-      requestId: storefrontResult?.requestId || undefined,
+      requestId: storefrontResult?.requestId || availabilityRequestId || undefined,
+      storefrontCartUrl: fallbackCartUrl || undefined,
+      publicCartUrl: publicPermalink || undefined,
+      availability: availabilitySummary || undefined,
+      variantReady: Boolean(variantReady),
       storefrontUserErrors: Array.isArray(storefrontResult?.userErrors) && storefrontResult.userErrors.length
         ? storefrontResult.userErrors
         : undefined,
@@ -230,6 +409,8 @@ export default async function cartStart(req, res) {
     quantity: normalizedQuantity,
     storefrontResult,
     fallbackResult,
+    availability: availabilitySummary || undefined,
+    requestId: storefrontResult?.requestId || availabilityRequestId || undefined,
   });
 
   return respond(res, 502, {
@@ -237,6 +418,7 @@ export default async function cartStart(req, res) {
     reason: fallbackResult.reason || storefrontResult?.reason || 'cart_start_failed',
     detail: fallbackResult.detail || storefrontResult?.detail || null,
     userErrors: storefrontResult?.userErrors || undefined,
-    requestId: storefrontResult?.requestId || undefined,
+    requestId: storefrontResult?.requestId || availabilityRequestId || undefined,
+    availability: availabilitySummary || undefined,
   });
 }

--- a/lib/shopify/storefrontCartServer.js
+++ b/lib/shopify/storefrontCartServer.js
@@ -42,6 +42,10 @@ const VARIANT_AVAILABILITY_QUERY = `
     productVariant(id: $id) {
       id
       availableForSale
+      product {
+        handle
+        onlineStoreUrl
+      }
     }
   }
 `;
@@ -205,9 +209,13 @@ function buildVariantAvailabilitySummary(variant) {
   if (!variant || typeof variant !== 'object') {
     return { exists: false };
   }
+  const product = variant.product && typeof variant.product === 'object' ? variant.product : null;
   return {
     exists: true,
     availableForSale: Boolean(variant.availableForSale),
+    variantId: typeof variant.id === 'string' ? variant.id : '',
+    productHandle: typeof product?.handle === 'string' ? product.handle : '',
+    productOnlineStoreUrl: typeof product?.onlineStoreUrl === 'string' ? product.onlineStoreUrl : '',
   };
 }
 
@@ -221,18 +229,26 @@ export async function waitForVariantAvailability({
   buyerIp,
   attempts = 5,
   delayMs = 2000,
+  initialDelayMs = 0,
 } = {}) {
   if (!variantGid) {
     return { ok: false, reason: 'missing_variant_gid' };
   }
   let lastSummary = null;
   let lastError = null;
+  let lastRequestId = null;
+  if (Number.isFinite(initialDelayMs) && initialDelayMs > 0) {
+    await wait(Math.max(0, Math.floor(initialDelayMs)));
+  }
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     const result = await executeStorefrontMutation(
       VARIANT_AVAILABILITY_QUERY,
       { id: variantGid },
       buyerIp ? { buyerIp } : {},
     );
+    if (result.requestId) {
+      lastRequestId = result.requestId;
+    }
     if (!result.ok) {
       if (result.reason === 'storefront_env_missing') {
         return result;
@@ -247,7 +263,7 @@ export async function waitForVariantAvailability({
           ok: true,
           attempts: attempt + 1,
           availability: summary,
-          requestId: result.requestId,
+          requestId: result.requestId || lastRequestId || undefined,
         };
       }
     }
@@ -261,6 +277,7 @@ export async function waitForVariantAvailability({
     attempts,
     availability: lastSummary || undefined,
     lastError: lastError || undefined,
+    requestId: lastError?.requestId || lastRequestId || undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
- wait for Shopify variants to be published before starting the cart flow and log the polling lifecycle
- align successful and fallback responses with the public cart permalink once availability is confirmed and include extra diagnostics
- expose variant availability metadata and request IDs to simplify debugging cart creation issues

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dae51dca6083279877607f79b9345a