### PR TITLE
Fix material dropdown selection for touch input

### DIFF
--- a/mgm-front/src/components/SizeControls.jsx
+++ b/mgm-front/src/components/SizeControls.jsx
@@ -490,8 +490,8 @@ export default function SizeControls({ material, size, onChange, locked = false,
                   aria-selected={isActive}
                   className={styles.selectOption}
                   tabIndex={0}
-                  onMouseDown={(e) => {
-                    e.preventDefault();
+                  onPointerDown={(event) => {
+                    event.preventDefault();
                     if (disabled) return;
                     if (String(option.value) !== String(material)) {
                       onChange({ material: option.value });


### PR DESCRIPTION
## Summary
- handle material dropdown option selection via pointer events so touch taps update the material

## Testing
- npm run lint *(fails: pre-existing lint errors for unused variables and undefined Buffer)*

------
https://chatgpt.com/codex/tasks/task_e_68db355e810c832798af6a032e864455