### PR TITLE
Improve print PDF image quality

### DIFF
--- a/lib/_lib/generatePrintPdf.js
+++ b/lib/_lib/generatePrintPdf.js
@@ -98,10 +98,10 @@ export async function generatePrintPdf({
       .toColourspace('srgb')
       .withMetadata({ density: DEFAULT_DPI });
     artworkBuffer = await pipeline
-      .jpeg({
-        quality: 95,
-        chromaSubsampling: '4:4:4',
-        mozjpeg: true,
+      .png({
+        compressionLevel: 0,
+        adaptiveFiltering: false,
+        force: true,
       })
       .toBuffer();
     artworkMetadata = await sharp(artworkBuffer).metadata();
@@ -138,10 +138,10 @@ export async function generatePrintPdf({
       ])
       .toColourspace('srgb')
       .withMetadata({ density: DEFAULT_DPI })
-      .jpeg({
-        quality: 95,
-        chromaSubsampling: '4:4:4',
-        mozjpeg: true,
+      .png({
+        compressionLevel: 0,
+        adaptiveFiltering: false,
+        force: true,
       })
       .toBuffer();
   } catch (err) {
@@ -165,7 +165,7 @@ export async function generatePrintPdf({
       height: pageHeightPt,
       color: rgb(r / 255, g / 255, b / 255),
     });
-    const embedded = await pdfDoc.embedJpg(areaCompositeBuffer);
+    const embedded = await pdfDoc.embedPng(areaCompositeBuffer);
     const areaWidthPt = cmToPoints(areaWidthCm);
     const areaHeightPt = cmToPoints(areaHeightCm);
     page.drawImage(embedded, {


### PR DESCRIPTION
## Summary
- update the print PDF generator to compose images using lossless PNG buffers
- embed the PNG into the resulting PDF to avoid JPEG recompression artifacts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddd29079148327841a9737e6416229