### PR TITLE
Avoid duplicate product tab when adding to cart

### DIFF
--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -290,7 +290,7 @@ export default function Mockup() {
       if (typeof window !== 'undefined') {
         try {
           const popup = window.open(productUrl, '_blank', 'noopener');
-          if (popup && !popup.closed) {
+          if (popup) {
             try {
               popup.opener = null;
             } catch (openerErr) {


### PR DESCRIPTION
## Summary
- update the add-to-cart flow to only fall back to a second window when the first attempt fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db06fecdb88327a7330eeace8d6378