### PR TITLE
Ensure Serie dropdown closes after option click

### DIFF
--- a/mgm-front/src/components/SizeControls.jsx
+++ b/mgm-front/src/components/SizeControls.jsx
@@ -539,6 +539,13 @@ export default function SizeControls({ material, size, onChange, locked = false,
           >
             {MATERIAL_OPTIONS.map((option) => {
               const isActive = material === option.value;
+              const closeSeriesMenu = () => {
+                if (disabled) return;
+                if (String(option.value) !== String(material)) {
+                  onChange({ material: option.value });
+                }
+                setSeriesOpen(false);
+              };
               return (
                 <div
                   role="option"
@@ -546,22 +553,14 @@ export default function SizeControls({ material, size, onChange, locked = false,
                   aria-selected={isActive}
                   className={styles.selectOption}
                   tabIndex={0}
-                  onPointerDown={(event) => {
+                  onClick={(event) => {
                     event.preventDefault();
-                    if (disabled) return;
-                    if (String(option.value) !== String(material)) {
-                      onChange({ material: option.value });
-                    }
-                    setSeriesOpen(true);
+                    closeSeriesMenu();
                   }}
                   onKeyDown={(event) => {
                     if (event.key === 'Enter' || event.key === ' ') {
                       event.preventDefault();
-                      if (disabled) return;
-                      if (String(option.value) !== String(material)) {
-                        onChange({ material: option.value });
-                      }
-                      setSeriesOpen(true);
+                      closeSeriesMenu();
                     }
                   }}
                 >


### PR DESCRIPTION
## Summary
- update Serie dropdown options to close the menu on click or keyboard activation while preserving other logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc160255748327b3f0ded346573ff4