### PR TITLE
Add cart fallback for private checkout link

### DIFF
--- a/lib/handlers/privateCheckout.js
+++ b/lib/handlers/privateCheckout.js
@@ -92,6 +92,22 @@ const LEGACY_CHECKOUT_CREATE_MUTATION = `
   }
 `;
 
+const CART_CREATE_MUTATION = `
+  mutation CartCreate($input: CartInput!) {
+    cartCreate(input: $input) {
+      cart {
+        id
+        checkoutUrl
+      }
+      userErrors {
+        message
+        code
+        field
+      }
+    }
+  }
+`;
+
 const PRIVATE_CHECKOUT_CREATE_MUTATION = `
   mutation PrivateCheckoutCreate($input: CheckoutCreateInput!) {
     privateCheckoutCreate(input: $input) {
@@ -230,6 +246,123 @@ function interpretUserErrors(rawErrors) {
   };
 }
 
+async function createCartCheckoutFallback({ lines, email, note, attributes, discountCode, buyerIp }) {
+  const normalizedLines = Array.isArray(lines) ? lines : [];
+  const cartLines = normalizedLines
+    .map((line) => {
+      if (!line || typeof line !== 'object') return null;
+      const gidRaw = typeof line.variantGid === 'string' ? line.variantGid : '';
+      const ensuredGid = gidRaw && gidRaw.startsWith('gid://')
+        ? gidRaw
+        : line.variantNumericId
+          ? `gid://shopify/ProductVariant/${line.variantNumericId}`
+          : '';
+      if (!ensuredGid) return null;
+      return {
+        merchandiseId: ensuredGid,
+        quantity: normalizeQuantity(line.quantity ?? 1),
+      };
+    })
+    .filter(Boolean);
+
+  if (!cartLines.length) {
+    return { ok: false, reason: 'missing_lines' };
+  }
+
+  const input = {
+    lines: cartLines,
+  };
+
+  const normalizedAttributes = normalizeCartAttributes(attributes);
+  if (normalizedAttributes.length) {
+    input.attributes = normalizedAttributes.map(({ key, value }) => ({ key, value }));
+  }
+
+  const noteValue = normalizeCartNote(note);
+  if (noteValue) {
+    input.note = noteValue;
+  }
+
+  const normalizedDiscount = typeof discountCode === 'string' ? discountCode.trim() : '';
+  if (normalizedDiscount) {
+    input.discountCodes = [normalizedDiscount];
+  }
+
+  const trimmedEmail = typeof email === 'string' ? email.trim() : '';
+  if (trimmedEmail) {
+    input.buyerIdentity = { email: trimmedEmail };
+  }
+
+  let resp;
+  try {
+    resp = await shopifyStorefrontGraphQL(
+      CART_CREATE_MUTATION,
+      { input },
+      buyerIp ? { buyerIp } : {},
+    );
+  } catch (err) {
+    if (err?.message === 'SHOPIFY_STOREFRONT_ENV_MISSING') {
+      return {
+        ok: false,
+        reason: 'shopify_env_missing',
+        missing: err.missing,
+      };
+    }
+    throw err;
+  }
+
+  const requestId = readRequestId(resp) || undefined;
+  const rawBody = await resp.text();
+  const json = parseJsonMaybe(rawBody);
+
+  if (!resp.ok) {
+    return {
+      ok: false,
+      reason: 'storefront_http_error',
+      status: resp.status,
+      body: typeof rawBody === 'string' ? rawBody.slice(0, 2000) : undefined,
+      requestId,
+    };
+  }
+
+  if (!json || typeof json !== 'object') {
+    return { ok: false, reason: 'storefront_invalid_response', requestId };
+  }
+
+  if (Array.isArray(json.errors) && json.errors.length) {
+    return { ok: false, reason: 'storefront_graphql_errors', errors: json.errors, requestId };
+  }
+
+  const payload = json?.data?.cartCreate;
+  if (!payload || typeof payload !== 'object') {
+    return { ok: false, reason: 'storefront_invalid_response', requestId };
+  }
+
+  const interpretedErrors = interpretUserErrors(payload.userErrors);
+  if (interpretedErrors.userErrors.length) {
+    return {
+      ok: false,
+      reason: interpretedErrors.reason,
+      userErrors: interpretedErrors.userErrors,
+      friendlyMessage: interpretedErrors.friendlyMessage,
+      requestId,
+    };
+  }
+
+  const cart = payload.cart && typeof payload.cart === 'object' ? payload.cart : null;
+  const checkoutUrlRaw = typeof cart?.checkoutUrl === 'string' ? cart.checkoutUrl.trim() : '';
+  if (!checkoutUrlRaw) {
+    return { ok: false, reason: 'missing_checkout_url', requestId };
+  }
+
+  return {
+    ok: true,
+    url: checkoutUrlRaw,
+    cartId: typeof cart?.id === 'string' ? cart.id : undefined,
+    requestId,
+  };
+}
+
 async function createStorefrontCheckout({ lines, email, note, attributes, discountCode, buyerIp }) {
   if (!Array.isArray(lines) || !lines.length) {
     return { ok: false, reason: 'missing_lines' };
@@ -364,6 +497,7 @@ async function createStorefrontCheckout({ lines, email, note, attributes, discou
   ];
 
   let lastErrorPayload = null;
+  let retriableMissingMutation = false;
 
   for (const attempt of mutationAttempts) {
     const result = await sendCheckoutMutation(attempt.mutation, attempt.key);
@@ -381,6 +515,7 @@ async function createStorefrontCheckout({ lines, email, note, attributes, discou
       });
 
       if (attempt.shouldRetryOnErrors && attempt.shouldRetryOnErrors(json.errors)) {
+        retriableMissingMutation = true;
         lastErrorPayload = {
           ok: false,
           reason: 'storefront_graphql_errors',
@@ -462,6 +597,39 @@ async function createStorefrontCheckout({ lines, email, note, attributes, discou
       checkoutId: typeof checkoutSource?.id === 'string' ? checkoutSource.id : undefined,
       requestId,
     };
+  }
+
+  if (retriableMissingMutation) {
+    const cartCheckout = await createCartCheckoutFallback({
+      lines,
+      email,
+      note,
+      attributes,
+      discountCode,
+      buyerIp,
+    });
+
+    if (cartCheckout.ok) {
+      safeInfo('private_checkout_cart_fallback_success', {
+        requestId: cartCheckout.requestId || null,
+        cartId: cartCheckout.cartId || null,
+      });
+      return {
+        ok: true,
+        url: cartCheckout.url,
+        checkoutId: cartCheckout.cartId,
+        cartId: cartCheckout.cartId,
+        requestId: cartCheckout.requestId,
+      };
+    }
+
+    safeWarn('private_checkout_cart_fallback_failed', {
+      reason: cartCheckout.reason,
+      requestId: cartCheckout.requestId || null,
+      status: cartCheckout.status || null,
+    });
+
+    lastErrorPayload = cartCheckout;
   }
 
   if (lastErrorPayload) {
@@ -583,6 +751,7 @@ export default async function privateCheckout(req, res) {
       url: checkoutResult.url,
       checkoutUrl: checkoutResult.url,
       ...(checkoutResult.checkoutId ? { checkoutId: checkoutResult.checkoutId } : {}),
+      ...(checkoutResult.cartId ? { cartId: checkoutResult.cartId } : {}),
       ...(checkoutResult.requestId ? { requestIds: [checkoutResult.requestId] } : {}),
     };
 


### PR DESCRIPTION
## Summary
- add a storefront cartCreate fallback for private checkouts when checkout mutations are unavailable
- normalize payload fields for the fallback, including attributes, notes, discount codes and buyer email
- surface the fallback cart checkout details in the response payload and logs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddd3f7fca0832797be7d46675fff29