### PR TITLE
Add Storefront checkout flow for private purchases

### DIFF
--- a/lib/handlers/privateCheckout.js
+++ b/lib/handlers/privateCheckout.js
@@ -4,13 +4,8 @@ import {
   resolveVariantIds,
   normalizeCartAttributes,
   normalizeCartNote,
-  createStorefrontCart,
-  buildCartPermalink,
 } from '../shopify/cartHelpers.js';
-import { shopifyAdminGraphQL, shopifyAdmin } from '../shopify.js';
-
-const REQUIRED_SCOPES = ['write_draft_orders', 'read_products'];
-const REQUIRED_API_VERSION = '2024-07';
+import { shopifyStorefrontGraphQL } from '../shopify.js';
 
 function safeLog(method, label, payload) {
   try {
@@ -41,10 +36,6 @@ function sendJson(res, status, body) {
   } else {
     res.statusCode = status;
   }
-  safeInfo('private_checkout_response', {
-    status,
-    contentType: typeof res.getHeader === 'function' ? res.getHeader('Content-Type') || contentType : contentType,
-  });
   const payload = body ?? {};
   if (typeof res.json === 'function') {
     res.json(payload);
@@ -55,15 +46,26 @@ function sendJson(res, status, body) {
   }
 }
 
+const LineInputSchema = z
+  .object({
+    variantId: z.union([z.string(), z.number()]).optional(),
+    variantGid: z.union([z.string(), z.number()]).optional(),
+    quantity: z.union([z.string(), z.number()]).optional(),
+  })
+  .passthrough();
+
 const BodySchema = z
   .object({
     variantId: z.union([z.string(), z.number()]).optional(),
     variantGid: z.union([z.string(), z.number()]).optional(),
     quantity: z.union([z.string(), z.number()]).optional(),
+    lines: z.array(LineInputSchema).optional(),
     email: z.string().email().optional(),
     note: z.any().optional(),
     attributes: z.any().optional(),
     noteAttributes: z.any().optional(),
+    discountCode: z.string().optional(),
+    discount: z.string().optional(),
     productHandle: z.union([z.string(), z.number()]).optional(),
   })
   .passthrough();
@@ -74,35 +76,17 @@ function normalizeQuantity(value) {
   return Math.max(1, Math.min(99, Math.floor(raw)));
 }
 
-function resolveMode() {
-  return 'draft_order';
-}
-
-const DRAFT_ORDER_CREATE_MUTATION = `
-  mutation DraftOrderCreate($input: DraftOrderInput!) {
-    draftOrderCreate(input: $input) {
-      draftOrder {
+const CHECKOUT_CREATE_MUTATION = `
+  mutation PrivateCheckoutCreate($input: CheckoutCreateInput!) {
+    checkoutCreate(input: $input) {
+      checkout {
         id
-        invoiceUrl
+        webUrl
       }
-      userErrors {
-        field
+      checkoutUserErrors {
         message
-      }
-    }
-  }
-`;
-
-const DRAFT_ORDER_INVOICE_SEND_MUTATION = `
-  mutation DraftOrderInvoiceSend($id: ID!, $input: DraftOrderInvoiceInput!) {
-    draftOrderInvoiceSend(id: $id, input: $input) {
-      draftOrder {
-        id
-        invoiceUrl
-      }
-      userErrors {
+        code
         field
-        message
       }
     }
   }
@@ -128,457 +112,238 @@ function parseJsonMaybe(text) {
   }
 }
 
-function formatUserErrors(rawErrors) {
-  if (!Array.isArray(rawErrors)) return [];
-  return rawErrors
+function normalizeLineInput(entry, fallbackQuantity) {
+  if (!entry || typeof entry !== 'object') return null;
+  const { variantId, variantGid, quantity } = entry;
+  const resolved = resolveVariantIds({ variantId, variantGid });
+  const variantNumericId = resolved.variantNumericId;
+  const ensuredGid = resolved.variantGid;
+  if (!variantNumericId && !ensuredGid) return null;
+  const qty = normalizeQuantity(quantity ?? fallbackQuantity ?? 1);
+  return {
+    variantNumericId,
+    variantGid: ensuredGid || (variantNumericId ? `gid://shopify/ProductVariant/${variantNumericId}` : ''),
+    quantity: qty,
+  };
+}
+
+function buildLinesFromBody(data) {
+  const normalized = [];
+  const candidateLines = Array.isArray(data.lines) ? data.lines : [];
+  for (const entry of candidateLines) {
+    const line = normalizeLineInput(entry, data.quantity);
+    if (line && line.variantGid) {
+      normalized.push(line);
+    }
+    if (normalized.length >= 99) break;
+  }
+  if (!normalized.length) {
+    const fallback = normalizeLineInput(
+      { variantId: data.variantId, variantGid: data.variantGid, quantity: data.quantity },
+      data.quantity,
+    );
+    if (fallback && fallback.variantGid) {
+      normalized.push(fallback);
+    }
+  }
+  return normalized;
+}
+
+function interpretUserErrors(rawErrors) {
+  if (!Array.isArray(rawErrors)) return { userErrors: [], reason: 'storefront_user_errors' };
+  const userErrors = rawErrors
     .map((entry) => {
       if (!entry || typeof entry !== 'object') return null;
       const message = typeof entry.message === 'string' ? entry.message.trim() : '';
-      if (!message) return null;
-      const code = typeof entry.code === 'string' ? entry.code : undefined;
+      const codeRaw = typeof entry.code === 'string' ? entry.code : '';
       const field = Array.isArray(entry.field)
-        ? entry.field.map((item) => String(item)).filter(Boolean)
+        ? entry.field.map((value) => (value == null ? '' : String(value))).filter(Boolean)
         : undefined;
+      if (!message && !codeRaw) return null;
       return {
-        message,
-        ...(code ? { code } : {}),
+        ...(message ? { message } : {}),
+        ...(codeRaw ? { code: codeRaw } : {}),
         ...(field && field.length ? { field } : {}),
       };
     })
     .filter(Boolean);
-}
+  if (!userErrors.length) return { userErrors: [], reason: 'storefront_user_errors' };
 
-function formatGraphQLErrors(rawErrors) {
-  if (!Array.isArray(rawErrors)) return [];
-  return rawErrors
-    .map((entry) => {
-      if (!entry || typeof entry !== 'object') return null;
-      const message = typeof entry.message === 'string' ? entry.message.trim() : '';
-      const code = typeof entry.code === 'string'
-        ? entry.code
-        : typeof entry?.extensions?.code === 'string'
-          ? entry.extensions.code
-          : undefined;
-      if (!message && !code) return null;
-      return {
-        ...(message ? { message } : {}),
-        ...(code ? { code } : {}),
-      };
-    })
+  const normalizedCodes = userErrors
+    .map((err) => (typeof err.code === 'string' ? err.code.toUpperCase() : ''))
     .filter(Boolean);
-}
-
-function readScopesFromEnv() {
-  const candidates = [
-    'SHOPIFY_API_SCOPES',
-    'SHOPIFY_SCOPES',
-    'SHOPIFY_APP_SCOPES',
-    'SHOPIFY_ADMIN_SCOPES',
-    'SHOPIFY_ADMIN_API_SCOPES',
-  ];
-  for (const name of candidates) {
-    if (!name) continue;
-    const raw = typeof process.env[name] === 'string' ? process.env[name].trim() : '';
-    if (raw) return raw;
-  }
-  return '';
-}
-
-function parseScopes(raw) {
-  if (!raw) return [];
-  return raw
-    .split(/[\s,]+/)
-    .map((scope) => scope.trim())
+  const normalizedMessages = userErrors
+    .map((err) => (typeof err.message === 'string' ? err.message.toLowerCase() : ''))
     .filter(Boolean);
-}
 
-async function fetchAdminAccessScopes() {
-  let resp;
-  try {
-    resp = await shopifyAdmin('oauth/access_scopes.json', { method: 'GET' });
-  } catch (err) {
-    if (err?.message === 'SHOPIFY_ENV_MISSING') {
-      return { ok: false, reason: 'shopify_env_missing', missing: err.missing };
-    }
-    safeWarn('private_checkout_scope_fetch_exception', {
-      message: typeof err?.message === 'string' ? err.message : undefined,
-    });
-    return { ok: false, reason: 'request_failed' };
-  }
-  const requestId = readRequestId(resp);
-  const textBody = await resp.text();
-  const json = parseJsonMaybe(textBody);
-  if (!resp.ok) {
-    safeWarn('private_checkout_scope_fetch_http_error', {
-      status: resp.status,
-      requestId: requestId || null,
-    });
+  if (normalizedCodes.some((code) => code.includes('DISCOUNT')) || normalizedMessages.some((msg) => msg.includes('discount'))) {
     return {
-      ok: false,
-      reason: 'http_error',
-      status: resp.status,
-      requestId,
-      body: textBody?.slice(0, 1000),
-    };
-  }
-  if (!json || typeof json !== 'object') {
-    safeWarn('private_checkout_scope_fetch_invalid', {
-      requestId: requestId || null,
-    });
-    return { ok: false, reason: 'invalid_response', requestId };
-  }
-  const scopes = Array.isArray(json.access_scopes)
-    ? json.access_scopes
-        .map((entry) => {
-          if (!entry) return '';
-          if (typeof entry === 'string') return entry;
-          if (typeof entry.handle === 'string') return entry.handle;
-          return '';
-        })
-        .filter(Boolean)
-    : [];
-  safeInfo('private_checkout_access_scopes', {
-    requestId: requestId || null,
-    scopesCount: scopes.length,
-  });
-  return { ok: true, scopes, requestId };
-}
-
-async function ensureShopifyRequirements() {
-  const scopesRaw = readScopesFromEnv();
-  const scopes = new Set(parseScopes(scopesRaw).map((scope) => scope.toLowerCase()));
-  let missingScopes = REQUIRED_SCOPES.filter((scope) => !scopes.has(scope));
-  let scopeSource = scopesRaw ? 'env' : 'unknown';
-  let scopeRequestId;
-  if (missingScopes.length) {
-    const accessScopes = await fetchAdminAccessScopes();
-    if (accessScopes.ok) {
-      const accessSet = new Set(accessScopes.scopes.map((scope) => scope.toLowerCase()));
-      missingScopes = REQUIRED_SCOPES.filter((scope) => !accessSet.has(scope));
-      scopeSource = 'api';
-      scopeRequestId = accessScopes.requestId;
-    } else if (accessScopes.reason === 'shopify_env_missing') {
-      return { ok: false, reason: 'shopify_env_missing', missing: accessScopes.missing };
-    } else {
-      scopeRequestId = accessScopes.requestId;
-      safeWarn('private_checkout_scope_probe_failed', {
-        reason: accessScopes.reason || 'unknown',
-        status: accessScopes.status,
-        requestId: scopeRequestId || null,
-      });
-      // No pudimos confirmar scopes; en entornos locales permitimos continuar para usar el fallback.
-      missingScopes = [];
-      if (scopeSource !== 'env') scopeSource = 'probe_failed';
-    }
-  }
-  const apiVersionRaw = typeof process.env.SHOPIFY_API_VERSION === 'string'
-    ? process.env.SHOPIFY_API_VERSION.trim()
-    : '';
-  const hasVersion = Boolean(apiVersionRaw);
-  const versionMismatch = hasVersion && apiVersionRaw !== REQUIRED_API_VERSION;
-  if (missingScopes.length || !hasVersion || versionMismatch) {
-    safeWarn('private_checkout_env_error', {
-      missingScopes: missingScopes.length ? missingScopes : undefined,
-      apiVersion: apiVersionRaw || null,
-      requiredVersion: REQUIRED_API_VERSION,
-      hasVersion,
-      versionMismatch,
-      scopeSource,
-      scopeRequestId: scopeRequestId || undefined,
-    });
-    return {
-      ok: false,
-      missingScopes,
-      apiVersion: apiVersionRaw,
-      hasVersion,
-      versionMismatch,
-      scopeSource,
-      scopeRequestId,
-    };
-  }
-  return { ok: true };
-}
-
-async function attemptStorefrontCheckoutFallback({ req, variantGid, quantity, note, attributes, email }) {
-  if (!variantGid) {
-    return { ok: false, reason: 'missing_variant_gid' };
-  }
-
-  const baseAttributes = Array.isArray(attributes)
-    ? attributes
-        .map((attr) => {
-          if (!attr || typeof attr !== 'object') return null;
-          const key = typeof attr.key === 'string' ? attr.key : typeof attr.name === 'string' ? attr.name : '';
-          if (!key) return null;
-          const value = typeof attr.value === 'string' ? attr.value : attr.value == null ? '' : String(attr.value);
-          return { key, value };
-        })
-        .filter(Boolean)
-    : [];
-
-  const fallbackAttributes = baseAttributes.slice();
-  const pushAttr = (key, value) => {
-    if (!key || typeof key !== 'string') return;
-    const trimmedKey = key.trim();
-    if (!trimmedKey) return;
-    fallbackAttributes.push({ key: trimmedKey, value: value == null ? '' : String(value) });
-  };
-
-  pushAttr('mgm_source', 'private-fallback');
-  if (email) {
-    pushAttr('customer_email', email);
-  }
-
-  const normalizedFallbackAttributes = normalizeCartAttributes(fallbackAttributes);
-
-  const buyerIp = (() => {
-    try {
-      return getClientIp(req);
-    } catch {
-      return undefined;
-    }
-  })();
-
-  let fallbackResult;
-  try {
-    fallbackResult = await createStorefrontCart({
-      variantGid,
-      quantity,
-      note,
-      attributes: normalizedFallbackAttributes,
-      buyerIp,
-    });
-  } catch (err) {
-    safeWarn('private_checkout_storefront_fallback_exception', {
-      message: typeof err?.message === 'string' ? err.message : undefined,
-    });
-    return { ok: false, reason: 'exception' };
-  }
-
-  if (fallbackResult?.ok && fallbackResult.checkoutUrl) {
-    safeInfo('private_checkout_storefront_fallback_success', {
-      cartId: fallbackResult.cartId || null,
-      checkoutUrl: fallbackResult.checkoutPlain || fallbackResult.checkoutUrl || null,
-      requestId: fallbackResult.requestId || null,
-    });
-    return {
-      ok: true,
-      url: fallbackResult.checkoutUrl,
-      cartUrl: fallbackResult.cartUrl,
-      requestId: fallbackResult.requestId,
+      userErrors,
+      reason: 'discount_code_invalid',
+      friendlyMessage:
+        'El código de descuento no es válido. Podés continuar sin cupón o probar con otro.',
     };
   }
 
-  safeWarn('private_checkout_storefront_fallback_failed', {
-    reason: fallbackResult?.reason || 'unknown',
-    status: fallbackResult?.status,
-    requestId: fallbackResult?.requestId || null,
-  });
-
-  if (fallbackResult?.reason === 'storefront_env_missing') {
-    return { ok: false, reason: 'storefront_env_missing', missing: fallbackResult.missing };
+  if (
+    normalizedCodes.some((code) => code.includes('UNAVAILABLE') || code.includes('NOT_AVAILABLE')) ||
+    normalizedMessages.some(
+      (msg) =>
+        msg.includes('no está disponible') ||
+        msg.includes('not available') ||
+        msg.includes('unavailable') ||
+        msg.includes('cannot be purchased'),
+    )
+  ) {
+    return {
+      userErrors,
+      reason: 'product_not_published_storefront',
+      friendlyMessage: 'Producto no publicado en canal Storefront.',
+    };
   }
 
   return {
-    ok: false,
-    reason: fallbackResult?.reason || 'unknown',
-    status: fallbackResult?.status,
-    requestId: fallbackResult?.requestId,
+    userErrors,
+    reason: 'storefront_user_errors',
+    friendlyMessage: 'No pudimos generar el checkout privado. Probá de nuevo en unos segundos.',
   };
 }
 
-function buildDraftOrderInput({ variantGid, quantity, note, attributes, email }) {
-  const qty = normalizeQuantity(quantity);
+async function createStorefrontCheckout({ lines, email, note, attributes, discountCode, buyerIp }) {
+  if (!Array.isArray(lines) || !lines.length) {
+    return { ok: false, reason: 'missing_lines' };
+  }
+  const lineItems = lines
+    .map((line) => {
+      if (!line?.variantGid) return null;
+      return {
+        variantId: line.variantGid,
+        quantity: line.quantity,
+      };
+    })
+    .filter(Boolean);
+  if (!lineItems.length) {
+    return { ok: false, reason: 'missing_lines' };
+  }
+
+  const normalizedAttributes = normalizeCartAttributes(attributes);
+  if (email) {
+    const hasEmailAttribute = normalizedAttributes.some(
+      (attr) => typeof attr?.key === 'string' && attr.key.toLowerCase() === 'customer_email',
+    );
+    if (!hasEmailAttribute && normalizedAttributes.length < 30) {
+      normalizedAttributes.push({ key: 'customer_email', value: email });
+    }
+  }
+
   const input = {
-    lineItems: [
-      {
-        variantId: variantGid,
-        quantity: qty,
-      },
-    ],
-    tags: ['private', 'custom-mockup'],
+    lineItems,
   };
+
+  if (normalizedAttributes.length) {
+    input.customAttributes = normalizedAttributes.map(({ key, value }) => ({ key, value }));
+  }
+
   const noteValue = normalizeCartNote(note);
   if (noteValue) {
     input.note = noteValue;
   }
-  if (email) {
-    input.email = email;
-  }
-  if (Array.isArray(attributes) && attributes.length) {
-    input.customAttributes = attributes.map((attr) => ({ key: attr.key, value: attr.value }));
-  }
-  return input;
-}
 
-async function createDraftOrder({ variantGid, quantity, note, attributes, email }) {
-  if (!variantGid) {
-    return { ok: false, reason: 'missing_variant_gid' };
+  const normalizedDiscount = typeof discountCode === 'string' ? discountCode.trim() : '';
+  if (normalizedDiscount) {
+    input.discountCode = normalizedDiscount;
   }
-  const customAttributes = normalizeCartAttributes(attributes);
-  const input = buildDraftOrderInput({ variantGid, quantity, note, attributes: customAttributes, email });
-  safeInfo('draft_order_create_attempt', {
-    variantId: variantGid,
-    quantity: normalizeQuantity(quantity),
-    hasEmail: Boolean(email),
-    hasNote: Boolean(normalizeCartNote(note)),
-    attributesCount: Array.isArray(customAttributes) ? customAttributes.length : 0,
-  });
+
+  if (typeof email === 'string' && email.trim()) {
+    input.email = email.trim();
+  }
+
   let resp;
   try {
-    resp = await shopifyAdminGraphQL(DRAFT_ORDER_CREATE_MUTATION, { input });
+    resp = await shopifyStorefrontGraphQL(
+      CHECKOUT_CREATE_MUTATION,
+      { input },
+      buyerIp ? { buyerIp } : {},
+    );
   } catch (err) {
-    if (err?.message === 'SHOPIFY_ENV_MISSING') {
+    if (err?.message === 'SHOPIFY_STOREFRONT_ENV_MISSING') {
       return { ok: false, reason: 'shopify_env_missing', missing: err.missing };
     }
     throw err;
   }
-  const requestId = readRequestId(resp);
-  const textBody = await resp.text();
-  const json = parseJsonMaybe(textBody);
+
+  const requestId = readRequestId(resp) || undefined;
+  const rawBody = await resp.text();
+  const json = parseJsonMaybe(rawBody);
+
   if (!resp.ok) {
-    return {
-      ok: false,
-      reason: 'http_error',
+    safeWarn('private_checkout_http_error', {
       status: resp.status,
-      body: textBody?.slice(0, 2000),
+      bodyPreview: typeof rawBody === 'string' ? rawBody.slice(0, 500) : '',
+      requestId: requestId || null,
+    });
+    return {
+      ok: false,
+      reason: 'storefront_http_error',
+      status: resp.status,
+      body: typeof rawBody === 'string' ? rawBody.slice(0, 2000) : undefined,
       requestId,
     };
   }
+
   if (!json || typeof json !== 'object') {
-    return { ok: false, reason: 'invalid_response', requestId };
+    safeWarn('private_checkout_non_json', { requestId: requestId || null });
+    return { ok: false, reason: 'storefront_invalid_response', requestId };
   }
-  const graphqlErrors = Array.isArray(json.errors) ? json.errors : [];
-  if (graphqlErrors.length) {
-    const formattedErrors = formatGraphQLErrors(graphqlErrors);
-    safeWarn('draft_order_graphql_errors', {
+
+  if (Array.isArray(json.errors) && json.errors.length) {
+    safeWarn('private_checkout_graphql_errors', {
+      errors: json.errors,
       requestId: requestId || null,
-      errors: formattedErrors,
     });
-    return {
-      ok: false,
-      reason: 'graphql_errors',
-      errors: formattedErrors,
-      requestId,
-    };
+    return { ok: false, reason: 'storefront_graphql_errors', errors: json.errors, requestId };
   }
-  const payload = json?.data?.draftOrderCreate;
+
+  const payload = json?.data?.checkoutCreate;
   if (!payload || typeof payload !== 'object') {
-    return { ok: false, reason: 'invalid_response', requestId };
+    safeWarn('private_checkout_missing_payload', { requestId: requestId || null });
+    return { ok: false, reason: 'storefront_invalid_response', requestId };
   }
-  const userErrors = formatUserErrors(payload.userErrors);
-  if (userErrors.length) {
-    safeWarn('draft_order_user_errors', {
+
+  const interpretedErrors = interpretUserErrors(payload.checkoutUserErrors);
+  if (interpretedErrors.userErrors.length) {
+    safeWarn('private_checkout_user_errors', {
+      userErrors: interpretedErrors.userErrors,
       requestId: requestId || null,
-      userErrors,
+      reason: interpretedErrors.reason,
     });
     return {
       ok: false,
-      reason: 'user_errors',
-      userErrors,
+      reason: interpretedErrors.reason,
+      userErrors: interpretedErrors.userErrors,
+      friendlyMessage: interpretedErrors.friendlyMessage,
       requestId,
     };
   }
-  const draftOrder = payload.draftOrder && typeof payload.draftOrder === 'object' ? payload.draftOrder : null;
-  const draftOrderId = typeof draftOrder?.id === 'string' ? draftOrder.id : '';
-  if (!draftOrderId) {
-    return { ok: false, reason: 'missing_draft_order', requestId };
+
+  const checkout = payload.checkout && typeof payload.checkout === 'object' ? payload.checkout : null;
+  const webUrl = typeof checkout?.webUrl === 'string' ? checkout.webUrl.trim() : '';
+  if (!webUrl) {
+    safeWarn('private_checkout_missing_weburl', { requestId: requestId || null });
+    return { ok: false, reason: 'missing_checkout_url', requestId };
   }
-  const invoiceUrl = typeof draftOrder?.invoiceUrl === 'string' ? draftOrder.invoiceUrl.trim() : '';
-  safeInfo('draft_order_create_success', {
+
+  safeInfo('private_checkout_success', {
     requestId: requestId || null,
-    draftOrderId,
+    checkoutId: typeof checkout?.id === 'string' ? checkout.id : null,
   });
+
   return {
     ok: true,
-    draftOrderId,
-    invoiceUrl,
+    url: webUrl,
+    checkoutId: typeof checkout?.id === 'string' ? checkout.id : undefined,
     requestId,
   };
-}
-
-async function sendDraftOrderInvoice({ draftOrderId, email }) {
-  let resp;
-  try {
-    resp = await shopifyAdminGraphQL(DRAFT_ORDER_INVOICE_SEND_MUTATION, {
-      id: draftOrderId,
-      input: email ? { to: email } : {},
-    });
-  } catch (err) {
-    if (err?.message === 'SHOPIFY_ENV_MISSING') {
-      return { ok: false, reason: 'shopify_env_missing', missing: err.missing };
-    }
-    throw err;
-  }
-  const requestId = readRequestId(resp);
-  const textBody = await resp.text();
-  const json = parseJsonMaybe(textBody);
-  if (!resp.ok) {
-    return {
-      ok: false,
-      reason: 'invoice_http_error',
-      status: resp.status,
-      body: textBody?.slice(0, 2000),
-      requestId,
-    };
-  }
-  if (!json || typeof json !== 'object') {
-    return { ok: false, reason: 'invoice_invalid_response', requestId };
-  }
-  const graphqlErrors = Array.isArray(json.errors) ? json.errors : [];
-  if (graphqlErrors.length) {
-    const formattedErrors = formatGraphQLErrors(graphqlErrors);
-    safeWarn('draft_order_graphql_errors', {
-      requestId: requestId || null,
-      errors: formattedErrors,
-      phase: 'invoice_send',
-    });
-    return {
-      ok: false,
-      reason: 'invoice_graphql_errors',
-      errors: formattedErrors,
-      requestId,
-    };
-  }
-  const payload = json?.data?.draftOrderInvoiceSend;
-  if (!payload || typeof payload !== 'object') {
-    return { ok: false, reason: 'invoice_invalid_response', requestId };
-  }
-  const userErrors = formatUserErrors(payload.userErrors);
-  if (userErrors.length) {
-    safeWarn('draft_order_user_errors', {
-      requestId: requestId || null,
-      userErrors,
-      phase: 'invoice_send',
-    });
-    return {
-      ok: false,
-      reason: 'invoice_user_errors',
-      userErrors,
-      requestId,
-    };
-  }
-  const invoiceDraftOrder = payload.draftOrder && typeof payload.draftOrder === 'object' ? payload.draftOrder : null;
-  const invoiceUrl = typeof invoiceDraftOrder?.invoiceUrl === 'string' ? invoiceDraftOrder.invoiceUrl.trim() : '';
-  if (!invoiceUrl) {
-    return { ok: false, reason: 'missing_invoice_url', requestId };
-  }
-  safeInfo('draft_order_invoice_send_success', {
-    requestId: requestId || null,
-    invoiceUrl,
-  });
-  return {
-    ok: true,
-    invoiceUrl,
-    requestId,
-  };
-}
-
-function buildProductFallbackUrl(handle) {
-  if (typeof handle !== 'string') return '';
-  const normalized = handle.trim();
-  if (!normalized) return '';
-  return `https://www.mgmgamers.store/products/${normalized}`;
 }
 
 export default async function privateCheckout(req, res) {
@@ -602,190 +367,112 @@ export default async function privateCheckout(req, res) {
       }
       throw err;
     });
+
     const parsed = BodySchema.safeParse(body || {});
     if (!parsed.success) {
-      return sendJson(res, 400, { ok: false, reason: 'bad_request' });
+      safeWarn('private_checkout_invalid_body', { issues: parsed.error.flatten().fieldErrors });
+      return sendJson(res, 400, { ok: false, reason: 'bad_request', issues: parsed.error.flatten().fieldErrors });
     }
+
     const {
       variantId,
       variantGid,
       quantity,
+      lines,
       email,
       note,
       attributes,
       noteAttributes,
+      discountCode,
+      discount,
       productHandle,
     } = parsed.data;
-    let { variantNumericId, variantGid: resolvedVariantGid } = resolveVariantIds({ variantId, variantGid });
-    if (!variantNumericId) {
-      return sendJson(res, 400, { ok: false, reason: 'bad_request' });
+
+    const normalizedLines = buildLinesFromBody({ variantId, variantGid, quantity, lines });
+    if (!normalizedLines.length) {
+      safeWarn('private_checkout_missing_variant', { body: parsed.data });
+      return sendJson(res, 400, { ok: false, reason: 'missing_variant' });
     }
-    if (!resolvedVariantGid || !resolvedVariantGid.startsWith('gid://shopify/ProductVariant/')) {
-      resolvedVariantGid = `gid://shopify/ProductVariant/${variantNumericId}`;
-    }
-    const qty = normalizeQuantity(quantity);
-    const mode = resolveMode();
-    safeInfo('private_checkout_request', {
-      variantGid: resolvedVariantGid,
-      quantity: qty,
-      mode,
+
+    const mergedAttributes = noteAttributes ?? attributes;
+    const buyerIp = getClientIp(req);
+    const checkoutResult = await createStorefrontCheckout({
+      lines: normalizedLines,
+      email,
+      note,
+      attributes: mergedAttributes,
+      discountCode: discountCode || discount || undefined,
+      buyerIp,
     });
 
-    const attributesInput = noteAttributes ?? attributes;
-    const normalizedAttributes = normalizeCartAttributes(attributesInput);
-
-    const requirementCheck = await ensureShopifyRequirements();
-    if (!requirementCheck.ok) {
-      if (requirementCheck.reason === 'shopify_env_missing') {
+    if (!checkoutResult.ok) {
+      if (checkoutResult.reason === 'shopify_env_missing') {
         return sendJson(res, 500, {
           ok: false,
           reason: 'shopify_env_missing',
-          missing: requirementCheck.missing,
+          missing: checkoutResult.missing,
         });
       }
 
-      const fallbackResult = await attemptStorefrontCheckoutFallback({
-        req,
-        variantGid: resolvedVariantGid,
-        quantity: qty,
-        note,
-        attributes: normalizedAttributes,
-        email,
-      });
+      const status =
+        checkoutResult.reason === 'missing_variant'
+          ? 400
+          : checkoutResult.reason === 'discount_code_invalid'
+            ? 400
+            : checkoutResult.reason === 'product_not_published_storefront'
+              ? 409
+              : checkoutResult.reason === 'storefront_user_errors'
+                ? 400
+                : checkoutResult.reason === 'missing_lines'
+                  ? 400
+                  : checkoutResult.reason === 'storefront_http_error'
+                    ? 502
+                    : checkoutResult.reason === 'storefront_graphql_errors'
+                      ? 502
+                      : checkoutResult.reason === 'storefront_invalid_response'
+                        ? 502
+                        : 502;
 
-      if (fallbackResult.ok && fallbackResult.url) {
-        const requestIds = fallbackResult.requestId ? [fallbackResult.requestId] : undefined;
-        return sendJson(res, 200, {
-          ok: true,
-          mode: 'storefront_checkout',
-          url: fallbackResult.url,
-          warningMessages: [
-            'No pudimos generar un checkout privado. Abrimos el checkout estandar de Shopify.',
-          ],
-          ...(requestIds ? { requestIds } : {}),
-        });
-      }
-
-      const fallbackUrl = buildProductFallbackUrl(productHandle)
-        || (variantNumericId ? buildCartPermalink(variantNumericId, qty) : '');
-      if (fallbackUrl) {
-        const requestIds = fallbackResult?.requestId ? [fallbackResult.requestId] : undefined;
-        return sendJson(res, 200, {
-          ok: true,
-          mode: 'product_page_fallback',
-          url: fallbackUrl,
-          warningMessages: [
-            'No pudimos generar un checkout privado. Abrimos el checkout estandar de Shopify.',
-          ],
-          fallbackReason: fallbackResult?.reason || 'missing_scope_or_version',
-          ...(requestIds ? { requestIds } : {}),
-        });
-      }
-
-      return sendJson(res, 500, {
+      const responsePayload = {
         ok: false,
-        reason: 'missing_scope_or_version',
-        ...(requirementCheck.missingScopes?.length ? { missingScopes: requirementCheck.missingScopes } : {}),
-        ...(requirementCheck.apiVersion ? { apiVersion: requirementCheck.apiVersion } : {}),
-        ...(requirementCheck.scopeSource ? { scopeSource: requirementCheck.scopeSource } : {}),
-        ...(requirementCheck.scopeRequestId ? { scopeRequestId: requirementCheck.scopeRequestId } : {}),
-        ...(fallbackResult
-          ? {
-              fallback: {
-                type: 'storefront_checkout',
-                ...(fallbackResult.reason ? { reason: fallbackResult.reason } : {}),
-                ...(fallbackResult.status ? { status: fallbackResult.status } : {}),
-                ...(fallbackResult.requestId ? { requestId: fallbackResult.requestId } : {}),
-                ...(Array.isArray(fallbackResult.missing) ? { missing: fallbackResult.missing } : {}),
-              },
-            }
-          : {}),
-      });
-    }
+        reason: checkoutResult.reason,
+        ...(checkoutResult.userErrors ? { userErrors: checkoutResult.userErrors } : {}),
+        ...(checkoutResult.errors ? { errors: checkoutResult.errors } : {}),
+        ...(checkoutResult.status ? { status: checkoutResult.status } : {}),
+        ...(checkoutResult.body ? { detail: checkoutResult.body } : {}),
+        ...(checkoutResult.friendlyMessage ? { message: checkoutResult.friendlyMessage } : {}),
+        ...(checkoutResult.requestId ? { requestIds: [checkoutResult.requestId] } : {}),
+        ...(productHandle ? { productHandle } : {}),
+      };
 
-    let draftOrderResult;
-    try {
-      draftOrderResult = await createDraftOrder({
-        variantGid: resolvedVariantGid,
-        quantity: qty,
-        note,
-        attributes: normalizedAttributes,
-        email,
-      });
-    } catch (err) {
-      safeError('draft_order_create_exception', err);
-      return sendJson(res, 502, { ok: false, reason: 'shopify_unreachable' });
-    }
-
-    if (!draftOrderResult.ok) {
-      if (draftOrderResult.reason === 'shopify_env_missing') {
-        return sendJson(res, 500, {
-          ok: false,
-          reason: 'shopify_env_missing',
-          missing: draftOrderResult.missing,
-        });
+      if (checkoutResult.reason === 'product_not_published_storefront' && !responsePayload.message) {
+        responsePayload.message = 'Producto no publicado en canal Storefront.';
       }
-      if (draftOrderResult.reason === 'user_errors') {
-        const fallbackUrl = buildProductFallbackUrl(productHandle);
-        if (fallbackUrl) {
-          safeInfo('private_checkout_product_page_fallback', {
-            variantGid: resolvedVariantGid,
-            productHandle,
-            requestId: draftOrderResult.requestId || null,
-          });
-          return sendJson(res, 200, {
-            ok: true,
-            mode: 'product_page_fallback',
-            url: fallbackUrl,
-          });
-        }
-      }
-      return sendJson(res, 502, {
-        ok: false,
-        reason: 'draft_order_failed',
-        ...(draftOrderResult.userErrors?.length ? { userErrors: draftOrderResult.userErrors } : {}),
-        ...(draftOrderResult.errors?.length ? { errors: draftOrderResult.errors } : {}),
-        ...(draftOrderResult.status ? { status: draftOrderResult.status } : {}),
-        ...(draftOrderResult.body ? { detail: draftOrderResult.body } : {}),
-        ...(draftOrderResult.requestId ? { requestId: draftOrderResult.requestId } : {}),
-      });
+
+      return sendJson(res, status, responsePayload);
     }
 
-    const requestIds = draftOrderResult.requestId ? [draftOrderResult.requestId] : [];
+    const successPayload = {
+      ok: true,
+      mode: 'storefront_checkout',
+      url: checkoutResult.url,
+      checkoutUrl: checkoutResult.url,
+      ...(checkoutResult.checkoutId ? { checkoutId: checkoutResult.checkoutId } : {}),
+      ...(checkoutResult.requestId ? { requestIds: [checkoutResult.requestId] } : {}),
+    };
 
-    if (draftOrderResult.invoiceUrl) {
-      return sendJson(res, 200, {
-        ok: true,
-        mode: 'draft_order',
-        url: draftOrderResult.invoiceUrl,
-        draftOrderId: draftOrderResult.draftOrderId,
-        ...(requestIds.length ? { requestIds } : {}),
-      });
-    }
-
-    const fallbackUrl = buildProductFallbackUrl(productHandle);
-    if (fallbackUrl) {
-      return sendJson(res, 200, {
-        ok: true,
-        mode: 'product_page_fallback',
-        url: fallbackUrl,
-        warningMessages: ['No pudimos generar el enlace directo, abrimos el producto.'],
-        ...(requestIds.length ? { requestIds } : {}),
-      });
-    }
-
-    return sendJson(res, 502, {
-      ok: false,
-      reason: 'draft_order_failed',
-    });
+    return sendJson(res, 200, successPayload);
   } catch (err) {
     if (res.statusCode === 413) {
+      safeWarn('private_checkout_payload_too_large', {});
       return sendJson(res, 413, { ok: false, reason: 'payload_too_large' });
     }
-    if (res.statusCode === 400 && err?.code === 'invalid_json') {
-      return sendJson(res, 400, { ok: false, reason: 'bad_request' });
+    if (res.statusCode === 400 && String(err?.code || err?.message).includes('invalid_json')) {
+      safeWarn('private_checkout_invalid_json', {});
+      return sendJson(res, 400, { ok: false, reason: 'invalid_json' });
     }
-    safeError('[private-checkout] unhandled_error', err);
-    return sendJson(res, 500, { ok: false, reason: 'internal_error' });
+    safeError('private_checkout_unhandled', err);
+    return sendJson(res, 500, { ok: false, reason: 'private_checkout_failed' });
   }
 }
+

--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -517,6 +517,24 @@ export async function createJobAndProduct(
       ...(productId ? { productId } : {}),
       ...(customerEmail ? { email: customerEmail } : {}),
     };
+    if (variantIdGid) {
+      basePrivatePayload.variantGid = variantIdGid;
+    }
+    if (variantId) {
+      basePrivatePayload.variantIds = [variantId];
+    }
+    if (variantIdGid) {
+      basePrivatePayload.variantGids = [variantIdGid];
+    }
+    basePrivatePayload.quantities = [1];
+    const linePayload: Record<string, unknown> = {
+      variantId: variantIdGid || variantId,
+      quantity: 1,
+    };
+    if (variantIdGid) {
+      linePayload.variantGid = variantIdGid;
+    }
+    basePrivatePayload.lines = [linePayload];
     if (privateDraftOrder?.note) {
       basePrivatePayload.note = privateDraftOrder.note;
     }

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -448,14 +448,76 @@ export default function Mockup() {
         if (!privatePayload.variantId) {
           privatePayload.variantId = variantIdForCheckout;
         }
+        if (!privatePayload.variantGid) {
+          const variantGidFromResult =
+            (typeof payloadFromResult?.variantGid === 'string' && payloadFromResult.variantGid.trim())
+              ? payloadFromResult.variantGid.trim()
+              : Array.isArray(payloadFromResult?.variantGids) && payloadFromResult.variantGids.length
+                ? String(payloadFromResult.variantGids[0] || '').trim()
+                : typeof result?.variantIdGid === 'string'
+                  ? result.variantIdGid
+                  : '';
+          if (variantGidFromResult) {
+            privatePayload.variantGid = variantGidFromResult;
+          }
+        }
         if (!privatePayload.quantity || Number(privatePayload.quantity) <= 0) {
           privatePayload.quantity = 1;
+        }
+        const normalizedLines = Array.isArray(payloadFromResult?.lines)
+          ? payloadFromResult.lines
+              .map((entry) => {
+                if (!entry || typeof entry !== 'object') return null;
+                const rawVariantId =
+                  typeof entry.variantId === 'string' && entry.variantId.trim()
+                    ? entry.variantId.trim()
+                    : typeof entry.variantGid === 'string' && entry.variantGid.trim()
+                      ? entry.variantGid.trim()
+                      : '';
+                if (!rawVariantId) return null;
+                const qtyRaw = Number(entry.quantity);
+                const normalizedQty = Number.isFinite(qtyRaw) && qtyRaw > 0 ? Math.max(1, Math.floor(qtyRaw)) : privatePayload.quantity;
+                const line = { variantId: rawVariantId, quantity: normalizedQty };
+                if (typeof entry.variantGid === 'string' && entry.variantGid.trim()) {
+                  line.variantGid = entry.variantGid.trim();
+                }
+                return line;
+              })
+              .filter(Boolean)
+          : [];
+        if (normalizedLines.length) {
+          privatePayload.lines = normalizedLines;
+        } else {
+          const fallbackLine = {
+            variantId: privatePayload.variantId,
+            quantity: privatePayload.quantity,
+          };
+          if (typeof privatePayload.variantGid === 'string' && privatePayload.variantGid.trim()) {
+            fallbackLine.variantGid = privatePayload.variantGid.trim();
+          }
+          privatePayload.lines = [fallbackLine];
+        }
+        if (!Array.isArray(privatePayload.variantIds) || !privatePayload.variantIds.length) {
+          if (privatePayload.variantId) {
+            privatePayload.variantIds = [privatePayload.variantId];
+          }
+        }
+        if (!Array.isArray(privatePayload.variantGids) || !privatePayload.variantGids.length) {
+          if (typeof privatePayload.variantGid === 'string' && privatePayload.variantGid.trim()) {
+            privatePayload.variantGids = [privatePayload.variantGid.trim()];
+          }
+        }
+        if (!Array.isArray(privatePayload.quantities) || !privatePayload.quantities.length) {
+          privatePayload.quantities = [privatePayload.quantity];
         }
         const emailCandidate = typeof submissionFlow.customerEmail === 'string'
           ? submissionFlow.customerEmail.trim()
           : '';
         if (emailCandidate && !privatePayload.email) {
           privatePayload.email = emailCandidate;
+        }
+        if (normalizedDiscountCode) {
+          privatePayload.discountCode = normalizedDiscountCode;
         }
         const privateEndpoint = '/api/private/checkout';
         let resolvedPrivateCheckoutUrl = '';


### PR DESCRIPTION
## Summary
- replace the private checkout handler to create Storefront API checkouts with optional discount codes and improved error handling
- enrich the private checkout payload built in the editor so variant arrays and lines are forwarded to the API
- ensure the editor request sends discount codes and normalized variant metadata for Storefront checkout creation

## Testing
- npm test *(fails: evaluateImage blocks nazi symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbd9921388327a2189f704e4e0ded