### PR TITLE
Fix stacking so config dropdown stays interactive

### DIFF
--- a/mgm-front/src/components/EditorCanvas.jsx
+++ b/mgm-front/src/components/EditorCanvas.jsx
@@ -1860,10 +1860,6 @@ const EditorCanvas = forwardRef(function EditorCanvas(
         )}
       </div>
 
-      {topLeftOverlay ? (
-        <div className={styles.overlayTopLeft}>{topLeftOverlay}</div>
-      ) : null}
-
       {showHistoryControls && (
         <div className={`${styles.overlayTopRight} ${styles.historyControls}`}>
           <button
@@ -2245,6 +2241,10 @@ const EditorCanvas = forwardRef(function EditorCanvas(
           </div>
         </div>
       </div>
+
+      {topLeftOverlay ? (
+        <div className={styles.overlayTopLeft}>{topLeftOverlay}</div>
+      ) : null}
     </div>
 
       {lastDiag && <p className={styles.errorBox}>{lastDiag}</p>}


### PR DESCRIPTION
## Summary
- render the config dropdown overlay after the bottom toolbar so it sits above it
- restore clickability of the series selector by preventing the toolbar from intercepting pointer events

## Testing
- npm run lint *(fails: existing issues in src/components/SizeControls.jsx and src/lib/printsGate.js)*

------
https://chatgpt.com/codex/tasks/task_e_68db2fe83d1083279bef8e7eee87a166