### PR TITLE
Prevent duplicate product tab opens when adding to cart

### DIFF
--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -290,16 +290,17 @@ export default function Mockup() {
       if (typeof window !== 'undefined') {
         try {
           const popup = window.open(productUrl, '_blank', 'noopener');
+          opened = true;
           if (popup) {
             try {
               popup.opener = null;
             } catch (openerErr) {
               console.debug?.('[mockup] product_tab_opener_clear_failed', openerErr);
             }
-            opened = true;
           }
         } catch (openErr) {
           console.warn('[mockup] product_page_open_failed', openErr);
+          opened = false;
         }
         if (!opened) {
           try {


### PR DESCRIPTION
## Summary
- ensure the product page is only opened once when starting the cart flow
- fall back to a secondary window.open call only if the first attempt throws

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db0849a7988327a0694944dcd5778d