### PR TITLE
Add responsive footer component

### DIFF
--- a/mgm-front/src/App.jsx
+++ b/mgm-front/src/App.jsx
@@ -1,6 +1,7 @@
 import { Link, Outlet } from 'react-router-dom';
 import styles from './App.module.css';
 import SeoJsonLd from './components/SeoJsonLd';
+import Footer from './components/Footer';
 
 export default function App() {
   return (
@@ -15,6 +16,7 @@ export default function App() {
       <main className={styles.main}>
         <Outlet />
       </main>
+      <Footer />
     </div>
   );
 }

--- a/mgm-front/src/components/Footer.jsx
+++ b/mgm-front/src/components/Footer.jsx
@@ -1,0 +1,60 @@
+import styles from './Footer.module.css';
+
+const sections = [
+  {
+    title: 'Más de nosotros',
+    links: [
+      { label: 'Nuestros productos' },
+      { label: 'Instagram' },
+      { label: 'Facebook' },
+      { label: 'TikTok' },
+    ],
+  },
+  {
+    title: '¿Necesitás ayuda?',
+    links: [
+      { label: 'Ayuda' },
+      { label: 'Contactanos' },
+    ],
+  },
+  {
+    title: 'Legal',
+    links: [
+      { label: 'ARCA' },
+      { label: 'Términos y Condiciones' },
+    ],
+  },
+];
+
+export default function Footer() {
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.topRow}>
+        <div className={styles.linkColumns}>
+          {sections.map((section) => (
+            <div key={section.title} className={styles.column}>
+              <h3 className={styles.columnTitle}>{section.title}</h3>
+              <ul className={styles.linkList}>
+                {section.links.map((item) => (
+                  <li key={item.label}>
+                    <a href="" className={styles.link}>
+                      {item.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <div className={styles.locationWrapper}>
+          <span className={styles.location}>San Juan, Argentina</span>
+        </div>
+      </div>
+      <div className={styles.bottomRow}>
+        <span className={styles.copyright}>
+          © 2025 MGM Gamers. Todos los derechos reservados.
+        </span>
+      </div>
+    </footer>
+  );
+}

--- a/mgm-front/src/components/Footer.module.css
+++ b/mgm-front/src/components/Footer.module.css
@@ -1,0 +1,115 @@
+.footer {
+  background: #101010;
+  padding: clamp(32px, 6vw, 60px) clamp(24px, 8vw, 80px);
+  color: rgba(242, 243, 245, 0.92);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 4vw, 40px);
+  font-family: 'Poppins', sans-serif;
+}
+
+.topRow {
+  display: flex;
+  justify-content: space-between;
+  gap: clamp(24px, 4vw, 48px);
+  flex-wrap: wrap;
+}
+
+.linkColumns {
+  display: flex;
+  gap: clamp(28px, 6vw, 80px);
+  flex-wrap: wrap;
+}
+
+.column {
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.columnTitle {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.linkList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.link {
+  color: rgba(242, 243, 245, 0.7);
+  font-size: 14px;
+  text-decoration: none;
+  transition: color 0.2s ease-in-out;
+}
+
+.link:hover,
+.link:focus-visible {
+  color: rgba(242, 243, 245, 1);
+  outline: none;
+}
+
+.locationWrapper {
+  margin-left: auto;
+  display: flex;
+  align-items: flex-start;
+}
+
+.location {
+  font-size: 18px;
+  font-weight: 600;
+  color: rgba(242, 243, 245, 1);
+}
+
+.bottomRow {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: clamp(16px, 3vw, 24px);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.copyright {
+  font-size: 12px;
+  color: rgba(242, 243, 245, 0.6);
+}
+
+@media (max-width: 768px) {
+  .topRow {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .locationWrapper {
+    margin-left: 0;
+  }
+
+  .bottomRow {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 480px) {
+  .footer {
+    padding: 28px 20px;
+  }
+
+  .column {
+    min-width: 140px;
+  }
+
+  .location {
+    font-size: 16px;
+  }
+
+  .copyright {
+    font-size: 11px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable footer component with the required sections and placeholder links
- style the footer to match the provided design and ensure responsive behavior
- include the footer in the main application layout so it appears on every page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db1491d5f48327b036ec6e257105e0