### PR TITLE
Handle large publish-product payloads

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1,8 +1,10 @@
 import { shopifyAdmin, shopifyAdminGraphQL } from '../shopify.js';
 import { buildProductUrl } from '../publicStorefront.js';
 import { publishToOnlineStore, resolveOnlineStorePublicationId } from '../shopify/publication.js';
+import { parseJsonBody } from '../_lib/http.js';
 
 const DEFAULT_VENDOR = 'MgMGamers';
+const PUBLISH_PRODUCT_BODY_LIMIT = 6 * 1024 * 1024; // 6 MiB
 const ONLINE_STORE_MISSING_MESSAGE = [
   'No pudimos encontrar el canal Online Store para publicar este producto.',
   'Revisá: 1) que el canal esté instalado, 2) que la app tenga el scope write_publications.',
@@ -12,14 +14,6 @@ const ONLINE_STORE_DISABLED_MESSAGE = 'Tu tienda no tiene el canal Online Store 
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
-}
-
-function ensureBody(body) {
-  if (body && typeof body === 'object') return body;
-  if (typeof body === 'string') {
-    try { return JSON.parse(body) || {}; } catch { return {}; }
-  }
-  return {};
 }
 
 function toNumber(value) {
@@ -1710,7 +1704,20 @@ export async function publishProduct(req, res) {
       });
     }
 
-    const body = ensureBody(req.body);
+    let body;
+    try {
+      body = await parseJsonBody(req, { limit: PUBLISH_PRODUCT_BODY_LIMIT });
+    } catch (err) {
+      const code = err?.code === 'payload_too_large' ? 'payload_too_large'
+        : err?.code === 'invalid_json' ? 'invalid_body'
+          : 'invalid_body';
+      const status = err?.code === 'payload_too_large' ? 413 : 400;
+      const message = err?.code === 'payload_too_large'
+        ? 'El mockup es demasiado grande. Probá de nuevo con una imagen más liviana.'
+        : 'El cuerpo de la petición es inválido.';
+      return res.status(status).json({ ok: false, reason: code, message });
+    }
+    body = body && typeof body === 'object' ? body : {};
 
     const mockupDataUrl = typeof body.mockupDataUrl === 'string' ? body.mockupDataUrl : '';
     const filename = typeof body.filename === 'string' && body.filename ? body.filename : 'mockup.png';


### PR DESCRIPTION
## Summary
- parse the publish-product request body with an increased 6 MiB limit so large mockup data URLs are preserved
- return explicit errors when the request payload is too large or invalid instead of silently accepting an empty body

## Testing
- npm test *(fails: evaluateImage blocks nazi symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68dd51c5fef88327aa77793ba9f0297a