### PR TITLE
Ensure new variants stay available without stock tracking

### DIFF
--- a/lib/handlers/cartStart.js
+++ b/lib/handlers/cartStart.js
@@ -1,11 +1,6 @@
 import { z } from 'zod';
 import { parseJsonBody, getClientIp } from '../_lib/http.js';
-import {
-  createStorefrontCartServer,
-  fallbackCartAdd,
-  SimpleCookieJar,
-  waitForVariantAvailability,
-} from '../shopify/storefrontCartServer.js';
+import { createStorefrontCartServer } from '../shopify/storefrontCartServer.js';
 
 const BodySchema = z
   .object({
@@ -52,106 +47,6 @@ function respond(res, status, payload, logLabel = 'cart_start_response') {
   } catch {}
 }
 
-function hasVariantInvalidUserError(result) {
-  if (!result || result.reason !== 'user_errors') return false;
-  if (!Array.isArray(result.userErrors)) return false;
-  return result.userErrors.some((err) => {
-    if (!err || typeof err !== 'object') return false;
-    const message = typeof err.message === 'string' ? err.message : '';
-    const code = typeof err.code === 'string' ? err.code : '';
-    if (code && code.toUpperCase() === 'INVALID') return true;
-    if (message && /does not exist/i.test(message)) return true;
-    if (message && /no existe/i.test(message)) return true;
-    return false;
-  });
-}
-
-async function attemptStorefrontCreate({
-  variantGid,
-  quantity,
-  buyerIp,
-  attempts = 2,
-  availabilityPrecheck = null,
-}) {
-  let lastError = null;
-  let availabilityChecked = Boolean(availabilityPrecheck?.ok);
-  let availabilitySummary = availabilityPrecheck?.availability || null;
-  let availabilityRequestId = availabilityPrecheck?.requestId || null;
-  const variantNumericId = variantGid.split('/').pop();
-  for (let i = 0; i < attempts; i += 1) {
-    const attemptNumber = i + 1;
-    try {
-      console.info('cart_start_storefront_attempt', {
-        attempt: attemptNumber,
-        variantGid,
-        variantNumericId,
-        quantity,
-        prechecked: availabilityChecked,
-      });
-    } catch {}
-    const result = await createStorefrontCartServer({ variantGid, quantity, buyerIp });
-    if (result.ok) {
-      return {
-        ...result,
-        attempts: attemptNumber,
-        availability: availabilitySummary || undefined,
-        availabilityRequestId: availabilityRequestId || undefined,
-      };
-    }
-    lastError = {
-      ...result,
-      attempts: attemptNumber,
-      availability: availabilitySummary || undefined,
-      availabilityRequestId: availabilityRequestId || undefined,
-    };
-    if (!availabilityChecked && hasVariantInvalidUserError(result)) {
-      availabilityChecked = true;
-      const availability = await waitForVariantAvailability({
-        variantGid,
-        buyerIp,
-        attempts: 10,
-        backoffMs: [2000, 3000, 4500, 6500, 9000, 13000, 18000, 26000, 36000, 48000],
-        initialDelayMs: 500,
-        productHandle: availabilitySummary?.productHandle,
-        productOnlineStoreUrl: availabilitySummary?.productOnlineStoreUrl,
-      });
-      availabilitySummary = availability?.availability || availabilitySummary;
-      if (availability?.requestId) {
-        availabilityRequestId = availability.requestId;
-      }
-      if (availability?.ok) {
-        try {
-          console.info('cart_start_variant_ready_after_retry', {
-            attempts: availability.attempts,
-            requestId: availability.requestId || null,
-            productHandle: availability?.availability?.productHandle || null,
-            variantGid,
-            variantNumericId,
-          });
-        } catch {}
-      }
-      if (!availability.ok) {
-        return {
-          ok: false,
-          reason: availability.reason || 'variant_not_ready',
-          availability,
-          userErrors: result.userErrors,
-          requestId: result.requestId,
-          attempts: attemptNumber,
-        };
-      }
-      await new Promise((resolve) => setTimeout(resolve, 200));
-      continue;
-    }
-    if (result.reason === 'user_errors' || result.reason === 'http_error' || result.reason === 'graphql_errors') {
-      await new Promise((resolve) => setTimeout(resolve, 200));
-      continue;
-    }
-    break;
-  }
-  return lastError || { ok: false, reason: 'storefront_failed' };
-}
-
 export default async function cartStart(req, res) {
   try {
     console.info('cart_start_request', { method: req.method, path: req.url || '' });
@@ -183,345 +78,58 @@ export default async function cartStart(req, res) {
   const normalizedQuantity = normalizeQuantity(quantity ?? 1);
   const buyerIp = getClientIp(req);
   const variantNumericId = variantGid.split('/').pop();
+  const permalink = buildCartPermalink(variantNumericId, normalizedQuantity);
+
+  let finalUrl = permalink;
+  let strategy = 'permalink';
+  let requestId = null;
+  let storefrontReason = null;
 
   try {
-    console.info('cart_start_variant_check_begin', {
-      variantGid,
-      variantNumericId,
-      quantity: normalizedQuantity,
-    });
-  } catch {}
-
-  const availabilityBackoff = [1500, 2500, 4000, 6000, 9000, 13000, 20000, 30000, 45000, 60000];
-  let availabilityPrecheck = null;
-  try {
-    availabilityPrecheck = await waitForVariantAvailability({
-      variantGid,
-      buyerIp,
-      attempts: availabilityBackoff.length + 1,
-      backoffMs: availabilityBackoff,
-    });
-  } catch (pollErr) {
-    availabilityPrecheck = null;
-    try {
-      console.error('cart_start_variant_poll_error', pollErr);
-    } catch {}
-  }
-
-  let variantReady = Boolean(availabilityPrecheck?.ok);
-  let availabilitySummary = availabilityPrecheck?.availability || null;
-  let availabilityRequestId = availabilityPrecheck?.requestId || null;
-  const availabilityReason = availabilityPrecheck?.reason || null;
-  const availabilityAttempts = availabilityPrecheck?.attempts || null;
-
-  const availabilityLastErrorMessage =
-    typeof availabilityPrecheck?.lastError?.body === 'string' && availabilityPrecheck.lastError.body
-      ? availabilityPrecheck.lastError.body.slice(0, 200)
-      : typeof availabilityPrecheck?.lastError?.reason === 'string'
-        ? availabilityPrecheck.lastError.reason
-        : null;
-
-  if (availabilityPrecheck?.ok) {
-    try {
-      console.info('cart_start_variant_ready', {
-        attempts: availabilityAttempts,
-        requestId: availabilityRequestId || null,
-        productHandle: availabilitySummary?.productHandle || null,
-        productUrl: availabilitySummary?.productOnlineStoreUrl || null,
-        variantGid,
-        variantNumericId,
-      });
-    } catch {}
-  } else if (availabilityPrecheck) {
-    try {
-      console.warn('cart_start_variant_pending', {
-        reason: availabilityReason || 'variant_not_ready',
-        attempts: availabilityAttempts,
-        requestId: availabilityRequestId || null,
-        productHandle: availabilitySummary?.productHandle || null,
-        variantGid,
-        variantNumericId,
-        lastErrorMessage: availabilityLastErrorMessage,
-      });
-    } catch {}
-  }
-
-  const publicPermalink = buildCartPermalink(variantNumericId, normalizedQuantity)
-    || `${CART_ORIGIN}/cart`;
-
-  if (!variantReady) {
-    try {
-      console.info('permalink_fallback_used', {
-        variantGid,
-        variantNumericId,
-        requestId: availabilityRequestId || null,
-        reason: availabilityReason || 'variant_not_ready',
-        availabilityAttempts,
-        lastErrorMessage: availabilityLastErrorMessage,
-        url: publicPermalink,
-      });
-    } catch {}
-    return respond(res, 200, {
-      ok: true,
-      url: publicPermalink,
-      cartUrl: publicPermalink,
-      cartWebUrl: publicPermalink,
-      cartPlain: `${CART_ORIGIN}/cart`,
-      usedFallback: true,
-      fallbackMode: 'permalink',
-      fallbackPlainUrl: publicPermalink,
-      requestId: availabilityRequestId || undefined,
-      storefrontCartUrl: undefined,
-      publicCartUrl: publicPermalink,
-      availability: availabilitySummary || undefined,
-      variantReady: false,
-    });
-  }
-
-  const storefrontResult = await attemptStorefrontCreate({
-    variantGid,
-    quantity: normalizedQuantity,
-    buyerIp,
-    attempts: variantReady ? 2 : 3,
-    availabilityPrecheck,
-  });
-
-  if (storefrontResult?.ok) {
-    const storefrontCartUrl = typeof storefrontResult.cartUrl === 'string'
-      ? storefrontResult.cartUrl.trim()
-      : '';
-    const checkoutUrl = typeof storefrontResult.checkoutUrl === 'string'
-      ? storefrontResult.checkoutUrl.trim()
-      : '';
-    if (!variantReady) {
-      variantReady = true;
-    }
-    if (!availabilitySummary && storefrontResult.availability) {
-      availabilitySummary = storefrontResult.availability;
-    }
-    if (!availabilityRequestId && storefrontResult.availabilityRequestId) {
-      availabilityRequestId = storefrontResult.availabilityRequestId;
-    }
-    const finalUrl = variantReady ? publicPermalink : storefrontCartUrl || publicPermalink;
-    try {
-      console.info('cart_start_return_storefront', {
-        url: finalUrl,
-        storefrontCartUrl,
-        checkoutUrl,
-        publicCartUrl: publicPermalink || null,
-        variantReady,
-        requestId: storefrontResult.requestId || availabilityRequestId || null,
-      });
-    } catch {}
-    return respond(res, 200, {
-      ok: true,
-      url: finalUrl,
-      cartId: storefrontResult.cartId || undefined,
-      cartUrl: finalUrl || undefined,
-      cartPlain: storefrontResult.cartPlain || `${CART_ORIGIN}/cart`,
-      cartToken: storefrontResult.cartToken || undefined,
-      cartWebUrl: finalUrl || undefined,
-      checkoutUrl: checkoutUrl || undefined,
-      checkoutPlain: storefrontResult.checkoutPlain || undefined,
-      usedFallback: false,
-      requestId: storefrontResult.requestId || availabilityRequestId || undefined,
-      storefrontCartUrl: storefrontCartUrl || undefined,
-      publicCartUrl: publicPermalink || undefined,
-      availability: availabilitySummary || undefined,
-      variantReady: true,
-    });
-  }
-
-  if (!availabilitySummary && storefrontResult?.availability) {
-    availabilitySummary = storefrontResult.availability;
-  }
-  if (!availabilityRequestId && storefrontResult?.availabilityRequestId) {
-    availabilityRequestId = storefrontResult.availabilityRequestId;
-  }
-
-  const storefrontLastErrorMessage = typeof storefrontResult?.detail === 'string' && storefrontResult.detail
-    ? storefrontResult.detail.slice(0, 200)
-    : typeof storefrontResult?.body === 'string' && storefrontResult.body
-      ? storefrontResult.body.slice(0, 200)
-      : Array.isArray(storefrontResult?.errors) && storefrontResult.errors.length
-        ? String(storefrontResult.errors[0]?.message || '') || undefined
-        : Array.isArray(storefrontResult?.userErrors) && storefrontResult.userErrors.length
-          ? String(storefrontResult.userErrors[0]?.message || '') || undefined
-          : undefined;
-  try {
-    console.warn('cart_start_storefront_failed', {
-      reason: storefrontResult?.reason || 'storefront_failed',
-      status: typeof storefrontResult?.status === 'number' ? storefrontResult.status : undefined,
-      userErrors: Array.isArray(storefrontResult?.userErrors) && storefrontResult.userErrors.length
-        ? storefrontResult.userErrors
-        : undefined,
-      errors: Array.isArray(storefrontResult?.errors) && storefrontResult.errors.length
-        ? storefrontResult.errors
-        : undefined,
-      detail: typeof storefrontResult?.body === 'string' && storefrontResult.body
-        ? storefrontResult.body
-        : typeof storefrontResult?.detail === 'string' && storefrontResult.detail
-          ? storefrontResult.detail
-          : undefined,
-      requestId: storefrontResult?.requestId || availabilityRequestId || undefined,
-      variantGid,
-      variantNumericId,
-      attempts: storefrontResult?.attempts || null,
-      lastErrorMessage: storefrontLastErrorMessage || null,
-    });
-  } catch {}
-
-  const jar = new SimpleCookieJar();
-  const fallbackResult = await fallbackCartAdd({
-    variantNumericId,
-    quantity: normalizedQuantity,
-    jar,
-  });
-  if (fallbackResult.ok) {
-    if (!variantReady) {
-      try {
-        console.info('cart_start_variant_verify_after_fallback', {
-          variantGid,
-          variantNumericId,
-        });
-      } catch {}
-    }
-    if (!variantReady) {
-      let fallbackAvailability = null;
-      try {
-        fallbackAvailability = await waitForVariantAvailability({
-          variantGid,
-          buyerIp,
-          attempts: 6,
-          backoffMs: [2000, 3000, 4500, 6500, 9000, 13000],
-          productHandle: availabilitySummary?.productHandle,
-          productOnlineStoreUrl: availabilitySummary?.productOnlineStoreUrl,
-        });
-      } catch (fallbackPollErr) {
-        try {
-          console.error('cart_start_variant_verify_error', fallbackPollErr);
-        } catch {}
+    const result = await createStorefrontCartServer({ variantGid, quantity: normalizedQuantity, buyerIp });
+    if (result.ok) {
+      const cartUrl = result.cartUrl || result.cartWebUrl || '';
+      const checkoutUrl = result.checkoutUrl || '';
+      if (cartUrl) {
+        finalUrl = cartUrl;
+        strategy = 'storefront_cart';
+      } else if (checkoutUrl) {
+        finalUrl = checkoutUrl;
+        strategy = 'storefront_checkout';
       }
-      if (fallbackAvailability?.ok) {
-        variantReady = true;
-        availabilitySummary = fallbackAvailability.availability || availabilitySummary;
-        if (!availabilityRequestId && fallbackAvailability.requestId) {
-          availabilityRequestId = fallbackAvailability.requestId;
-        }
-        try {
-          console.info('cart_start_variant_ready_after_fallback', {
-            attempts: fallbackAvailability.attempts,
-            requestId: fallbackAvailability.requestId || null,
-            productHandle: fallbackAvailability?.availability?.productHandle || null,
-            variantGid,
-            variantNumericId,
-          });
-        } catch {}
-      } else if (fallbackAvailability) {
-        try {
-          console.warn('cart_start_variant_still_pending', {
-            reason: fallbackAvailability?.reason || 'variant_not_ready',
-            attempts: fallbackAvailability?.attempts || null,
-            requestId: fallbackAvailability?.requestId || null,
-            variantGid,
-            variantNumericId,
-          });
-        } catch {}
-      }
+      requestId = result.requestId || null;
+    } else {
+      requestId = result?.requestId || null;
+      storefrontReason = result?.reason || null;
     }
-    const fallbackCartUrl = typeof fallbackResult.cartUrl === 'string'
-      ? fallbackResult.cartUrl.trim()
-      : '';
-    const fallbackPlainUrl = typeof fallbackResult.fallbackCartUrl === 'string'
-      ? fallbackResult.fallbackCartUrl.trim()
-      : '';
-    const finalUrl = variantReady
-      ? publicPermalink
-      : fallbackCartUrl || fallbackPlainUrl || publicPermalink;
+  } catch (err) {
+    storefrontReason = 'exception';
     try {
-      console.info('cart_start_return_fallback', {
-        url: finalUrl,
-        fallbackCartUrl,
-        fallbackPlainUrl,
-        publicCartUrl: publicPermalink || null,
-        variantReady,
-        requestId: storefrontResult?.requestId || availabilityRequestId || null,
-        detailPreview: typeof fallbackResult?.detail === 'string'
-          ? fallbackResult.detail.slice(0, 200)
-          : undefined,
-        variantGid,
-        variantNumericId,
-      });
+      console.error('cart_start_storefront_exception', { message: err?.message || String(err) });
     } catch {}
-    return respond(res, 200, {
-      ok: true,
-      url: finalUrl,
-      cartUrl: finalUrl || undefined,
-      cartWebUrl: finalUrl || undefined,
-      cartPlain: fallbackPlainUrl || `${CART_ORIGIN}/cart`,
-      fallbackUrl: fallbackCartUrl || undefined,
-      fallbackPlainUrl: fallbackPlainUrl || undefined,
-      usedFallback: true,
-      requestId: storefrontResult?.requestId || availabilityRequestId || undefined,
-      storefrontCartUrl: fallbackCartUrl || undefined,
-      publicCartUrl: publicPermalink || undefined,
-      availability: availabilitySummary || undefined,
-      variantReady: Boolean(variantReady),
-      storefrontUserErrors: Array.isArray(storefrontResult?.userErrors) && storefrontResult.userErrors.length
-        ? storefrontResult.userErrors
-        : undefined,
-    });
   }
 
-  const finalReason = fallbackResult.reason || storefrontResult?.reason || 'cart_start_failed';
-  const fallbackLastErrorMessage = typeof fallbackResult?.detail === 'string' && fallbackResult.detail
-    ? fallbackResult.detail.slice(0, 200)
-    : typeof fallbackResult?.reason === 'string'
-      ? fallbackResult.reason
-      : null;
-  try {
-    console.error('cart_start_failure', {
-      variantGid,
-      variantNumericId,
-      quantity: normalizedQuantity,
-      storefrontResult,
-      fallbackResult,
-      availability: availabilitySummary || undefined,
-      requestId: storefrontResult?.requestId || availabilityRequestId || undefined,
-      finalReason,
-    });
-  } catch {}
+  if (!finalUrl) {
+    finalUrl = permalink || CART_ORIGIN;
+    strategy = 'permalink';
+  }
 
   try {
-    console.info('permalink_fallback_used', {
+    console.info('cart_start_result', {
+      strategy,
+      url: finalUrl,
       variantGid,
       variantNumericId,
-      requestId: storefrontResult?.requestId || availabilityRequestId || null,
-      reason: finalReason,
-      availabilityAttempts: availabilityAttempts || null,
-      lastErrorMessage: fallbackLastErrorMessage || storefrontLastErrorMessage || null,
-      url: publicPermalink,
+      requestId: requestId || null,
+      storefrontReason,
     });
   } catch {}
 
   return respond(res, 200, {
     ok: true,
-    url: publicPermalink,
-    cartUrl: publicPermalink,
-    cartWebUrl: publicPermalink,
-    cartPlain: `${CART_ORIGIN}/cart`,
-    fallbackPlainUrl: publicPermalink,
-    usedFallback: true,
-    fallbackMode: 'permalink',
-    requestId: storefrontResult?.requestId || availabilityRequestId || undefined,
-    storefrontCartUrl: undefined,
-    publicCartUrl: publicPermalink,
-    availability: availabilitySummary || undefined,
-    variantReady: Boolean(variantReady),
-    storefrontUserErrors: Array.isArray(storefrontResult?.userErrors) && storefrontResult.userErrors.length
-      ? storefrontResult.userErrors
-      : undefined,
-    fallbackError: fallbackResult.reason || undefined,
-    storefrontError: storefrontResult?.reason || undefined,
+    url: finalUrl,
+    strategy,
+    ...(requestId ? { requestId } : {}),
+    ...(storefrontReason ? { storefrontReason } : {}),
   });
 }

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -3,7 +3,6 @@ import { buildProductUrl } from '../publicStorefront.js';
 import { publishToOnlineStore, resolveOnlineStorePublicationId } from '../shopify/publication.js';
 
 const DEFAULT_VENDOR = 'MgMGamers';
-const INVENTORY_TARGET_QUANTITY = 9999;
 const ONLINE_STORE_MISSING_MESSAGE = [
   'No pudimos encontrar el canal Online Store para publicar este producto.',
   'Revisá: 1) que el canal esté instalado, 2) que la app tenga el scope write_publications.',
@@ -739,6 +738,18 @@ function buildVariantFromRestVariant(defaultVariant, restVariant, updateInput) {
       : typeof base.sku === 'string'
         ? base.sku
         : null;
+  const inventoryPolicyRaw = typeof rest.inventory_policy === 'string'
+    ? rest.inventory_policy.trim().toUpperCase()
+    : typeof base.inventoryPolicy === 'string'
+      ? base.inventoryPolicy
+      : null;
+  const availableForSaleRaw = typeof rest.available === 'boolean'
+    ? rest.available
+    : typeof rest.available_for_sale === 'boolean'
+      ? rest.available_for_sale
+      : typeof base.availableForSale === 'boolean'
+        ? base.availableForSale
+        : null;
   const inventoryItemId = typeof base?.inventoryItem?.id === 'string'
     ? base.inventoryItem.id
     : buildInventoryItemGid(rest.inventory_item_id);
@@ -750,6 +761,12 @@ function buildVariantFromRestVariant(defaultVariant, restVariant, updateInput) {
     price: price || null,
     sku: sku || null,
   };
+  if (inventoryPolicyRaw) {
+    variant.inventoryPolicy = inventoryPolicyRaw;
+  }
+  if (availableForSaleRaw != null) {
+    variant.availableForSale = Boolean(availableForSaleRaw);
+  }
   if (inventoryItemId) {
     variant.inventoryItem = { id: inventoryItemId };
   }
@@ -767,6 +784,8 @@ async function executeProductVariantRestUpdate({ variantId, payload, maxAttempts
     id: Number.isFinite(Number(legacyId)) ? Number(legacyId) : legacyId,
     price: payload?.price,
     taxable: payload?.taxable === true,
+    inventory_policy: 'continue',
+    inventory_management: null,
   };
   if (typeof payload?.sku === 'string' && payload.sku) {
     variantPayload.sku = payload.sku;
@@ -1224,6 +1243,8 @@ const PRODUCT_VARIANT_UPDATE_MUTATION = `mutation ProductVariantUpdate($input: P
       title
       price
       sku
+      availableForSale
+      inventoryPolicy
       inventoryItem {
         id
       }
@@ -1246,6 +1267,8 @@ const PRODUCT_VARIANTS_BULK_UPDATE_MUTATION = `mutation ProductVariantsBulkUpdat
       title
       price
       sku
+      availableForSale
+      inventoryPolicy
       inventoryItem {
         id
       }
@@ -1692,6 +1715,8 @@ export async function publishProduct(req, res) {
     const mockupDataUrl = typeof body.mockupDataUrl === 'string' ? body.mockupDataUrl : '';
     const filename = typeof body.filename === 'string' && body.filename ? body.filename : 'mockup.png';
     const warnings = [];
+    let variantInventoryMode = 'not_tracked';
+    let variantAvailableForSale = null;
 
     if (!mockupDataUrl) {
       return res.status(400).json({ ok: false, reason: 'missing_mockup_dataurl' });
@@ -1831,6 +1856,8 @@ export async function publishProduct(req, res) {
     const variantUpdateInputBase = {
       price: priceValue,
       taxable: true,
+      inventoryPolicy: 'CONTINUE',
+      inventoryManagement: null,
     };
 
     try {
@@ -2542,22 +2569,16 @@ export async function publishProduct(req, res) {
       console.info('product_variant_update_success', variantSuccessLog);
     } catch {}
 
+    variantInventoryMode = 'not_tracked';
+    variantAvailableForSale = typeof updatedVariant?.availableForSale === 'boolean'
+      ? updatedVariant.availableForSale
+      : null;
+
     const variantInventoryItemId = typeof updatedVariant?.inventoryItem?.id === 'string'
       ? updatedVariant.inventoryItem.id
       : typeof defaultVariant?.inventoryItem?.id === 'string'
         ? defaultVariant.inventoryItem.id
         : null;
-
-    if (!primaryLocationId) {
-      return res.status(400).json({
-        ok: false,
-        reason: 'inventory_adjust_location_missing',
-        message: 'No se pudo determinar la ubicación principal para ajustar el inventario en Shopify.',
-        requestId: variantRequestIdFinal || null,
-        visibility,
-        ...meta,
-      });
-    }
 
     if (!variantInventoryItemId) {
       return res.status(502).json({
@@ -2571,7 +2592,7 @@ export async function publishProduct(req, res) {
     }
 
     const inventoryItemUpdateInput = {
-      tracked: true,
+      tracked: false,
     };
 
     let inventoryTrackWarning = null;
@@ -2590,91 +2611,40 @@ export async function publishProduct(req, res) {
 
       const buildTrackWarning = (payload = {}) => ({
         code: 'inventory_tracking_warning',
-        message: 'No se pudo activar el tracking de stock en Shopify. Continuamos sin tracking.',
+        message: 'No se pudo desactivar el tracking de stock en Shopify. Continuamos permitiendo ventas sin stock.',
         requestId: trackRequestId || null,
         ...(trackRequestIds.length ? { requestIds: trackRequestIds } : {}),
         ...payload,
       });
 
       if (!trackResp.ok) {
-        if (trackResp.status === 401 || trackResp.status === 403) {
-          inventoryTrackWarning = buildTrackWarning({ status: trackResp.status, body: trackJson });
-        } else {
-          return res.status(502).json({
-            ok: false,
-            reason: 'shopify_error',
-            status: trackResp.status,
-            body: trackJson,
-            requestId: trackRequestId || null,
-            ...(trackRequestIds.length ? { requestIds: trackRequestIds } : {}),
-            message: 'Shopify devolviA3 un error al actualizar el tracking de inventario.',
-            visibility,
-            ...meta,
-          });
-        }
+        inventoryTrackWarning = buildTrackWarning({ status: trackResp.status, body: trackJson });
       } else {
         const trackErrors = Array.isArray(trackJson?.errors) ? trackJson.errors : [];
         const formattedTrackErrors = formatGraphQLErrors(trackErrors);
         const trackPayload = trackJson?.data?.inventoryItemUpdate;
 
         if (trackErrors.length && !trackPayload) {
-          if (detectMissingScope(trackErrors)) {
-            const missingScopes = collectMissingScopes(trackErrors);
-            const missing = missingScopes.length ? missingScopes : ['write_inventory'];
-            inventoryTrackWarning = buildTrackWarning({ detail: formattedTrackErrors, missing });
-          } else {
-            try {
-              console.error('inventory_item_update_graphql_errors', {
-                requestId: trackRequestId || null,
-                errors: formattedTrackErrors,
-              });
-            } catch {}
-            return res.status(502).json({
-              ok: false,
-              reason: 'inventory_tracking_graphql_errors',
-              errors: formattedTrackErrors,
-              requestId: trackRequestId || null,
-              message: 'Shopify devolviA3 errores al actualizar el tracking de inventario.',
-              visibility,
-              ...meta,
-            });
-          }
-        } else if (!trackPayload) {
-          return res.status(502).json({
-            ok: false,
-            reason: 'inventory_tracking_failed',
-            detail: trackJson,
-            requestId: trackRequestId || null,
-            message: 'Shopify no confirmA3 el tracking de inventario.',
-            visibility,
-            ...meta,
+          const missing = detectMissingScope(trackErrors)
+            ? collectMissingScopes(trackErrors)
+            : [];
+          inventoryTrackWarning = buildTrackWarning({
+            detail: formattedTrackErrors,
+            ...(missing.length ? { missing } : {}),
           });
+        } else if (!trackPayload) {
+          inventoryTrackWarning = buildTrackWarning({ detail: trackJson });
         } else {
           const rawTrackUserErrors = Array.isArray(trackPayload?.userErrors) ? trackPayload.userErrors : [];
           const trackUserErrors = sanitizeUserErrors(rawTrackUserErrors);
           if (trackUserErrors.length) {
-            if (detectMissingScope(rawTrackUserErrors)) {
-              const missingScopes = collectMissingScopes(rawTrackUserErrors);
-              const missing = missingScopes.length ? missingScopes : ['write_inventory'];
-              inventoryTrackWarning = buildTrackWarning({ detail: trackUserErrors, missing });
-            } else {
-              const trackUserErrorMessages = trackUserErrors
-                .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
-                .filter((msg) => Boolean(msg));
-              const friendlyTrackMessage = trackUserErrorMessages.length
-                ? trackUserErrorMessages[0]
-                : 'Shopify rechazA3 el tracking de inventario.';
-              return res.status(400).json({
-                ok: false,
-                reason: 'inventory_tracking_user_errors',
-                detail: trackUserErrors,
-                requestId: trackRequestId || null,
-                message: friendlyTrackMessage,
-                visibility,
-                ...meta,
-                ...(trackUserErrorMessages.length ? { messages: trackUserErrorMessages } : {}),
-              });
-            }
+            const missing = detectMissingScope(rawTrackUserErrors)
+              ? collectMissingScopes(rawTrackUserErrors)
+              : [];
+            inventoryTrackWarning = buildTrackWarning({
+              detail: trackUserErrors,
+              ...(missing.length ? { missing } : {}),
+            });
           } else {
             try {
               console.info('inventory_item_update_success', {
@@ -2682,6 +2652,7 @@ export async function publishProduct(req, res) {
                 productId: meta.productAdminId || null,
                 variantId: meta.variantAdminId || null,
                 inventoryItemId: variantInventoryItemId,
+                tracked: false,
               });
             } catch {}
           }
@@ -2691,180 +2662,15 @@ export async function publishProduct(req, res) {
       if (err?.message === 'SHOPIFY_ENV_MISSING') {
         throw err;
       }
-      return res.status(502).json({
-        ok: false,
-        reason: 'inventory_tracking_exception',
-        message: 'OcurriA3 un error al actualizar el tracking de inventario.',
+      inventoryTrackWarning = {
+        code: 'inventory_tracking_warning',
+        message: 'Ocurrió un error al desactivar el tracking de inventario. Continuamos permitiendo ventas sin stock.',
         detail: { message: err?.message || String(err) },
-        visibility,
-        ...meta,
-      });
-    }
-
-    const inventorySetInput = {
-      reason: 'CORRECTION',
-      setQuantities: [{
-        inventoryItemId: variantInventoryItemId,
-        locationId: primaryLocationId,
-        quantity: INVENTORY_TARGET_QUANTITY,
-        name: 'available',
-      }],
-    };
-
-    let inventoryStockWarning = null;
-    let inventorySetRequestIds = [];
-    let inventorySetRequestId = null;
-    let needInventoryRestFallback = false;
-
-    try {
-      const {
-        resp: setResp,
-        json: setJson,
-        requestId: setRequestId,
-        attempts: setAttempts,
-      } = await executeInventorySetOnHandQuantities({ input: inventorySetInput });
-
-      inventorySetRequestId = setRequestId || null;
-      inventorySetRequestIds = Array.isArray(setAttempts)
-        ? setAttempts.map((entry) => entry?.requestId).filter(Boolean)
-        : [];
-
-      const buildStockWarning = (payload = {}) => ({
-        code: 'inventory_set_on_hand_warning',
-        message: 'No se pudo fijar el stock en Shopify. Continuamos sin actualizar inventario.',
-        requestId: inventorySetRequestId || null,
-        ...(inventorySetRequestIds.length ? { requestIds: inventorySetRequestIds } : {}),
-        ...payload,
-      });
-
-      if (!setResp.ok) {
-        if (setResp.status === 401 || setResp.status === 403) {
-          inventoryStockWarning = buildStockWarning({ status: setResp.status, body: setJson });
-        } else {
-          needInventoryRestFallback = true;
-        }
-      } else {
-        const setErrors = Array.isArray(setJson?.errors) ? setJson.errors : [];
-        const formattedSetErrors = formatGraphQLErrors(setErrors);
-        const setPayload = setJson?.data?.inventorySetOnHandQuantities;
-
-        if (setErrors.length && !setPayload) {
-          if (detectMissingScope(setErrors)) {
-            const missingScopes = collectMissingScopes(setErrors);
-            const missing = missingScopes.length ? missingScopes : ['write_inventory'];
-            inventoryStockWarning = buildStockWarning({ detail: formattedSetErrors, missing });
-          } else {
-            needInventoryRestFallback = true;
-          }
-        } else if (!setPayload) {
-          needInventoryRestFallback = true;
-        } else {
-          const rawSetUserErrors = Array.isArray(setPayload?.userErrors) ? setPayload.userErrors : [];
-          const setUserErrors = sanitizeUserErrors(rawSetUserErrors);
-          if (setUserErrors.length) {
-            if (detectMissingScope(rawSetUserErrors)) {
-              const missingScopes = collectMissingScopes(rawSetUserErrors);
-              const missing = missingScopes.length ? missingScopes : ['write_inventory'];
-              inventoryStockWarning = buildStockWarning({ detail: setUserErrors, missing });
-            } else {
-              const setUserErrorMessages = setUserErrors
-                .map((error) => (typeof error?.message === 'string' ? error.message.trim() : ''))
-                .filter((msg) => Boolean(msg));
-              const friendlySetMessage = setUserErrorMessages.length
-                ? setUserErrorMessages[0]
-                : 'Shopify rechazA3 la actualizaciA3n de stock.';
-              return res.status(400).json({
-                ok: false,
-                reason: 'inventory_set_on_hand_user_errors',
-                detail: setUserErrors,
-                requestId: inventorySetRequestId || null,
-                message: friendlySetMessage,
-                visibility,
-                ...meta,
-                ...(setUserErrorMessages.length ? { messages: setUserErrorMessages } : {}),
-              });
-            }
-          } else {
-            try {
-              console.info('inventory_set_on_hand_success', {
-                requestId: inventorySetRequestId || null,
-                productId: meta.productAdminId || null,
-                variantId: meta.variantAdminId || null,
-                locationId: primaryLocationId,
-                inventoryItemId: variantInventoryItemId,
-              });
-            } catch {}
-          }
-        }
-      }
-
-      if (!inventoryStockWarning && needInventoryRestFallback) {
-        const {
-          resp: restResp,
-          json: restJson,
-          requestId: restRequestId,
-          attempts: restAttempts,
-        } = await executeInventoryLevelsSet({
-          inventoryItemId: variantInventoryItemId,
-          locationId: primaryLocationId,
-          available: INVENTORY_TARGET_QUANTITY,
-        });
-
-        const restRequestIds = Array.isArray(restAttempts)
-          ? restAttempts.map((entry) => entry?.requestId).filter(Boolean)
-          : [];
-
-        const buildRestWarning = (payload = {}) => ({
-          code: 'inventory_set_on_hand_warning',
-          message: 'No se pudo fijar el stock en Shopify. Continuamos sin actualizar inventario.',
-          requestId: restRequestId || inventorySetRequestId || null,
-          ...(restRequestIds.length ? { requestIds: restRequestIds } : {}),
-          ...payload,
-        });
-
-        if (!restResp.ok) {
-          if (restResp.status === 401 || restResp.status === 403) {
-            inventoryStockWarning = buildRestWarning({ status: restResp.status, body: restJson });
-          } else {
-            return res.status(502).json({
-              ok: false,
-              reason: 'inventory_set_on_hand_rest_failed',
-              status: restResp.status,
-              body: restJson,
-              requestId: restRequestId || null,
-              ...(restRequestIds.length ? { requestIds: restRequestIds } : {}),
-              message: 'Shopify devolviA3 un error al fijar el stock de la variante.',
-              visibility,
-              ...meta,
-            });
-          }
-        } else {
-          try {
-            console.info('inventory_levels_set_success', {
-              requestId: restRequestId || null,
-              productId: meta.productAdminId || null,
-              variantId: meta.variantAdminId || null,
-              locationId: primaryLocationId,
-              inventoryItemId: variantInventoryItemId,
-            });
-          } catch {}
-        }
-      }
-    } catch (err) {
-      if (err?.message === 'SHOPIFY_ENV_MISSING') {
-        throw err;
-      }
-      return res.status(502).json({
-        ok: false,
-        reason: 'inventory_set_on_hand_exception',
-        message: 'OcurriA3 un error al fijar el stock de la variante.',
-        detail: { message: err?.message || String(err) },
-        visibility,
-        ...meta,
-      });
+      };
     }
 
     if (inventoryTrackWarning) {
+      variantInventoryMode = 'tracked_continue';
       warnings.push(inventoryTrackWarning);
       try {
         console.warn('inventory_item_update_warning', {
@@ -2876,18 +2682,6 @@ export async function publishProduct(req, res) {
       } catch {}
     }
 
-    if (inventoryStockWarning) {
-      warnings.push(inventoryStockWarning);
-      try {
-        console.warn('inventory_set_on_hand_warning', {
-          ...inventoryStockWarning,
-          productId: meta.productAdminId || null,
-          variantId: meta.variantAdminId || null,
-          locationId: primaryLocationId,
-          inventoryItemId: variantInventoryItemId,
-        });
-      } catch {}
-    }
 
     if (productMediaInput.length) {
       const mediaWarningMessage = 'No se pudo asociar la imagen, seguimos sin mockup.';
@@ -3276,6 +3070,21 @@ export async function publishProduct(req, res) {
       responsePayload.publicationSource = null;
       responsePayload.requestIds = null;
     }
+
+    const publishedFlag = !isPrivate ? publishResult?.ok === true : false;
+    try {
+      console.info('variant_inventory_diagnostics', {
+        productId: meta.productAdminId || null,
+        variantId: meta.variantAdminId || null,
+        variant_inventory_mode: variantInventoryMode,
+        inventory_qty: 0,
+        policy: 'CONTINUE',
+        published: publishedFlag,
+        availableForSale: variantAvailableForSale == null
+          ? null
+          : variantAvailableForSale === true,
+      });
+    } catch {}
 
     return res.status(200).json(responsePayload);
   } catch (e) {


### PR DESCRIPTION
## Summary
- disable inventory tracking for freshly created variants, force CONTINUE policy, and log storefront availability diagnostics
- request variant availability data from Shopify updates so new products stay available for sale immediately
- simplify the cart start handler to use the previous single-attempt flow with permalink fallback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daf944cfac8327b4e4646d4bf63593