### PR TITLE
Show editor label only on home page

### DIFF
--- a/mgm-front/src/App.jsx
+++ b/mgm-front/src/App.jsx
@@ -14,7 +14,7 @@ export default function App() {
         <Link to="/" className={styles.brand}>
           MGM GAMERS®
         </Link>
-        <span>EDITOR</span>
+        {location.pathname === '/' && <span>EDITOR</span>}
       </header>
       <main className={styles.main}>
         <Outlet />


### PR DESCRIPTION
## Summary
- render the EDITOR label in the navbar only when the current route is the home page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc5d9a2c8083279cec547634c68516