### PR TITLE
feat: mostrar resumen de configuración sobre el precio

### DIFF
--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -918,13 +918,31 @@ export default function Home() {
                       const amount = typeof transfer === 'number' ? Math.max(0, transfer) : 0;
                       const formattedAmount = `$${format(amount)}`;
                       const priceClasses = [styles.canvasPriceTag];
+                      const widthValue = Number(activeSizeCm?.w);
+                      const heightValue = Number(activeSizeCm?.h);
+                      const hasDimensions =
+                        Number.isFinite(widthValue) && Number.isFinite(heightValue) && widthValue > 0 && heightValue > 0;
+                      const formatDimension = value => {
+                        if (!Number.isFinite(value)) return '';
+                        const hasDecimals = Math.abs(value - Math.trunc(value)) > 0.0001;
+                        return value.toLocaleString('es-AR', {
+                          minimumFractionDigits: hasDecimals ? 1 : 0,
+                          maximumFractionDigits: hasDecimals ? 1 : 1,
+                        });
+                      };
+                      const summaryLabel = hasDimensions
+                        ? `${material}/${formatDimension(widthValue)}x${formatDimension(heightValue)}`
+                        : material;
                       if (!valid) {
                         priceClasses.push(styles.canvasPriceTagDisabled);
                       }
                       return (
                         <div className={priceClasses.join(' ')}>
-                          <span className={styles.canvasPriceAmount}>{formattedAmount}</span>
-                          <span className={styles.canvasPriceLabel}>Con transferencia</span>
+                          <span className={styles.canvasPriceSummary}>{summaryLabel}</span>
+                          <div className={styles.canvasPriceLine}>
+                            <span className={styles.canvasPriceAmount}>{formattedAmount}</span>
+                            <span className={styles.canvasPriceLabel}>Con transferencia</span>
+                          </div>
                         </div>
                       );
                     }}

--- a/mgm-front/src/pages/Home.module.css
+++ b/mgm-front/src/pages/Home.module.css
@@ -449,11 +449,30 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 12px;
   color: #f6f7fb;
   font-family: 'Poppins', sans-serif;
   letter-spacing: 0.01em;
   pointer-events: auto;
+}
+
+.canvasPriceSummary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 16px;
+  border-radius: 14px;
+  background: rgba(34, 35, 44, 0.86);
+  box-shadow: 0 10px 30px rgba(7, 7, 9, 0.55);
+  font-size: 18px;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.canvasPriceLine {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 10px;
 }
 
 .canvasPriceLabel {


### PR DESCRIPTION
## Summary
- añade un resumen del material y la medida seleccionada sobre el precio en el configurador
- alinea el monto con la etiqueta de transferencia en una sola línea y actualiza el estilo del módulo de precio

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db36daeca48327ba8eb828bb10f371