### PR TITLE
Align frontend API configuration with shared /api base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # MGM API
 
-## Dev setup (two terminals)
+## Dev setup
+
+### Modo recomendado (mismo origen que Vercel)
+
+```bash
+npm run dev:vercel
+```
+
+Esto levanta `vercel dev` en `http://localhost:3001`. El frontend debe seguir apuntando a `/api`, por lo que no se necesitan cambios adicionales.
+
+### Modo alternativo (dos terminales)
 
 Terminal 1 (API):
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,5 +1,5 @@
 # Integrations
 
-- En dev: correr `npx vercel dev` (API → http://localhost:3001) y `npm run dev` (front → http://localhost:5173).
-- En prod: configurar `VITE_API_URL` en Vercel del proyecto front con la URL pública de la API.
+- En dev (modo recomendado): correr `npm run dev:vercel` en la raíz para levantar `vercel dev` en `http://localhost:3001` y, en `mgm-front`, ejecutar `npm run dev`. El front habla siempre con `/api`, así que no se necesitan URLs absolutas.
+- En dev (modo alternativo): si corrés la API con `npm run dev:api`, asegurate de exportar `VITE_USE_PROXY=1` antes de `npm run dev` en `mgm-front` para que el proxy de Vite mantenga `/api` como origen.
 - Webhooks Shopify: apuntar a `https://<tu-api>.vercel.app/api/shopify-webhook`.

--- a/mgm-front/.env.local
+++ b/mgm-front/.env.local
@@ -1,2 +1,1 @@
 VITE_USE_PROXY=1
-VITE_API_URL=http://localhost:3001

--- a/mgm-front/README.md
+++ b/mgm-front/README.md
@@ -7,13 +7,13 @@ This template provides a minimal setup to get React working in Vite with HMR and
 Antes de iniciar el entorno de desarrollo crea un archivo `.env.local` con:
 
 ```
-VITE_API_URL=URL_de_tu_API
+VITE_USE_PROXY=1 # opcional: activa el proxy local de /api → http://localhost:3001
 VITE_SUPABASE_URL=URL_de_tu_proyecto_Supabase
 VITE_SUPABASE_ANON_KEY=clave_anon_de_Supabase
 VITE_BUSQUEDA_PASSWORD=contraseña_para_el_buscador
 ```
 
-Luego ejecuta `npm run dev` para iniciar el frontend.
+Luego ejecuta `npm run dev` para iniciar el frontend. Todas las llamadas a la API se hacen contra `/api`, por lo que no hace falta configurar URLs absolutas.
 
 Currently, two official plugins are available:
 

--- a/mgm-front/src/lib/api.js
+++ b/mgm-front/src/lib/api.js
@@ -7,36 +7,27 @@ const API_ORIGIN = CLEAN_API_URL.endsWith('/api')
   : CLEAN_API_URL;
 const USE_PROXY = (import.meta.env.VITE_USE_PROXY || '').trim() === '1';
 const IS_DEV = Boolean(import.meta.env && import.meta.env.DEV);
-
-let hasWarnedAboutMissingApiUrl = false;
+const API_BASE_PATH = '/api';
 
 function normalizePath(path) {
-  if (!path) return '/';
-  return path.startsWith('/') ? path : `/${path}`;
+  const ensured = path ? (path.startsWith('/') ? path : `/${path}`) : '/';
+  if (ensured === API_BASE_PATH) {
+    return API_BASE_PATH;
+  }
+  if (ensured.startsWith(`${API_BASE_PATH}/`)) {
+    return ensured;
+  }
+  const trimmed = ensured.replace(/^\/+/, '');
+  if (!trimmed) {
+    return API_BASE_PATH;
+  }
+  return `${API_BASE_PATH}/${trimmed}`;
 }
 
 function resolveRequestUrl(path) {
   const normalizedPath = normalizePath(path);
-  if (IS_DEV && USE_PROXY) {
+  if (!API_ORIGIN || (IS_DEV && USE_PROXY)) {
     return normalizedPath;
-  }
-  if (!API_ORIGIN) {
-    if (!hasWarnedAboutMissingApiUrl) {
-      hasWarnedAboutMissingApiUrl = true;
-      try {
-        console.error('[api] missing_api_url', {
-          message: 'VITE_API_URL is not configured. Requests will fail.',
-          path: normalizedPath,
-        });
-      } catch (loggingErr) {
-        if (loggingErr) {
-          // noop
-        }
-      }
-    }
-    const error = new Error('VITE_API_URL is not configured');
-    error.code = 'missing_api_url';
-    throw error;
   }
   return `${API_ORIGIN}${normalizedPath}`;
 }
@@ -77,22 +68,12 @@ export function apiFetch(methodOrPath, maybePathOrInit, maybeBody, maybeInitOver
 }
 
 export function getApiBaseUrl() {
-  if (IS_DEV && USE_PROXY) {
-    return '/api';
+  if (!API_ORIGIN || (IS_DEV && USE_PROXY)) {
+    return API_BASE_PATH;
   }
-  if (!API_ORIGIN) {
-    return '';
-  }
-  return `${API_ORIGIN}/api`;
+  return `${API_ORIGIN}${API_BASE_PATH}`;
 }
 
 export function getResolvedApiUrl(path) {
-  try {
-    return resolveRequestUrl(path);
-  } catch (err) {
-    if (err && err.code === 'missing_api_url') {
-      return '';
-    }
-    throw err;
-  }
+  return resolveRequestUrl(path);
 }

--- a/mgm-front/src/lib/api.ts
+++ b/mgm-front/src/lib/api.ts
@@ -7,36 +7,27 @@ const API_ORIGIN = CLEAN_API_URL.endsWith('/api')
   : CLEAN_API_URL;
 const USE_PROXY = (import.meta.env.VITE_USE_PROXY || '').trim() === '1';
 const IS_DEV = Boolean(import.meta.env && import.meta.env.DEV);
-
-let hasWarnedAboutMissingApiUrl = false;
+const API_BASE_PATH = '/api';
 
 function normalizePath(path: string): string {
-  if (!path) return '/';
-  return path.startsWith('/') ? path : `/${path}`;
+  const ensured = path ? (path.startsWith('/') ? path : `/${path}`) : '/';
+  if (ensured === API_BASE_PATH) {
+    return API_BASE_PATH;
+  }
+  if (ensured.startsWith(`${API_BASE_PATH}/`)) {
+    return ensured;
+  }
+  const trimmed = ensured.replace(/^\/+/, '');
+  if (!trimmed) {
+    return API_BASE_PATH;
+  }
+  return `${API_BASE_PATH}/${trimmed}`;
 }
 
 function resolveRequestUrl(path: string): string {
   const normalizedPath = normalizePath(path);
-  if (IS_DEV && USE_PROXY) {
+  if (!API_ORIGIN || (IS_DEV && USE_PROXY)) {
     return normalizedPath;
-  }
-  if (!API_ORIGIN) {
-    if (!hasWarnedAboutMissingApiUrl) {
-      hasWarnedAboutMissingApiUrl = true;
-      try {
-        console.error('[api] missing_api_url', {
-          message: 'VITE_API_URL is not configured. Requests will fail.',
-          path: normalizedPath,
-        });
-      } catch (loggingErr) {
-        if (loggingErr) {
-          // noop
-        }
-      }
-    }
-    const error = new Error('VITE_API_URL is not configured');
-    (error as Error & { code?: string }).code = 'missing_api_url';
-    throw error;
   }
   return `${API_ORIGIN}${normalizedPath}`;
 }
@@ -92,22 +83,12 @@ export function apiFetch(
 }
 
 export function getApiBaseUrl(): string {
-  if (IS_DEV && USE_PROXY) {
-    return '/api';
+  if (!API_ORIGIN || (IS_DEV && USE_PROXY)) {
+    return API_BASE_PATH;
   }
-  if (!API_ORIGIN) {
-    return '';
-  }
-  return `${API_ORIGIN}/api`;
+  return `${API_ORIGIN}${API_BASE_PATH}`;
 }
 
 export function getResolvedApiUrl(path: string): string {
-  try {
-    return resolveRequestUrl(path);
-  } catch (err) {
-    if ((err as Error & { code?: string })?.code === 'missing_api_url') {
-      return '';
-    }
-    throw err;
-  }
+  return resolveRequestUrl(path);
 }

--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -649,7 +649,7 @@ export async function createJobAndProduct(
             err.friendlyMessage = 'No pudimos generar el checkout privado, probá de nuevo.';
           }
           if (reason === 'private_checkout_missing_api_url') {
-            err.friendlyMessage = 'Configurá VITE_API_URL para conectar con la API.';
+            err.friendlyMessage = 'Verificá que la API esté disponible en /api (vercel dev o proxy activo).';
           }
           if (!err.detail && typeof rawBody === 'string' && rawBody) {
             err.detail = rawBody.slice(0, 200);

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -538,7 +538,7 @@ export default function Mockup() {
           if (missingApiUrl) {
             const err = new Error('private_checkout_missing_api_url');
             err.reason = 'private_checkout_missing_api_url';
-            err.friendlyMessage = 'Configurá VITE_API_URL para conectar con la API.';
+            err.friendlyMessage = 'Verificá que la API esté disponible en /api (vercel dev o proxy activo).';
             throw err;
           }
           const err = new Error('private_checkout_network_error');

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "vercel-build": "node -e \"const fs=require('fs');fs.mkdirSync('public',{recursive:true});fs.writeFileSync('public/index.html','OK');console.log('no-build');\"",
     "vercel:link": "node scripts/vercel-link.mjs",
     "vercel:pull": "vercel pull --yes --environment=development",
+    "dev:vercel": "vercel dev --listen 0.0.0.0:3001",
     "dev:api": "node ./scripts/dev-api-server.mjs",
     "dev:front": "cd mgm-front && vite",
     "dev:all": "concurrently -k -n api,front -c blue,green \"npm:dev:api\" \"npm:dev:front\"",


### PR DESCRIPTION
## Summary
- update the frontend API helper to always resolve requests against the logical /api base while keeping optional origin overrides
- document and streamline dev workflows by introducing the vercel dev script and removing the need for VITE_API_URL in local envs
- refresh private checkout messaging to point teams to the unified /api endpoint when connectivity issues arise

## Testing
- not run (not requested)

## QA Checklist
- [x] Compra privada y búsqueda usan rutas /api en ambos modos de desarrollo y producción (verificado en la configuración)
- [x] Frontend sin URLs absolutas a localhost; proxy de Vite mantiene same-origin en desarrollo
- [x] Variables de entorno VITE_* coherentes entre desarrollo y Vercel


------
https://chatgpt.com/codex/tasks/task_e_68ddbf5047d88327be91691d0ac49d10