### PR TITLE
Hide price when no image

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -907,28 +907,30 @@ export default function Home() {
 
           <div className={editorContainerClasses}>
             <div className={canvasStageClasses} ref={lienzoCardRef}>
-              <div className={styles.canvasPriceWrapper}>
-                <Calculadora
-                  width={activeSizeCm.w}
-                  height={activeSizeCm.h}
-                  material={material}
-                  setPrice={setPriceAmount}
-                  render={({ transfer, valid, format }) => {
-                    const amount = typeof transfer === 'number' ? Math.max(0, transfer) : 0;
-                    const formattedAmount = `$${format(amount)}`;
-                    const priceClasses = [styles.canvasPriceTag];
-                    if (!valid) {
-                      priceClasses.push(styles.canvasPriceTagDisabled);
-                    }
-                    return (
-                      <div className={priceClasses.join(' ')}>
-                        <span className={styles.canvasPriceAmount}>{formattedAmount}</span>
-                        <span className={styles.canvasPriceLabel}>Con transferencia</span>
-                      </div>
-                    );
-                  }}
-                />
-              </div>
+              {hasImage && (
+                <div className={styles.canvasPriceWrapper}>
+                  <Calculadora
+                    width={activeSizeCm.w}
+                    height={activeSizeCm.h}
+                    material={material}
+                    setPrice={setPriceAmount}
+                    render={({ transfer, valid, format }) => {
+                      const amount = typeof transfer === 'number' ? Math.max(0, transfer) : 0;
+                      const formattedAmount = `$${format(amount)}`;
+                      const priceClasses = [styles.canvasPriceTag];
+                      if (!valid) {
+                        priceClasses.push(styles.canvasPriceTagDisabled);
+                      }
+                      return (
+                        <div className={priceClasses.join(' ')}>
+                          <span className={styles.canvasPriceAmount}>{formattedAmount}</span>
+                          <span className={styles.canvasPriceLabel}>Con transferencia</span>
+                        </div>
+                      );
+                    }}
+                  />
+                </div>
+              )}
               <div className={styles.canvasViewport}>
 
                 <EditorCanvas


### PR DESCRIPTION
## Summary
- conditionally render the price banner in the editor only when an image has been uploaded

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db1968782c8327a0967f7372a0648b