### PR TITLE
feat: enlarge color picker

### DIFF
--- a/mgm-front/src/components/ColorPopover.jsx
+++ b/mgm-front/src/components/ColorPopover.jsx
@@ -7,7 +7,7 @@ const EYEDROPPER_ICON_SRC = resolveIconAsset("tintero.svg", {
   fallbackToPublic: false,
 });
 
-const PICKER_SCALE = 0.5;
+const PICKER_SCALE = 1;
 const PICKER_BASE_WIDTH = 320;
 const PICKER_BASE_HEIGHT = 416;
 const DEFAULT_COLOR = "#ffffff";

--- a/mgm-front/src/components/EditorCanvas.module.css
+++ b/mgm-front/src/components/EditorCanvas.module.css
@@ -1,5 +1,5 @@
 .colorPickerWrapper {
-  --picker-scale: 0.65;
+  --picker-scale: 1;
   position: relative;
   display: inline-block;
   overflow: visible;


### PR DESCRIPTION
## Summary
- double the color picker scale so the popover renders at full size
- align the default picker scale CSS variable with the updated component value to keep dimensions consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db15b354788327b6a570d5e34d1891