### PR TITLE
Use cart add permalink for cart start

### DIFF
--- a/lib/handlers/cartStart.js
+++ b/lib/handlers/cartStart.js
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import { parseJsonBody, getClientIp } from '../_lib/http.js';
-import { createStorefrontCartServer } from '../shopify/storefrontCartServer.js';
 
 const BodySchema = z
   .object({
@@ -21,7 +20,8 @@ function buildCartPermalink(variantNumericId, quantity) {
   const id = variantNumericId ? String(variantNumericId).trim() : '';
   const qty = Number.isFinite(quantity) && quantity > 0 ? Math.max(1, Math.floor(quantity)) : 1;
   if (!id) return '';
-  return `${CART_ORIGIN}/cart/${id}:${qty}`;
+  const params = new URLSearchParams({ id, quantity: String(qty), return_to: '/cart' });
+  return `${CART_ORIGIN}/cart/add?${params.toString()}`;
 }
 
 function respond(res, status, payload, logLabel = 'cart_start_response') {
@@ -80,66 +80,22 @@ export default async function cartStart(req, res) {
   const variantNumericId = variantGid.split('/').pop();
   const permalink = buildCartPermalink(variantNumericId, normalizedQuantity);
 
-  let finalUrl = permalink;
-  let strategy = 'permalink';
-  let requestId = null;
-  let storefrontReason = null;
-  let userErrors = null;
-
-  try {
-    const result = await createStorefrontCartServer({ variantGid, quantity: normalizedQuantity, buyerIp });
-    if (result.ok) {
-      const cartUrl = result.cartUrl || result.cartWebUrl || '';
-      const checkoutUrl = result.checkoutUrl || '';
-      if (cartUrl) {
-        finalUrl = cartUrl;
-        strategy = 'storefront_cart';
-      } else if (checkoutUrl) {
-        finalUrl = checkoutUrl;
-        strategy = 'storefront_checkout';
-      }
-      requestId = result.requestId || null;
-    } else {
-      requestId = result?.requestId || null;
-      storefrontReason = result?.reason || null;
-      if (Array.isArray(result?.userErrors) && result.userErrors.length) {
-        userErrors = result.userErrors;
-        try {
-          console.warn('cart_start_user_errors', {
-            requestId: requestId || null,
-            userErrors,
-          });
-        } catch {}
-      }
-    }
-  } catch (err) {
-    storefrontReason = 'exception';
+  if (!permalink) {
     try {
-      console.error('cart_start_storefront_exception', { message: err?.message || String(err) });
+      console.warn('cart_start_permalink_missing', { variantGid, variantNumericId });
     } catch {}
+    return respond(res, 500, { ok: false, error: 'permalink_unavailable' });
   }
-
-  if (!finalUrl) {
-    finalUrl = permalink || CART_ORIGIN;
-    strategy = 'permalink';
-  }
-
-  const responsePayload = {
-    ok: true,
-    url: finalUrl,
-    strategy,
-    ...(requestId ? { requestId } : {}),
-    ...(storefrontReason ? { storefrontReason } : {}),
-    ...(userErrors ? { userErrors } : {}),
-  };
 
   try {
-    console.info('cart_start_result', {
-      ...responsePayload,
+    console.info('cart_start_url_returned', {
+      url: permalink,
       variantGid,
       variantNumericId,
+      buyerIp: buyerIp || null,
+      return_to: '/cart',
     });
   } catch {}
 
-  return respond(res, 200, responsePayload, 'cart_start_success');
+  return respond(res, 200, { ok: true, url: permalink }, 'cart_start_success');
 }

--- a/mgm-front/src/lib/cart.ts
+++ b/mgm-front/src/lib/cart.ts
@@ -33,7 +33,11 @@ export function openCartUrl(rawUrl: string, options?: OpenCartOptions): boolean 
       console.warn?.('[openCartUrl] popup_navigation_failed', err);
     }
   }
-  const win = window.open(url, target);
+  const features = target === '_blank' ? 'noopener' : undefined;
+  const win =
+    features !== undefined
+      ? window.open(url, target, features)
+      : window.open(url, target);
   if (win && target === '_blank') {
     try {
       win.opener = null;


### PR DESCRIPTION
## Summary
- build a Shopify cart add permalink in `/api/cart/start` using the variant numeric id and log the returned URL
- update the mockup page to open the provided cart link immediately in a new tab and simplify logging
- ensure the shared `openCartUrl` helper opens `_blank` links with the `noopener` feature for safety

## Testing
- npm test
- npm --prefix mgm-front run build

------
https://chatgpt.com/codex/tasks/task_e_68db00ed75548327aa4a46a1861a0aca