### PR TITLE
Refresh mockup testimonials section

### DIFF
--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -19,6 +19,26 @@ const CART_STATUS_LABELS = {
   opening: 'Abriendo producto…',
 };
 
+const TESTIMONIAL_IMAGES = ['testimonio1', 'testimonio2', 'testimonio3'];
+
+const BENEFITS = [
+  {
+    icon: '🎁',
+    title: 'Regalos sorpresa en cada pedido',
+    description: 'Detalles pensados para vos y tu comunidad en cada envío.',
+  },
+  {
+    icon: '💪',
+    title: 'Durabilidad y calidad garantizada',
+    description: 'Hechos a mano, con materiales premium y testeados por creadores.',
+  },
+  {
+    icon: '🎨',
+    title: 'Un mousepad que se adapta a tu setup',
+    description: 'Elegí tamaño, material y diseño para que combine con tu espacio.',
+  },
+];
+
 
 export default function Mockup() {
   const flow = useFlow();
@@ -759,6 +779,9 @@ export default function Mockup() {
           ) : null}
 
         </div>
+        <p className={styles.discountBadge}>
+          Aprovechá un 20% off pagando en transferencia bancaria
+        </p>
         <div className={styles.ctaRow}>
           <div className={styles.ctaCard}>
             <button
@@ -808,6 +831,36 @@ export default function Mockup() {
             </p>
           </div>
         </div>
+        <section className={styles.communitySection}>
+          <h2 className={styles.communityTitle}>
+            Nos encantaría que formes parte de nuestra comunidad
+          </h2>
+          <p className={styles.communitySubtitle}>por eso vamos a convencerte</p>
+          <div className={styles.testimonialsGrid}>
+            {TESTIMONIAL_IMAGES.map((image) => (
+              <figure key={image} className={styles.testimonialCard}>
+                <div className={styles.testimonialImageWrapper}>
+                  <img
+                    src={`/mockup/${image}.jpg`}
+                    alt={`Testimonio de cliente ${image.replace('testimonio', '')}`}
+                    loading="lazy"
+                  />
+                </div>
+              </figure>
+            ))}
+          </div>
+          <div className={styles.benefitsGrid}>
+            {BENEFITS.map((benefit) => (
+              <article key={benefit.title} className={styles.benefitCard}>
+                <span aria-hidden="true" className={styles.benefitIcon}>
+                  {benefit.icon}
+                </span>
+                <h3 className={styles.benefitTitle}>{benefit.title}</h3>
+                <p className={styles.benefitDescription}>{benefit.description}</p>
+              </article>
+            ))}
+          </div>
+        </section>
         <button
           type="button"
           disabled={busy}
@@ -827,10 +880,9 @@ export default function Mockup() {
           Descargar PDF
         </button>
       </main>
-      <section className={styles.footerSection}>
-        <p className={styles.footerMessage}>
-          Nos encantaría que seas parte nuestra comunidad y por eso quiero convencerte 😎
-        </p>
+      <section className={styles.marketingSection}>
+        <h2 className={styles.marketingTitle}>Nuestro mejor marketing</h2>
+        <p className={styles.marketingSubtitle}>nuestros clientes</p>
       </section>
       {isBuyPromptOpen ? (
         <div

--- a/mgm-front/src/pages/Mockup.module.css
+++ b/mgm-front/src/pages/Mockup.module.css
@@ -88,6 +88,22 @@
   box-shadow: var(--shadow);
 }
 
+.discountBadge {
+  margin: clamp(12px, 3vh, 24px) auto clamp(24px, 5vh, 36px);
+  padding: 10px 22px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(242, 243, 245, 0.92);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
 .ctaRow {
   width: min(980px, 100%);
   display: grid;
@@ -175,18 +191,123 @@
   max-width: 320px;
 }
 
-.footerSection {
-  max-width: 1100px;
-  margin: clamp(28px, 6vh, 64px) auto 0;
+.communitySection {
+  width: min(1100px, 100%);
+  margin: clamp(48px, 10vh, 96px) auto 0;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 6vh, 48px);
+  align-items: center;
   text-align: center;
 }
 
-.footerMessage {
+.communityTitle {
   margin: 0;
-  font-size: clamp(22px, 3.2vw, 36px);
-  font-weight: 500;
+  font-size: clamp(26px, 4vw, 40px);
+  font-weight: 600;
   letter-spacing: 0.01em;
-  color: rgba(242, 243, 245, 0.92);
+  color: rgba(242, 243, 245, 0.96);
+}
+
+.communitySubtitle {
+  margin: 0;
+  font-size: 16px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(154, 160, 166, 0.9);
+}
+
+.testimonialsGrid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(16px, 3vw, 28px);
+}
+
+.testimonialCard {
+  margin: 0;
+  padding: clamp(12px, 3vw, 20px);
+  border-radius: calc(var(--radius) + 4px);
+  background: var(--surface);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow);
+}
+
+.testimonialImageWrapper {
+  position: relative;
+  width: 100%;
+  padding-top: 75%;
+  overflow: hidden;
+  border-radius: calc(var(--radius) - 2px);
+  background: rgba(15, 16, 17, 0.6);
+}
+
+.testimonialImageWrapper img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.benefitsGrid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(16px, 3vw, 28px);
+}
+
+.benefitCard {
+  background: rgba(18, 20, 22, 0.85);
+  border-radius: calc(var(--radius) + 2px);
+  padding: clamp(20px, 4vw, 28px);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: var(--shadow);
+}
+
+.benefitIcon {
+  font-size: 24px;
+}
+
+.benefitTitle {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: rgba(242, 243, 245, 0.98);
+}
+
+.benefitDescription {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: rgba(154, 160, 166, 0.92);
+}
+
+.marketingSection {
+  max-width: 1100px;
+  margin: clamp(48px, 10vh, 96px) auto 0;
+  text-align: center;
+}
+
+.marketingTitle {
+  margin: 0;
+  font-size: clamp(24px, 3.2vw, 36px);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: rgba(242, 243, 245, 0.96);
+}
+
+.marketingSubtitle {
+  margin: 8px 0 0;
+  font-size: clamp(26px, 4vw, 44px);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+  color: rgba(242, 243, 245, 0.82);
 }
 
 .hiddenButton {
@@ -335,6 +456,11 @@
   .ctaButton {
     width: 100%;
   }
+
+  .testimonialsGrid,
+  .benefitsGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 480px) {
@@ -358,6 +484,22 @@
 
   .ctaHint {
     font-size: 11.5px;
+  }
+
+  .discountBadge {
+    font-size: 13px;
+    width: 100%;
+    justify-content: center;
+  }
+
+  .testimonialsGrid,
+  .benefitsGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .benefitCard {
+    text-align: center;
+    align-items: center;
   }
 
   .modalTitle {


### PR DESCRIPTION
## Summary
- add a community and testimonials block to the mockup page with placeholders for the upcoming testimonio images
- refresh the marketing copy with a discount badge, benefits list, and updated footer headline to match the latest mockup
- extend the page styles to support the new testimonial grid, benefits cards, and responsive layout tweaks

## Testing
- npm run lint *(fails: /workspace/MGM-PERSONALIZADOS/mgm-front/src/lib/printsGate.js 11:12  error  'Buffer' is not defined  no-undef)*

------
https://chatgpt.com/codex/tasks/task_e_68db152f1c588327b489b13b20a51a94