### PR TITLE
Add storefront checkout fallback when draft order scope missing

### DIFF
--- a/lib/handlers/privateCheckout.js
+++ b/lib/handlers/privateCheckout.js
@@ -1,9 +1,10 @@
 import { z } from 'zod';
-import { parseJsonBody } from '../_lib/http.js';
+import { parseJsonBody, getClientIp } from '../_lib/http.js';
 import {
   resolveVariantIds,
   normalizeCartAttributes,
   normalizeCartNote,
+  createStorefrontCart,
 } from '../shopify/cartHelpers.js';
 import { shopifyAdminGraphQL, shopifyAdmin } from '../shopify.js';
 
@@ -296,6 +297,94 @@ async function ensureShopifyRequirements() {
   return { ok: true };
 }
 
+async function attemptStorefrontCheckoutFallback({ req, variantGid, quantity, note, attributes, email }) {
+  if (!variantGid) {
+    return { ok: false, reason: 'missing_variant_gid' };
+  }
+
+  const baseAttributes = Array.isArray(attributes)
+    ? attributes
+        .map((attr) => {
+          if (!attr || typeof attr !== 'object') return null;
+          const key = typeof attr.key === 'string' ? attr.key : typeof attr.name === 'string' ? attr.name : '';
+          if (!key) return null;
+          const value = typeof attr.value === 'string' ? attr.value : attr.value == null ? '' : String(attr.value);
+          return { key, value };
+        })
+        .filter(Boolean)
+    : [];
+
+  const fallbackAttributes = baseAttributes.slice();
+  const pushAttr = (key, value) => {
+    if (!key || typeof key !== 'string') return;
+    const trimmedKey = key.trim();
+    if (!trimmedKey) return;
+    fallbackAttributes.push({ key: trimmedKey, value: value == null ? '' : String(value) });
+  };
+
+  pushAttr('mgm_source', 'private-fallback');
+  if (email) {
+    pushAttr('customer_email', email);
+  }
+
+  const normalizedFallbackAttributes = normalizeCartAttributes(fallbackAttributes);
+
+  const buyerIp = (() => {
+    try {
+      return getClientIp(req);
+    } catch {
+      return undefined;
+    }
+  })();
+
+  let fallbackResult;
+  try {
+    fallbackResult = await createStorefrontCart({
+      variantGid,
+      quantity,
+      note,
+      attributes: normalizedFallbackAttributes,
+      buyerIp,
+    });
+  } catch (err) {
+    safeWarn('private_checkout_storefront_fallback_exception', {
+      message: typeof err?.message === 'string' ? err.message : undefined,
+    });
+    return { ok: false, reason: 'exception' };
+  }
+
+  if (fallbackResult?.ok && fallbackResult.checkoutUrl) {
+    safeInfo('private_checkout_storefront_fallback_success', {
+      cartId: fallbackResult.cartId || null,
+      checkoutUrl: fallbackResult.checkoutPlain || fallbackResult.checkoutUrl || null,
+      requestId: fallbackResult.requestId || null,
+    });
+    return {
+      ok: true,
+      url: fallbackResult.checkoutUrl,
+      cartUrl: fallbackResult.cartUrl,
+      requestId: fallbackResult.requestId,
+    };
+  }
+
+  safeWarn('private_checkout_storefront_fallback_failed', {
+    reason: fallbackResult?.reason || 'unknown',
+    status: fallbackResult?.status,
+    requestId: fallbackResult?.requestId || null,
+  });
+
+  if (fallbackResult?.reason === 'storefront_env_missing') {
+    return { ok: false, reason: 'storefront_env_missing', missing: fallbackResult.missing };
+  }
+
+  return {
+    ok: false,
+    reason: fallbackResult?.reason || 'unknown',
+    status: fallbackResult?.status,
+    requestId: fallbackResult?.requestId,
+  };
+}
+
 function buildDraftOrderInput({ variantGid, quantity, note, attributes, email }) {
   const qty = normalizeQuantity(quantity);
   const input = {
@@ -499,24 +588,6 @@ export default async function privateCheckout(req, res) {
     res.setHeader?.('Allow', 'POST');
     return sendJson(res, 405, { ok: false, reason: 'method_not_allowed' });
   }
-  const requirementCheck = await ensureShopifyRequirements();
-  if (!requirementCheck.ok) {
-    if (requirementCheck.reason === 'shopify_env_missing') {
-      return sendJson(res, 500, {
-        ok: false,
-        reason: 'shopify_env_missing',
-        missing: requirementCheck.missing,
-      });
-    }
-    return sendJson(res, 500, {
-      ok: false,
-      reason: 'missing_scope_or_version',
-      ...(requirementCheck.missingScopes?.length ? { missingScopes: requirementCheck.missingScopes } : {}),
-      ...(requirementCheck.apiVersion ? { apiVersion: requirementCheck.apiVersion } : {}),
-      ...(requirementCheck.scopeSource ? { scopeSource: requirementCheck.scopeSource } : {}),
-      ...(requirementCheck.scopeRequestId ? { scopeRequestId: requirementCheck.scopeRequestId } : {}),
-    });
-  }
   try {
     const body = await parseJsonBody(req).catch((err) => {
       if (err?.code === 'payload_too_large') {
@@ -560,6 +631,59 @@ export default async function privateCheckout(req, res) {
 
     const attributesInput = noteAttributes ?? attributes;
     const normalizedAttributes = normalizeCartAttributes(attributesInput);
+
+    const requirementCheck = await ensureShopifyRequirements();
+    if (!requirementCheck.ok) {
+      if (requirementCheck.reason === 'shopify_env_missing') {
+        return sendJson(res, 500, {
+          ok: false,
+          reason: 'shopify_env_missing',
+          missing: requirementCheck.missing,
+        });
+      }
+
+      const fallbackResult = await attemptStorefrontCheckoutFallback({
+        req,
+        variantGid: resolvedVariantGid,
+        quantity: qty,
+        note,
+        attributes: normalizedAttributes,
+        email,
+      });
+
+      if (fallbackResult.ok && fallbackResult.url) {
+        const requestIds = fallbackResult.requestId ? [fallbackResult.requestId] : undefined;
+        return sendJson(res, 200, {
+          ok: true,
+          mode: 'storefront_checkout',
+          url: fallbackResult.url,
+          warningMessages: [
+            'No pudimos generar un checkout privado. Abrimos el checkout estándar de Shopify.',
+          ],
+          ...(requestIds ? { requestIds } : {}),
+        });
+      }
+
+      return sendJson(res, 500, {
+        ok: false,
+        reason: 'missing_scope_or_version',
+        ...(requirementCheck.missingScopes?.length ? { missingScopes: requirementCheck.missingScopes } : {}),
+        ...(requirementCheck.apiVersion ? { apiVersion: requirementCheck.apiVersion } : {}),
+        ...(requirementCheck.scopeSource ? { scopeSource: requirementCheck.scopeSource } : {}),
+        ...(requirementCheck.scopeRequestId ? { scopeRequestId: requirementCheck.scopeRequestId } : {}),
+        ...(fallbackResult
+          ? {
+              fallback: {
+                type: 'storefront_checkout',
+                ...(fallbackResult.reason ? { reason: fallbackResult.reason } : {}),
+                ...(fallbackResult.status ? { status: fallbackResult.status } : {}),
+                ...(fallbackResult.requestId ? { requestId: fallbackResult.requestId } : {}),
+                ...(Array.isArray(fallbackResult.missing) ? { missing: fallbackResult.missing } : {}),
+              },
+            }
+          : {}),
+      });
+    }
 
     let draftOrderResult;
     try {


### PR DESCRIPTION
## Summary
- add a Storefront checkout fallback when the draft order scopes or API version are unavailable
- include a warning message and request ids when the fallback succeeds so the UI can notify the user
- surface fallback diagnostics alongside the existing missing scope error response for easier debugging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db09e85108832791834bb1d9d144ee