### PR TITLE
Render footer only on mockup route

### DIFF
--- a/mgm-front/src/App.jsx
+++ b/mgm-front/src/App.jsx
@@ -1,9 +1,12 @@
-import { Link, Outlet } from 'react-router-dom';
+import { Link, Outlet, useLocation } from 'react-router-dom';
 import styles from './App.module.css';
 import SeoJsonLd from './components/SeoJsonLd';
 import Footer from './components/Footer';
 
 export default function App() {
+  const location = useLocation();
+  const shouldShowFooter = location.pathname === '/mockup';
+
   return (
     <div className={styles.container}>
       <SeoJsonLd />
@@ -16,7 +19,7 @@ export default function App() {
       <main className={styles.main}>
         <Outlet />
       </main>
-      <Footer />
+      {shouldShowFooter && <Footer />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- render the footer only when the /mockup route is active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db303e61f883278501c20137d973ff