### PR TITLE
Keep custom size when switching materials

### DIFF
--- a/mgm-front/src/components/SizeControls.jsx
+++ b/mgm-front/src/components/SizeControls.jsx
@@ -541,6 +541,7 @@ export default function SizeControls({ material, size, onChange, locked = false,
                     if (String(option.value) !== String(material)) {
                       onChange({ material: option.value });
                     }
+                    setSeriesOpen(true);
                   }}
                   onKeyDown={(event) => {
                     if (event.key === 'Enter' || event.key === ' ') {
@@ -549,6 +550,7 @@ export default function SizeControls({ material, size, onChange, locked = false,
                       if (String(option.value) !== String(material)) {
                         onChange({ material: option.value });
                       }
+                      setSeriesOpen(true);
                     }
                   }}
                 >

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -167,7 +167,8 @@ export default function Home() {
         return;
       }
       const lim = LIMITS[next.material];
-      const prev = lastSize.current[next.material] || size;
+      const stored = lastSize.current[next.material];
+      const prev = mode === 'custom' || !stored ? size : stored;
       const clamped = {
         w: Math.min(Math.max(prev.w, 1), lim.maxW),
         h: Math.min(Math.max(prev.h, 1), lim.maxH),
@@ -178,6 +179,9 @@ export default function Home() {
         opt => Number(opt.w) === Number(clamped.w) && Number(opt.h) === Number(clamped.h)
       );
       setMode(isStd ? 'standard' : 'custom');
+      if (!stored || stored.w !== clamped.w || stored.h !== clamped.h) {
+        lastSize.current[next.material] = clamped;
+      }
       return;
     }
     if (next.mode && next.mode !== mode) {


### PR DESCRIPTION
## Summary
- preserve the active custom dimensions when switching between Classic and PRO and clamp them to the new limits
- keep the series selector dropdown open after choosing a material option

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbe691804c8327aba75ea905fad3d4