### PR TITLE
Close series dropdown after selection

### DIFF
--- a/mgm-front/src/components/SizeControls.jsx
+++ b/mgm-front/src/components/SizeControls.jsx
@@ -552,7 +552,7 @@ export default function SizeControls({ material, size, onChange, locked = false,
                     if (String(option.value) !== String(material)) {
                       onChange({ material: option.value });
                     }
-                    setSeriesOpen(true);
+                    setSeriesOpen(false);
                   }}
                   onKeyDown={(event) => {
                     if (event.key === 'Enter' || event.key === ' ') {
@@ -561,7 +561,7 @@ export default function SizeControls({ material, size, onChange, locked = false,
                       if (String(option.value) !== String(material)) {
                         onChange({ material: option.value });
                       }
-                      setSeriesOpen(true);
+                      setSeriesOpen(false);
                     }
                   }}
                 >


### PR DESCRIPTION
## Summary
- close the Serie dropdown after a material option is chosen so it collapses automatically

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc160255748327b3f0ded346573ff4