### PR TITLE
Handle non-PDF preview files

### DIFF
--- a/lib/api/handlers/printsPreview.js
+++ b/lib/api/handlers/printsPreview.js
@@ -81,23 +81,41 @@ export default async function printsPreviewHandler(req, res) {
     return;
   }
 
-  const pdfBuffer = await toBuffer(data);
-  if (!pdfBuffer.length) {
-    res.status(500).json({ ok: false, reason: 'empty_pdf', message: 'El PDF descargado está vacío.' });
+  const fileBuffer = await toBuffer(data);
+  if (!fileBuffer.length) {
+    res.status(500).json({ ok: false, reason: 'empty_file', message: 'El archivo descargado está vacío.' });
     return;
   }
 
-  try {
-    const image = await sharp(pdfBuffer, { density: DEFAULT_PREVIEW_DENSITY })
-      .resize({ width: DEFAULT_PREVIEW_WIDTH, fit: 'inside', withoutEnlargement: true })
-      .png({ compressionLevel: 8, adaptiveFiltering: true })
-      .toBuffer();
+  const lowerPath = storagePath.toLowerCase();
+  const isPdf = lowerPath.endsWith('.pdf');
+  const isImage = /(\.png|\.jpg|\.jpeg|\.webp)$/.test(lowerPath);
 
-    res.setHeader('Content-Type', 'image/png');
-    res.setHeader('Cache-Control', 'public, max-age=300, immutable');
-    res.status(200).end(image);
-  } catch (err) {
-    console.error('[prints-preview] generate_failed', err);
-    res.status(500).json({ ok: false, reason: 'preview_generation_failed', message: 'No se pudo generar el preview.' });
+  if (isPdf) {
+    try {
+      const image = await sharp(fileBuffer, { density: DEFAULT_PREVIEW_DENSITY })
+        .resize({ width: DEFAULT_PREVIEW_WIDTH, fit: 'inside', withoutEnlargement: true })
+        .png({ compressionLevel: 8, adaptiveFiltering: true })
+        .toBuffer();
+
+      res.setHeader('Content-Type', 'image/png');
+      res.setHeader('Cache-Control', 'public, max-age=300, immutable');
+      res.status(200).end(image);
+      return;
+    } catch (err) {
+      console.error('[prints-preview] generate_failed', err);
+      res.status(500).json({ ok: false, reason: 'preview_generation_failed', message: 'No se pudo generar el preview.' });
+      return;
+    }
   }
+
+  if (isImage) {
+    const extension = lowerPath.endsWith('.png') ? 'png' : lowerPath.endsWith('.webp') ? 'webp' : 'jpeg';
+    res.setHeader('Content-Type', `image/${extension}`);
+    res.setHeader('Cache-Control', 'public, max-age=300, immutable');
+    res.status(200).end(fileBuffer);
+    return;
+  }
+
+  res.status(415).json({ ok: false, reason: 'unsupported_format', message: 'Formato de archivo no soportado para preview.' });
 }


### PR DESCRIPTION
## Summary
- avoid running Sharp on preview images downloaded from Supabase and return them directly with the proper headers
- preserve the PDF preview generation path while improving error messaging for empty downloads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddbb891ff48327853938423e5e250a