### PR TITLE
Improve private checkout scope handling

### DIFF
--- a/lib/handlers/privateCheckout.js
+++ b/lib/handlers/privateCheckout.js
@@ -5,7 +5,7 @@ import {
   normalizeCartAttributes,
   normalizeCartNote,
 } from '../shopify/cartHelpers.js';
-import { shopifyAdminGraphQL } from '../shopify.js';
+import { shopifyAdminGraphQL, shopifyAdmin } from '../shopify.js';
 
 const REQUIRED_SCOPES = ['write_draft_orders', 'read_products'];
 const REQUIRED_API_VERSION = '2024-07';
@@ -192,10 +192,82 @@ function parseScopes(raw) {
     .filter(Boolean);
 }
 
-function ensureShopifyRequirements() {
+async function fetchAdminAccessScopes() {
+  let resp;
+  try {
+    resp = await shopifyAdmin('oauth/access_scopes.json', { method: 'GET' });
+  } catch (err) {
+    if (err?.message === 'SHOPIFY_ENV_MISSING') {
+      return { ok: false, reason: 'shopify_env_missing', missing: err.missing };
+    }
+    safeWarn('private_checkout_scope_fetch_exception', {
+      message: typeof err?.message === 'string' ? err.message : undefined,
+    });
+    return { ok: false, reason: 'request_failed' };
+  }
+  const requestId = readRequestId(resp);
+  const textBody = await resp.text();
+  const json = parseJsonMaybe(textBody);
+  if (!resp.ok) {
+    safeWarn('private_checkout_scope_fetch_http_error', {
+      status: resp.status,
+      requestId: requestId || null,
+    });
+    return {
+      ok: false,
+      reason: 'http_error',
+      status: resp.status,
+      requestId,
+      body: textBody?.slice(0, 1000),
+    };
+  }
+  if (!json || typeof json !== 'object') {
+    safeWarn('private_checkout_scope_fetch_invalid', {
+      requestId: requestId || null,
+    });
+    return { ok: false, reason: 'invalid_response', requestId };
+  }
+  const scopes = Array.isArray(json.access_scopes)
+    ? json.access_scopes
+        .map((entry) => {
+          if (!entry) return '';
+          if (typeof entry === 'string') return entry;
+          if (typeof entry.handle === 'string') return entry.handle;
+          return '';
+        })
+        .filter(Boolean)
+    : [];
+  safeInfo('private_checkout_access_scopes', {
+    requestId: requestId || null,
+    scopesCount: scopes.length,
+  });
+  return { ok: true, scopes, requestId };
+}
+
+async function ensureShopifyRequirements() {
   const scopesRaw = readScopesFromEnv();
   const scopes = new Set(parseScopes(scopesRaw).map((scope) => scope.toLowerCase()));
-  const missingScopes = REQUIRED_SCOPES.filter((scope) => !scopes.has(scope));
+  let missingScopes = REQUIRED_SCOPES.filter((scope) => !scopes.has(scope));
+  let scopeSource = scopesRaw ? 'env' : 'unknown';
+  let scopeRequestId;
+  if (missingScopes.length) {
+    const accessScopes = await fetchAdminAccessScopes();
+    if (accessScopes.ok) {
+      const accessSet = new Set(accessScopes.scopes.map((scope) => scope.toLowerCase()));
+      missingScopes = REQUIRED_SCOPES.filter((scope) => !accessSet.has(scope));
+      scopeSource = 'api';
+      scopeRequestId = accessScopes.requestId;
+    } else if (accessScopes.reason === 'shopify_env_missing') {
+      return { ok: false, reason: 'shopify_env_missing', missing: accessScopes.missing };
+    } else {
+      scopeRequestId = accessScopes.requestId;
+      safeWarn('private_checkout_scope_probe_failed', {
+        reason: accessScopes.reason || 'unknown',
+        status: accessScopes.status,
+        requestId: scopeRequestId || null,
+      });
+    }
+  }
   const apiVersionRaw = typeof process.env.SHOPIFY_API_VERSION === 'string'
     ? process.env.SHOPIFY_API_VERSION.trim()
     : '';
@@ -208,6 +280,8 @@ function ensureShopifyRequirements() {
       requiredVersion: REQUIRED_API_VERSION,
       hasVersion,
       versionMismatch,
+      scopeSource,
+      scopeRequestId: scopeRequestId || undefined,
     });
     return {
       ok: false,
@@ -215,6 +289,8 @@ function ensureShopifyRequirements() {
       apiVersion: apiVersionRaw,
       hasVersion,
       versionMismatch,
+      scopeSource,
+      scopeRequestId,
     };
   }
   return { ok: true };
@@ -423,13 +499,22 @@ export default async function privateCheckout(req, res) {
     res.setHeader?.('Allow', 'POST');
     return sendJson(res, 405, { ok: false, reason: 'method_not_allowed' });
   }
-  const requirementCheck = ensureShopifyRequirements();
+  const requirementCheck = await ensureShopifyRequirements();
   if (!requirementCheck.ok) {
+    if (requirementCheck.reason === 'shopify_env_missing') {
+      return sendJson(res, 500, {
+        ok: false,
+        reason: 'shopify_env_missing',
+        missing: requirementCheck.missing,
+      });
+    }
     return sendJson(res, 500, {
       ok: false,
       reason: 'missing_scope_or_version',
       ...(requirementCheck.missingScopes?.length ? { missingScopes: requirementCheck.missingScopes } : {}),
       ...(requirementCheck.apiVersion ? { apiVersion: requirementCheck.apiVersion } : {}),
+      ...(requirementCheck.scopeSource ? { scopeSource: requirementCheck.scopeSource } : {}),
+      ...(requirementCheck.scopeRequestId ? { scopeRequestId: requirementCheck.scopeRequestId } : {}),
     });
   }
   try {


### PR DESCRIPTION
## Summary
- fetch Shopify access scopes from the Admin API when environment variables do not list them
- relax the private checkout gate by confirming required scopes via the API and improve the error payloads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db07d7127c832792678b3f8791a18b