### PR TITLE
Handle Shopify cart cookie fallback

### DIFF
--- a/lib/shopify/storefrontCartServer.js
+++ b/lib/shopify/storefrontCartServer.js
@@ -132,6 +132,12 @@ class SimpleCookieJar {
     }
     return parts.join('; ');
   }
+
+  get(name) {
+    if (!name) return '';
+    const value = this.cookies.get(name);
+    return typeof value === 'string' ? value : '';
+  }
 }
 
 function buildLines(variantGid, quantity) {
@@ -447,7 +453,7 @@ export async function fallbackCartAdd({ variantNumericId, quantity, jar = new Si
       detail,
     };
   }
-  const token = typeof json?.token === 'string' ? json.token.trim() : '';
+  let token = typeof json?.token === 'string' ? json.token.trim() : '';
   const items = Array.isArray(json?.items) ? json.items : [];
   const matchedItem = items.find((item) => {
     if (!item || typeof item !== 'object') return false;
@@ -460,7 +466,31 @@ export async function fallbackCartAdd({ variantNumericId, quantity, jar = new Si
     return variantId && variantId === String(itemId);
   });
   const detail = json ? JSON.stringify(json).slice(0, 2000) : text ? text.slice(0, 2000) : '';
-  if (!token || !matchedItem) {
+  if (!matchedItem) {
+    try {
+      console.error('[storefront_cart] ajax_cart_silent_failure', {
+        status: resp.status,
+        contentType,
+        payload,
+        detail,
+        hasToken: Boolean(token),
+        matchedItem: Boolean(matchedItem),
+      });
+    } catch {}
+    return {
+      ok: false,
+      reason: 'ajax_cart_silent_failure',
+      detail,
+      status: resp.status,
+    };
+  }
+  if (!token) {
+    const cookieToken = jar.get('cart');
+    if (cookieToken) {
+      token = cookieToken.trim();
+    }
+  }
+  if (!token) {
     try {
       console.error('[storefront_cart] ajax_cart_silent_failure', {
         status: resp.status,


### PR DESCRIPTION
## Summary
- allow the fallback cart flow to read the Shopify `cart` cookie when the AJAX response omits a token
- expose a helper on the simple cookie jar and cover the cookie-based flow with a new unit test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daeb0f63748327a4d1df60b85b2356