### PR TITLE
Restore automatic cart flow with storefront fallback

### DIFF
--- a/lib/handlers/cartStart.js
+++ b/lib/handlers/cartStart.js
@@ -84,6 +84,7 @@ export default async function cartStart(req, res) {
   let strategy = 'permalink';
   let requestId = null;
   let storefrontReason = null;
+  let userErrors = null;
 
   try {
     const result = await createStorefrontCartServer({ variantGid, quantity: normalizedQuantity, buyerIp });
@@ -101,6 +102,15 @@ export default async function cartStart(req, res) {
     } else {
       requestId = result?.requestId || null;
       storefrontReason = result?.reason || null;
+      if (Array.isArray(result?.userErrors) && result.userErrors.length) {
+        userErrors = result.userErrors;
+        try {
+          console.warn('cart_start_user_errors', {
+            requestId: requestId || null,
+            userErrors,
+          });
+        } catch {}
+      }
     }
   } catch (err) {
     storefrontReason = 'exception';
@@ -114,22 +124,22 @@ export default async function cartStart(req, res) {
     strategy = 'permalink';
   }
 
-  try {
-    console.info('cart_start_result', {
-      strategy,
-      url: finalUrl,
-      variantGid,
-      variantNumericId,
-      requestId: requestId || null,
-      storefrontReason,
-    });
-  } catch {}
-
-  return respond(res, 200, {
+  const responsePayload = {
     ok: true,
     url: finalUrl,
     strategy,
     ...(requestId ? { requestId } : {}),
     ...(storefrontReason ? { storefrontReason } : {}),
-  });
+    ...(userErrors ? { userErrors } : {}),
+  };
+
+  try {
+    console.info('cart_start_result', {
+      ...responsePayload,
+      variantGid,
+      variantNumericId,
+    });
+  } catch {}
+
+  return respond(res, 200, responsePayload, 'cart_start_success');
 }


### PR DESCRIPTION
## Summary
- restore the automatic cart start flow on the mockup page, calling `/api/cart/start`, logging responses, and falling back to permalinks with discount support
- add server-side logging for Shopify user errors and emit a `cart_start_success` log when returning the cart URL

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dafd29713483279b1feb2bc3a337e1