### PR TITLE
Adjust mobile size presets and series selection behavior

### DIFF
--- a/mgm-front/src/lib/printsGate.js
+++ b/mgm-front/src/lib/printsGate.js
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer';
+
 const STORAGE_KEY = 'MGM_prints_gate';
 export const PRINTS_GATE_PASSWORD = 'Spesia666';
 const DURATION_MS = 24 * 60 * 60 * 1000;

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -87,10 +87,7 @@ export default function Home() {
   const activeWcm = isGlasspad ? GLASSPAD_SIZE_CM.w : sizeCm.w;
   const activeHcm = isGlasspad ? GLASSPAD_SIZE_CM.h : sizeCm.h;
   const activeSizeCm = useMemo(() => ({ w: activeWcm, h: activeHcm }), [activeWcm, activeHcm]);
-  const lastSize = useRef({
-    Classic: { w: 90, h: 40 },
-    PRO: { w: 90, h: 40 },
-  });
+  const lastSize = useRef({});
 
   const glasspadInitRef = useRef(false);
   useEffect(() => {


### PR DESCRIPTION
## Summary
- filter the Classic preset list on small screens and hide quick sizes for Glasspad
- keep the series selector menu open between selections and ensure custom sizes persist between materials
- import Buffer for the prints gate helper to satisfy linting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbdfb545d883279cec16663a1a6aa9