### PR TITLE
Show continuar text button on mobile

### DIFF
--- a/mgm-front/src/components/OptionsStep.jsx
+++ b/mgm-front/src/components/OptionsStep.jsx
@@ -10,8 +10,10 @@ import {
 import styles from './OptionsStep.module.css';
 import { buildSubmitJobBody, prevalidateSubmitBody } from '../lib/jobPayload';
 import { submitJob } from '../lib/submitJob';
+import { resolveIconAsset } from '../lib/iconRegistry.js';
 
 const LOW_ACK_ERROR_MESSAGE = 'La calidad parece baja. Confirmá que aceptás continuar.';
+const CONTINUE_ICON_SRC = resolveIconAsset('continuar.svg');
 
 const Form = z.object({
   material: z.enum(['Classic','PRO','Glasspad']),
@@ -243,8 +245,18 @@ export default function OptionsStep({ uploaded, onSubmitted }) {
         className={styles.submitButton}
         disabled={busy || (level === 'bad' && !ackLow)}
         onClick={submit}
+        type="button"
       >
-        {busy ? 'Enviando…' : 'Continuar'}
+        {busy ? 'Enviando…' : (
+          <>
+            <span className={styles.submitButtonText}>Continuar</span>
+            <img
+              alt="Continuar"
+              className={styles.submitButtonIcon}
+              src={CONTINUE_ICON_SRC}
+            />
+          </>
+        )}
       </button>
     </div>
   );

--- a/mgm-front/src/components/OptionsStep.module.css
+++ b/mgm-front/src/components/OptionsStep.module.css
@@ -36,4 +36,37 @@
 
 .submitButton {
   margin-top: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px;
+}
+
+.submitButtonIcon {
+  width: 24px;
+  height: 24px;
+  display: block;
+}
+
+.submitButtonText {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  .submitButton {
+    background-color: rgba(48, 93, 38, 0.2);
+    color: #305D26;
+    border-radius: 999px;
+    padding: 12px 24px;
+    font-weight: 600;
+  }
+
+  .submitButtonIcon {
+    display: none;
+  }
+
+  .submitButtonText {
+    display: inline;
+  }
 }


### PR DESCRIPTION
## Summary
- show the "Continuar" label alongside the continuar icon in the options step button
- adjust styles so the icon version appears on desktop while mobile keeps the green button treatment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db30a6d024832793a4b1e0b9eb3867