### PR TITLE
Use continuar icon in options step submit button

### DIFF
--- a/mgm-front/src/components/OptionsStep.jsx
+++ b/mgm-front/src/components/OptionsStep.jsx
@@ -10,8 +10,10 @@ import {
 import styles from './OptionsStep.module.css';
 import { buildSubmitJobBody, prevalidateSubmitBody } from '../lib/jobPayload';
 import { submitJob } from '../lib/submitJob';
+import { resolveIconAsset } from '../lib/iconRegistry.js';
 
 const LOW_ACK_ERROR_MESSAGE = 'La calidad parece baja. Confirmá que aceptás continuar.';
+const CONTINUE_ICON_SRC = resolveIconAsset('continuar.svg');
 
 const Form = z.object({
   material: z.enum(['Classic','PRO','Glasspad']),
@@ -243,8 +245,15 @@ export default function OptionsStep({ uploaded, onSubmitted }) {
         className={styles.submitButton}
         disabled={busy || (level === 'bad' && !ackLow)}
         onClick={submit}
+        type="button"
       >
-        {busy ? 'Enviando…' : 'Continuar'}
+        {busy ? 'Enviando…' : (
+          <img
+            alt="Continuar"
+            className={styles.submitButtonIcon}
+            src={CONTINUE_ICON_SRC}
+          />
+        )}
       </button>
     </div>
   );

--- a/mgm-front/src/components/OptionsStep.module.css
+++ b/mgm-front/src/components/OptionsStep.module.css
@@ -36,4 +36,13 @@
 
 .submitButton {
   margin-top: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.submitButtonIcon {
+  width: 24px;
+  height: 24px;
+  display: block;
 }


### PR DESCRIPTION
## Summary
- import the continuar icon in the options step submit button
- render the icon when the form is idle and keep the busy text fallback
- adjust the button styles to center the icon

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db30a6d024832793a4b1e0b9eb3867