### PR TITLE
Handle Shopify private checkout mutation fallback

### DIFF
--- a/lib/handlers/privateCheckout.js
+++ b/lib/handlers/privateCheckout.js
@@ -76,11 +76,32 @@ function normalizeQuantity(value) {
   return Math.max(1, Math.min(99, Math.floor(raw)));
 }
 
-const CHECKOUT_CREATE_MUTATION = `
-  mutation PrivateCheckoutCreate($input: CheckoutCreateInput!) {
+const LEGACY_CHECKOUT_CREATE_MUTATION = `
+  mutation LegacyCheckoutCreate($input: CheckoutCreateInput!) {
     checkoutCreate(input: $input) {
       checkout {
         id
+        webUrl
+      }
+      checkoutUserErrors {
+        message
+        code
+        field
+      }
+    }
+  }
+`;
+
+const PRIVATE_CHECKOUT_CREATE_MUTATION = `
+  mutation PrivateCheckoutCreate($input: CheckoutCreateInput!) {
+    privateCheckoutCreate(input: $input) {
+      checkout {
+        id
+        webUrl
+      }
+      privateCheckout {
+        id
+        url
         webUrl
       }
       checkoutUserErrors {
@@ -258,92 +279,196 @@ async function createStorefrontCheckout({ lines, email, note, attributes, discou
     input.email = email.trim();
   }
 
-  let resp;
-  try {
-    resp = await shopifyStorefrontGraphQL(
-      CHECKOUT_CREATE_MUTATION,
-      { input },
-      buyerIp ? { buyerIp } : {},
-    );
-  } catch (err) {
-    if (err?.message === 'SHOPIFY_STOREFRONT_ENV_MISSING') {
-      return { ok: false, reason: 'shopify_env_missing', missing: err.missing };
+  async function sendCheckoutMutation(mutation, contextKey) {
+    let resp;
+    try {
+      resp = await shopifyStorefrontGraphQL(
+        mutation,
+        { input },
+        buyerIp ? { buyerIp } : {},
+      );
+    } catch (err) {
+      if (err?.message === 'SHOPIFY_STOREFRONT_ENV_MISSING') {
+        return {
+          ok: false,
+          reason: 'shopify_env_missing',
+          missing: err.missing,
+        };
+      }
+      throw err;
     }
-    throw err;
+
+    const requestId = readRequestId(resp) || undefined;
+    const rawBody = await resp.text();
+    const json = parseJsonMaybe(rawBody);
+
+    if (!resp.ok) {
+      safeWarn('private_checkout_http_error', {
+        status: resp.status,
+        bodyPreview: typeof rawBody === 'string' ? rawBody.slice(0, 500) : '',
+        requestId: requestId || null,
+        mutation: contextKey,
+      });
+      return {
+        ok: false,
+        reason: 'storefront_http_error',
+        status: resp.status,
+        body: typeof rawBody === 'string' ? rawBody.slice(0, 2000) : undefined,
+        requestId,
+      };
+    }
+
+    if (!json || typeof json !== 'object') {
+      safeWarn('private_checkout_non_json', { requestId: requestId || null, mutation: contextKey });
+      return { ok: false, reason: 'storefront_invalid_response', requestId };
+    }
+
+    return {
+      ok: true,
+      requestId,
+      json,
+    };
   }
 
-  const requestId = readRequestId(resp) || undefined;
-  const rawBody = await resp.text();
-  const json = parseJsonMaybe(rawBody);
+  const mutationAttempts = [
+    {
+      key: 'private_checkout_create',
+      mutation: PRIVATE_CHECKOUT_CREATE_MUTATION,
+      getPayload(json) {
+        return json?.data?.privateCheckoutCreate;
+      },
+      shouldRetryOnErrors(errors) {
+        return errors.some((err) => {
+          const message = typeof err?.message === 'string' ? err.message : '';
+          return (
+            message.includes("Field 'privateCheckoutCreate' doesn't exist") ||
+            message.includes('Unknown argument') ||
+            message.includes('Unknown type "PrivateCheckoutCreateInput"')
+          );
+        });
+      },
+    },
+    {
+      key: 'legacy_checkout_create',
+      mutation: LEGACY_CHECKOUT_CREATE_MUTATION,
+      getPayload(json) {
+        return json?.data?.checkoutCreate;
+      },
+      shouldRetryOnErrors(errors) {
+        return errors.some((err) => {
+          const message = typeof err?.message === 'string' ? err.message : '';
+          return message.includes("Field 'checkoutCreate' doesn't exist");
+        });
+      },
+    },
+  ];
 
-  if (!resp.ok) {
-    safeWarn('private_checkout_http_error', {
-      status: resp.status,
-      bodyPreview: typeof rawBody === 'string' ? rawBody.slice(0, 500) : '',
+  let lastErrorPayload = null;
+
+  for (const attempt of mutationAttempts) {
+    const result = await sendCheckoutMutation(attempt.mutation, attempt.key);
+    if (!result.ok) {
+      return result;
+    }
+
+    const { json, requestId } = result;
+
+    if (Array.isArray(json.errors) && json.errors.length) {
+      safeWarn('private_checkout_graphql_errors', {
+        errors: json.errors,
+        requestId: requestId || null,
+        mutation: attempt.key,
+      });
+
+      if (attempt.shouldRetryOnErrors && attempt.shouldRetryOnErrors(json.errors)) {
+        lastErrorPayload = {
+          ok: false,
+          reason: 'storefront_graphql_errors',
+          errors: json.errors,
+          requestId,
+        };
+        continue;
+      }
+
+      return {
+        ok: false,
+        reason: 'storefront_graphql_errors',
+        errors: json.errors,
+        requestId,
+      };
+    }
+
+    const payload = attempt.getPayload(json);
+    if (!payload || typeof payload !== 'object') {
+      safeWarn('private_checkout_missing_payload', {
+        requestId: requestId || null,
+        mutation: attempt.key,
+      });
+      lastErrorPayload = { ok: false, reason: 'storefront_invalid_response', requestId };
+      continue;
+    }
+
+    const rawUserErrors = Array.isArray(payload.checkoutUserErrors)
+      ? payload.checkoutUserErrors
+      : Array.isArray(payload.userErrors)
+        ? payload.userErrors
+        : [];
+
+    const interpretedErrors = interpretUserErrors(rawUserErrors);
+    if (interpretedErrors.userErrors.length) {
+      safeWarn('private_checkout_user_errors', {
+        userErrors: interpretedErrors.userErrors,
+        requestId: requestId || null,
+        reason: interpretedErrors.reason,
+        mutation: attempt.key,
+      });
+      return {
+        ok: false,
+        reason: interpretedErrors.reason,
+        userErrors: interpretedErrors.userErrors,
+        friendlyMessage: interpretedErrors.friendlyMessage,
+        requestId,
+      };
+    }
+
+    const checkoutSource =
+      payload.checkout && typeof payload.checkout === 'object'
+        ? payload.checkout
+        : payload.privateCheckout && typeof payload.privateCheckout === 'object'
+          ? payload.privateCheckout
+          : null;
+
+    const webUrlRaw = checkoutSource?.webUrl || checkoutSource?.url;
+    const webUrl = typeof webUrlRaw === 'string' ? webUrlRaw.trim() : '';
+
+    if (!webUrl) {
+      safeWarn('private_checkout_missing_weburl', {
+        requestId: requestId || null,
+        mutation: attempt.key,
+      });
+      lastErrorPayload = { ok: false, reason: 'missing_checkout_url', requestId };
+      continue;
+    }
+
+    safeInfo('private_checkout_success', {
       requestId: requestId || null,
+      checkoutId: typeof checkoutSource?.id === 'string' ? checkoutSource.id : null,
+      mutation: attempt.key,
     });
+
     return {
-      ok: false,
-      reason: 'storefront_http_error',
-      status: resp.status,
-      body: typeof rawBody === 'string' ? rawBody.slice(0, 2000) : undefined,
+      ok: true,
+      url: webUrl,
+      checkoutId: typeof checkoutSource?.id === 'string' ? checkoutSource.id : undefined,
       requestId,
     };
   }
 
-  if (!json || typeof json !== 'object') {
-    safeWarn('private_checkout_non_json', { requestId: requestId || null });
-    return { ok: false, reason: 'storefront_invalid_response', requestId };
+  if (lastErrorPayload) {
+    return lastErrorPayload;
   }
 
-  if (Array.isArray(json.errors) && json.errors.length) {
-    safeWarn('private_checkout_graphql_errors', {
-      errors: json.errors,
-      requestId: requestId || null,
-    });
-    return { ok: false, reason: 'storefront_graphql_errors', errors: json.errors, requestId };
-  }
-
-  const payload = json?.data?.checkoutCreate;
-  if (!payload || typeof payload !== 'object') {
-    safeWarn('private_checkout_missing_payload', { requestId: requestId || null });
-    return { ok: false, reason: 'storefront_invalid_response', requestId };
-  }
-
-  const interpretedErrors = interpretUserErrors(payload.checkoutUserErrors);
-  if (interpretedErrors.userErrors.length) {
-    safeWarn('private_checkout_user_errors', {
-      userErrors: interpretedErrors.userErrors,
-      requestId: requestId || null,
-      reason: interpretedErrors.reason,
-    });
-    return {
-      ok: false,
-      reason: interpretedErrors.reason,
-      userErrors: interpretedErrors.userErrors,
-      friendlyMessage: interpretedErrors.friendlyMessage,
-      requestId,
-    };
-  }
-
-  const checkout = payload.checkout && typeof payload.checkout === 'object' ? payload.checkout : null;
-  const webUrl = typeof checkout?.webUrl === 'string' ? checkout.webUrl.trim() : '';
-  if (!webUrl) {
-    safeWarn('private_checkout_missing_weburl', { requestId: requestId || null });
-    return { ok: false, reason: 'missing_checkout_url', requestId };
-  }
-
-  safeInfo('private_checkout_success', {
-    requestId: requestId || null,
-    checkoutId: typeof checkout?.id === 'string' ? checkout.id : null,
-  });
-
-  return {
-    ok: true,
-    url: webUrl,
-    checkoutId: typeof checkout?.id === 'string' ? checkout.id : undefined,
-    requestId,
-  };
+  return { ok: false, reason: 'storefront_invalid_response' };
 }
 
 export default async function privateCheckout(req, res) {


### PR DESCRIPTION
## Summary
- add support for Shopify's private checkout mutation while keeping the legacy checkout mutation as a fallback
- improve logging and error handling around checkout mutation responses and web URL extraction

## Testing
- npm test *(fails: evaluateImage blocks nazi symbols assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc199572083278700c110cbc205f6