### PR TITLE
Fix preview image resolution in prints search

### DIFF
--- a/lib/api/handlers/printsSearch.js
+++ b/lib/api/handlers/printsSearch.js
@@ -72,6 +72,13 @@ function parseMeasurement(query) {
 function buildPreviewUrl(path) {
   if (!path) return null;
   const normalized = path.startsWith('outputs/') ? path : `outputs/${path}`;
+  const lower = normalized.toLowerCase();
+  if (lower.endsWith('.pdf')) {
+    const previewCandidate = normalized
+      .replace(/^outputs\/pdf\//i, 'outputs/preview/')
+      .replace(/\.pdf$/i, '.jpg');
+    return `/api/prints/preview?path=${encodeURIComponent(previewCandidate)}`;
+  }
   return `/api/prints/preview?path=${encodeURIComponent(normalized)}`;
 }
 

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -14,10 +14,10 @@ const OUTPUT_BUCKET = 'outputs';
 const PUBLISH_PRODUCT_BODY_LIMIT = 6 * 1024 * 1024; // 6 MiB
 const ONLINE_STORE_MISSING_MESSAGE = [
   'No pudimos encontrar el canal Online Store para publicar este producto.',
-  'Revisá: 1) que el canal esté instalado, 2) que la app tenga el scope write_publications.',
-  'Luego probá de nuevo.',
+  'RevisÃ¡: 1) que el canal estÃ© instalado, 2) que la app tenga el scope write_publications.',
+  'Luego probÃ¡ de nuevo.',
 ].join('\n');
-const ONLINE_STORE_DISABLED_MESSAGE = 'Tu tienda no tiene el canal Online Store habilitado. Instalalo o bien omití la publicación y usa Storefront para el carrito.';
+const ONLINE_STORE_DISABLED_MESSAGE = 'Tu tienda no tiene el canal Online Store habilitado. Instalalo o bien omitÃ­ la publicaciÃ³n y usa Storefront para el carrito.';
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
@@ -324,7 +324,7 @@ function buildMetaDescription({ productTypeLabel, designName, widthCm, heightCm,
     ? 'Glasspad gamer personalizado'
     : 'Mousepad gamer personalizado';
   const sections = [baseLabel];
-  if (designName) sections.push(`Diseño ${designName}`);
+  if (designName) sections.push(`DiseÃ±o ${designName}`);
   if (measurement) sections.push(`Medida ${measurement} cm`);
   if (materialLabel) sections.push(`Material ${materialLabel}`);
   return `${sections.join('. ')}.`;
@@ -1743,9 +1743,9 @@ export async function publishProduct(req, res) {
     const envStatus = await ensureShopifyEnvironmentReady();
     if (!envStatus.ok) {
       const reason = envStatus.reason || 'shopify_env_invalid';
-      let message = 'Token/Admin API inválido o dominio incorrecto';
+      let message = 'Token/Admin API invÃ¡lido o dominio incorrecto';
       if (reason === 'invalid_api_version') {
-        message = `La versión de la API de Shopify debe ser ${DEFAULT_SHOPIFY_API_VERSION}.`;
+        message = `La versiÃ³n de la API de Shopify debe ser ${DEFAULT_SHOPIFY_API_VERSION}.`;
       }
       try {
         console.error('shopify_env_check_failed', {
@@ -1777,8 +1777,8 @@ export async function publishProduct(req, res) {
           : 'invalid_body';
       const status = err?.code === 'payload_too_large' ? 413 : 400;
       const message = err?.code === 'payload_too_large'
-        ? 'El mockup es demasiado grande. Probá de nuevo con una imagen más liviana.'
-        : 'El cuerpo de la petición es inválido.';
+        ? 'El mockup es demasiado grande. ProbÃ¡ de nuevo con una imagen mÃ¡s liviana.'
+        : 'El cuerpo de la peticiÃ³n es invÃ¡lido.';
       return res.status(status).json({ ok: false, reason: code, message });
     }
     body = body && typeof body === 'object' ? body : {};
@@ -1903,8 +1903,8 @@ export async function publishProduct(req, res) {
       };
 
       const message = missingFilesScope
-        ? 'No se pudo subir la imagen porque falta el scope write_files. Se seguirá sin mockup.'
-        : 'No se pudo subir la imagen, se seguirá sin mockup.';
+        ? 'No se pudo subir la imagen porque falta el scope write_files. Se seguirÃ¡ sin mockup.'
+        : 'No se pudo subir la imagen, se seguirÃ¡ sin mockup.';
 
       const warningPayload = {
         ...warningBase,
@@ -1988,7 +1988,7 @@ export async function publishProduct(req, res) {
           body: locationJson,
           requestId: lastLocationRequestId,
           ...(locationRequestIds.length ? { requestIds: locationRequestIds } : {}),
-          message: 'Shopify devolvió un error al obtener las ubicaciones de la tienda.',
+          message: 'Shopify devolviÃ³ un error al obtener las ubicaciones de la tienda.',
         });
       }
 
@@ -2026,7 +2026,7 @@ export async function publishProduct(req, res) {
           reason: 'shopify_graphql_errors',
           errors: formattedLocationErrors,
           requestId: lastLocationRequestId || null,
-          message: 'Shopify devolvió errores al obtener las ubicaciones de la tienda.',
+          message: 'Shopify devolviÃ³ errores al obtener las ubicaciones de la tienda.',
         });
       }
 
@@ -2036,7 +2036,7 @@ export async function publishProduct(req, res) {
           reason: 'shopify_location_missing',
           requestId: lastLocationRequestId || null,
           ...(formattedLocationErrors.length ? { errors: formattedLocationErrors } : {}),
-          message: 'No se encontró una ubicación activa en Shopify para asignar stock.',
+          message: 'No se encontrÃ³ una ubicaciÃ³n activa en Shopify para asignar stock.',
         });
       }
 
@@ -2045,14 +2045,14 @@ export async function publishProduct(req, res) {
           ok: false,
           reason: 'shopify_location_inactive',
           requestId: lastLocationRequestId || null,
-          message: 'La ubicación primaria encontrada no está activa en Shopify.',
+          message: 'La ubicaciÃ³n primaria encontrada no estÃ¡ activa en Shopify.',
         });
       }
 
       if (locationErrors.length) {
         const warningPayload = {
           code: 'shopify_locations_warning',
-          message: 'Shopify devolvió advertencias al obtener las ubicaciones de la tienda.',
+          message: 'Shopify devolviÃ³ advertencias al obtener las ubicaciones de la tienda.',
           requestId: lastLocationRequestId || null,
           detail: formattedLocationErrors,
         };
@@ -2085,7 +2085,7 @@ export async function publishProduct(req, res) {
       return res.status(502).json({
         ok: false,
         reason: 'locations_query_failed',
-        message: 'No se pudo obtener la ubicación principal de la tienda en Shopify.',
+        message: 'No se pudo obtener la ubicaciÃ³n principal de la tienda en Shopify.',
       });
     }
 
@@ -2120,7 +2120,7 @@ export async function publishProduct(req, res) {
         ...(Array.isArray(productAttempts)
           ? { requestIds: productAttempts.map((entry) => entry?.requestId).filter(Boolean) }
           : {}),
-        message: 'Shopify devolvió un error al crear el producto.',
+        message: 'Shopify devolviÃ³ un error al crear el producto.',
       });
     }
     const productErrors = Array.isArray(productJson?.errors) ? productJson.errors : [];
@@ -2145,8 +2145,8 @@ export async function publishProduct(req, res) {
         }
         const graphQLErrorMessages = collectGraphQLErrorMessages(productErrors);
         const graphQLErrorMessage = graphQLErrorMessages.length
-          ? `Shopify devolvió errores: ${graphQLErrorMessages.join(' | ')}`
-          : 'Shopify devolvió un error al crear el producto.';
+          ? `Shopify devolviÃ³ errores: ${graphQLErrorMessages.join(' | ')}`
+          : 'Shopify devolviÃ³ un error al crear el producto.';
         try {
           console.error('product_create_graphql_errors', {
             requestId: productRequestId || null,
@@ -2166,8 +2166,8 @@ export async function publishProduct(req, res) {
 
       const errorMessages = collectGraphQLErrorMessages(productErrors);
       const warningMessage = errorMessages.length
-        ? `Shopify devolvió advertencias: ${errorMessages.join(' | ')}`
-        : 'Shopify devolvió advertencias durante la creación del producto.';
+        ? `Shopify devolviÃ³ advertencias: ${errorMessages.join(' | ')}`
+        : 'Shopify devolviÃ³ advertencias durante la creaciÃ³n del producto.';
       const warningPayload = {
         code: 'shopify_graphql_warning',
         message: warningMessage,
@@ -2190,7 +2190,7 @@ export async function publishProduct(req, res) {
         reason: 'product_create_failed',
         detail: productJson,
         requestId: productRequestId || null,
-        message: 'Shopify devolvió un error al crear el producto.',
+        message: 'Shopify devolviÃ³ un error al crear el producto.',
       });
     }
     const userErrors = sanitizeUserErrors(productPayload.userErrors);
@@ -2200,7 +2200,7 @@ export async function publishProduct(req, res) {
         .filter((msg) => Boolean(msg));
       const friendlyUserError = userErrorMessages.length
         ? userErrorMessages[0]
-        : 'Shopify rechazó la creación del producto.';
+        : 'Shopify rechazÃ³ la creaciÃ³n del producto.';
       try {
         console.error('product_create_user_errors', {
           requestId: productRequestId || null,
@@ -2234,7 +2234,7 @@ export async function publishProduct(req, res) {
       return res.status(502).json({
         ok: false,
         reason: 'product_missing_id',
-        message: 'Shopify no devolvió un ID válido para el producto creado.',
+        message: 'Shopify no devolviÃ³ un ID vÃ¡lido para el producto creado.',
         requestId: productRequestId || null,
         visibility,
         ...meta,
@@ -2292,7 +2292,7 @@ export async function publishProduct(req, res) {
           body: variantQueryJson,
           requestId: variantQueryRequestId,
           ...(variantQueryRequestIds.length ? { requestIds: variantQueryRequestIds } : {}),
-          message: 'Shopify devolvió un error al obtener la variante por defecto del producto.',
+          message: 'Shopify devolviÃ³ un error al obtener la variante por defecto del producto.',
           visibility,
           ...meta,
         });
@@ -2322,8 +2322,8 @@ export async function publishProduct(req, res) {
         }
         const variantQueryMessages = collectGraphQLErrorMessages(variantQueryErrors);
         const friendlyVariantQueryMessage = variantQueryMessages.length
-          ? `Shopify devolvió errores: ${variantQueryMessages.join(' | ')}`
-          : 'Shopify devolvió un error al obtener la variante del producto.';
+          ? `Shopify devolviÃ³ errores: ${variantQueryMessages.join(' | ')}`
+          : 'Shopify devolviÃ³ un error al obtener la variante del producto.';
         return res.status(502).json({
           ok: false,
           reason: 'shopify_graphql_errors',
@@ -2345,7 +2345,7 @@ export async function publishProduct(req, res) {
         return res.status(502).json({
           ok: false,
           reason: 'product_missing_variant',
-          message: 'Shopify no devolvió la variante por defecto del producto.',
+          message: 'Shopify no devolviÃ³ la variante por defecto del producto.',
           requestId: variantQueryRequestId || null,
           visibility,
           ...meta,
@@ -2355,8 +2355,8 @@ export async function publishProduct(req, res) {
       if (variantQueryErrors.length) {
         const variantQueryMessages = collectGraphQLErrorMessages(variantQueryErrors);
         const warningMessage = variantQueryMessages.length
-          ? `Shopify devolvió advertencias al leer la variante: ${variantQueryMessages.join(' | ')}`
-          : 'Shopify devolvió advertencias al leer la variante del producto.';
+          ? `Shopify devolviÃ³ advertencias al leer la variante: ${variantQueryMessages.join(' | ')}`
+          : 'Shopify devolviÃ³ advertencias al leer la variante del producto.';
         const warningPayload = {
           code: 'shopify_graphql_warning',
           message: warningMessage,
@@ -2376,7 +2376,7 @@ export async function publishProduct(req, res) {
       return res.status(502).json({
         ok: false,
         reason: 'product_missing_variant',
-        message: 'Shopify no devolvió variantes para el producto creado.',
+        message: 'Shopify no devolviÃ³ variantes para el producto creado.',
         requestId: productRequestId || null,
         visibility,
         ...meta,
@@ -2500,7 +2500,7 @@ export async function publishProduct(req, res) {
           requestId: variantGraphQLRequestId,
           ...(variantGraphQLRequestIds.length ? { requestIds: variantGraphQLRequestIds } : {}),
           ...(restFallbackDetail ? { restFallback: restFallbackDetail } : {}),
-          message: 'Shopify devolvió un error al actualizar la variante del producto.',
+          message: 'Shopify devolviÃ³ un error al actualizar la variante del producto.',
           visibility,
           ...meta,
         });
@@ -2528,8 +2528,8 @@ export async function publishProduct(req, res) {
         }
         const variantErrorMessages = collectGraphQLErrorMessages(variantErrors);
         const friendlyVariantMessage = variantErrorMessages.length
-          ? `Shopify devolvió errores al actualizar la variante: ${variantErrorMessages.join(' | ')}`
-          : 'Shopify devolvió un error al actualizar la variante del producto.';
+          ? `Shopify devolviÃ³ errores al actualizar la variante: ${variantErrorMessages.join(' | ')}`
+          : 'Shopify devolviÃ³ un error al actualizar la variante del producto.';
         try {
           console.error('product_variant_update_graphql_errors', {
             requestId: variantGraphQLRequestId || null,
@@ -2559,7 +2559,7 @@ export async function publishProduct(req, res) {
           requestId: variantGraphQLRequestId,
           ...(variantGraphQLRequestIds.length ? { requestIds: variantGraphQLRequestIds } : {}),
           ...(restFallbackDetail ? { restFallback: restFallbackDetail } : {}),
-          message: 'Shopify devolvió un error al actualizar la variante del producto.',
+          message: 'Shopify devolviÃ³ un error al actualizar la variante del producto.',
           visibility,
           ...meta,
         });
@@ -2571,7 +2571,7 @@ export async function publishProduct(req, res) {
           .filter((msg) => Boolean(msg));
         const friendlyVariantUserError = variantUserErrorMessages.length
           ? variantUserErrorMessages[0]
-          : 'Shopify rechazó la actualización de la variante.';
+          : 'Shopify rechazÃ³ la actualizaciÃ³n de la variante.';
         if (hasGraphQLUserMissingScope) {
           const missingScopes = collectMissingScopes(rawVariantUserErrors);
           const missing = missingScopes.length ? missingScopes : ['write_products'];
@@ -2611,7 +2611,7 @@ export async function publishProduct(req, res) {
         requestId: variantGraphQLRequestId,
         ...(variantGraphQLRequestIds.length ? { requestIds: variantGraphQLRequestIds } : {}),
         ...(restFallbackDetail ? { restFallback: restFallbackDetail } : {}),
-        message: 'Shopify devolvió un error al actualizar la variante del producto.',
+        message: 'Shopify devolviÃ³ un error al actualizar la variante del producto.',
         visibility,
         ...meta,
       });
@@ -2620,8 +2620,8 @@ export async function publishProduct(req, res) {
     if (variantUpdateSource === 'graphql' && variantErrors.length) {
       const variantWarningMessages = collectGraphQLErrorMessages(variantErrors);
       const variantWarningMessage = variantWarningMessages.length
-        ? `Shopify devolvió advertencias al actualizar la variante: ${variantWarningMessages.join(' | ')}`
-        : 'Shopify devolvió advertencias durante la actualización de la variante del producto.';
+        ? `Shopify devolviÃ³ advertencias al actualizar la variante: ${variantWarningMessages.join(' | ')}`
+        : 'Shopify devolviÃ³ advertencias durante la actualizaciÃ³n de la variante del producto.';
       const variantWarningPayload = {
         code: 'shopify_graphql_warning',
         message: variantWarningMessage,
@@ -2666,7 +2666,7 @@ export async function publishProduct(req, res) {
       return res.status(502).json({
         ok: false,
         reason: 'inventory_item_missing',
-        message: 'Shopify no devolvió el inventoryItem de la variante para ajustar el stock.',
+        message: 'Shopify no devolviÃ³ el inventoryItem de la variante para ajustar el stock.',
         requestId: variantRequestIdFinal || null,
         visibility,
         ...meta,
@@ -2746,7 +2746,7 @@ export async function publishProduct(req, res) {
       }
       inventoryTrackWarning = {
         code: 'inventory_tracking_warning',
-        message: 'Ocurrió un error al desactivar el tracking de inventario. Continuamos permitiendo ventas sin stock.',
+        message: 'OcurriÃ³ un error al desactivar el tracking de inventario. Continuamos permitiendo ventas sin stock.',
         detail: { message: err?.message || String(err) },
       };
     }
@@ -2889,7 +2889,7 @@ export async function publishProduct(req, res) {
           body: statusJson,
           requestId: statusRequestId,
           ...(statusRequestIds.length ? { requestIds: statusRequestIds } : {}),
-          message: 'Shopify devolvió un error al activar el producto.',
+          message: 'Shopify devolviÃ³ un error al activar el producto.',
           ...meta,
           visibility,
         });
@@ -2927,8 +2927,8 @@ export async function publishProduct(req, res) {
           errors: formattedStatusErrors,
           requestId: statusRequestId,
           message: statusErrorMessages.length
-            ? `Shopify devolvió errores: ${statusErrorMessages.join(' | ')}`
-            : 'Shopify devolvió un error al activar el producto.',
+            ? `Shopify devolviÃ³ errores: ${statusErrorMessages.join(' | ')}`
+            : 'Shopify devolviÃ³ un error al activar el producto.',
           ...(statusErrorMessages.length ? { messages: statusErrorMessages } : {}),
           ...meta,
           visibility,
@@ -2941,7 +2941,7 @@ export async function publishProduct(req, res) {
           reason: 'product_status_update_invalid_response',
           detail: statusJson,
           requestId: statusRequestId,
-          message: 'Shopify no devolvió un resultado válido al activar el producto.',
+          message: 'Shopify no devolviÃ³ un resultado vÃ¡lido al activar el producto.',
           ...meta,
           visibility,
         });
@@ -2954,7 +2954,7 @@ export async function publishProduct(req, res) {
           .filter(Boolean);
         const friendlyStatusMessage = statusUserErrorMessages.length
           ? statusUserErrorMessages[0]
-          : 'Shopify rechazó el cambio de estado del producto.';
+          : 'Shopify rechazÃ³ el cambio de estado del producto.';
         try {
           console.error('product_status_update_user_errors', {
             requestId: statusRequestId,
@@ -2979,8 +2979,8 @@ export async function publishProduct(req, res) {
       if (statusErrors.length) {
         const statusErrorMessages = collectGraphQLErrorMessages(statusErrors);
         const warningMessage = statusErrorMessages.length
-          ? `Shopify devolvió advertencias al activar el producto: ${statusErrorMessages.join(' | ')}`
-          : 'Shopify devolvió advertencias al activar el producto.';
+          ? `Shopify devolviÃ³ advertencias al activar el producto: ${statusErrorMessages.join(' | ')}`
+          : 'Shopify devolviÃ³ advertencias al activar el producto.';
         const warningPayload = {
           code: 'product_status_update_warning',
           message: warningMessage,
@@ -3022,7 +3022,7 @@ export async function publishProduct(req, res) {
       return res.status(400).json({
         ok: false,
         reason: 'product_not_active',
-        message: 'El producto creado no quedó activo en Shopify. Revisá la visibilidad configurada y volvé a intentarlo.',
+        message: 'El producto creado no quedÃ³ activo en Shopify. RevisÃ¡ la visibilidad configurada y volvÃ© a intentarlo.',
         ...meta,
         visibility,
         requestId: statusRequestId,
@@ -3034,7 +3034,7 @@ export async function publishProduct(req, res) {
       return res.status(400).json({
         ok: false,
         reason: 'product_missing_variant',
-        message: 'Shopify no devolvió variantes para el producto creado.',
+        message: 'Shopify no devolviÃ³ variantes para el producto creado.',
         ...meta,
         visibility,
       });
@@ -3114,7 +3114,7 @@ export async function publishProduct(req, res) {
         return res.status(502).json({
           ok: false,
           reason: publishResult.reason || 'publish_failed',
-          message: 'Shopify rechazó la publicación del producto.',
+          message: 'Shopify rechazÃ³ la publicaciÃ³n del producto.',
           detail: publishResult,
           ...meta,
           visibility,
@@ -3225,11 +3225,13 @@ export async function publishProduct(req, res) {
         } catch (previewErr) {
           console.warn('publish-product preview_upload', previewErr);
         }
-        const previewPath = previewUpload?.path
-          ? (previewUpload.path.startsWith('outputs/') ? previewUpload.path : `outputs/${previewUpload.path}`)
+        const previewRecordPath = previewUpload?.path || null;
+        const previewPath = previewRecordPath
+          ? (previewRecordPath.startsWith('outputs/') ? previewRecordPath : `outputs/${previewRecordPath}`)
           : (pdfUpload.path.startsWith('outputs/') ? pdfUpload.path : `outputs/${pdfUpload.path}`);
         pdfAsset = {
           ...pdfUpload,
+          previewRecordPath,
           previewPath,
         };
 
@@ -3259,6 +3261,7 @@ export async function publishProduct(req, res) {
             job_id: jobIdForRecord || null,
             file_size_bytes: pdfResult.pdfBuffer.length,
             image_hash: imageHash,
+            preview_url: previewRecordPath,
           }, { onConflict: 'job_key', ignoreDuplicates: false });
           if (printsErr) {
             throw printsErr;
@@ -3273,7 +3276,7 @@ export async function publishProduct(req, res) {
         return res.status(413).json({
           ok: false,
           reason: 'pdf_too_large',
-          message: 'El PDF generado supera el tama�o permitido por Supabase.',
+          message: 'El PDF generado supera el tamaño permitido por Supabase.',
           limit_bytes: pdfError.limit ?? undefined,
           size_bytes: pdfError.size ?? undefined,
         });


### PR DESCRIPTION
## Summary
- point prints search preview URLs at the stored preview image instead of the PDF asset
- persist the preview image path in published print records so future searches can resolve it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddd55b00b083278fbb3e2dfc7c024d