### PR TITLE
Prevent config panel from closing when selecting material

### DIFF
--- a/mgm-front/src/components/SizeControls.jsx
+++ b/mgm-front/src/components/SizeControls.jsx
@@ -525,6 +525,9 @@ export default function SizeControls({ material, size, onChange, locked = false,
             className={styles.selectMenu}
             style={floatingMenuStyle}
             ref={seriesMenuRef}
+            onPointerDown={(event) => {
+              event.stopPropagation();
+            }}
           >
             {MATERIAL_OPTIONS.map((option) => {
               const isActive = material === option.value;


### PR DESCRIPTION
## Summary
- stop pointer events from the series menu bubbling up to the document
- keep the configuration panel open while switching between material options

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc0ef978dc8327842d6c6c0bef7bd4