### PR TITLE
Fix prints search routing for Vercel dev

### DIFF
--- a/api/[...slug].js
+++ b/api/[...slug].js
@@ -69,6 +69,7 @@ const RATE_LIMITS = {
   'POST prints/upload': { limit: 12, windowMs: 60_000 },
   'GET prints/search': { limit: 30, windowMs: 60_000 },
   'GET prints/preview': { limit: 60, windowMs: 60_000 },
+  'GET prints/health': { limit: 120, windowMs: 60_000 },
   'POST shopify-webhook': { limit: 60, windowMs: 60_000 },
 };
 
@@ -170,6 +171,11 @@ export default withCors(async function handler(req, res) {
         res.statusCode = status;
         res.setHeader('Content-Type', 'application/json; charset=utf-8');
         return res.end(JSON.stringify(body));
+      }
+      case 'GET prints/health': {
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        return res.end(JSON.stringify({ ok: true }));
       }
       case 'GET prints/preview': {
         const { default: previewHandler } = await import('../lib/api/handlers/printsPreview.js');

--- a/api/prints/health.js
+++ b/api/prints/health.js
@@ -1,0 +1,30 @@
+import { randomUUID } from 'node:crypto';
+
+import { withCors } from '../../lib/cors.js';
+
+function sendJson(res, status, payload) {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify(payload));
+}
+
+export default withCors(function printsHealth(req, res) {
+  if (req.method !== 'GET') {
+    const requestId = randomUUID();
+    console.error('prints_health_error', {
+      diagId: requestId,
+      type: 'method_not_allowed',
+      method: req.method,
+    });
+    res.setHeader('Allow', 'GET');
+    return sendJson(res, 405, {
+      ok: false,
+      reason: 'method_not_allowed',
+      code: 'method_not_allowed',
+      message: 'Método no permitido. Usá GET en /api/prints/health.',
+      requestId,
+    });
+  }
+
+  return sendJson(res, 200, { ok: true });
+});

--- a/api/prints/search.js
+++ b/api/prints/search.js
@@ -1,0 +1,37 @@
+import { randomUUID } from 'node:crypto';
+
+import { withCors } from '../../lib/cors.js';
+import { ensureQuery } from '../../lib/_lib/http.js';
+import { searchPrintsHandler } from '../../lib/api/handlers/printsSearch.js';
+
+function sendJson(res, status, payload) {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify(payload));
+}
+
+export default withCors(async function printsSearch(req, res) {
+  if (req.method !== 'GET') {
+    const requestId = randomUUID();
+    console.error('prints_search_error', {
+      diagId: requestId,
+      type: 'method_not_allowed',
+      method: req.method,
+    });
+    res.setHeader('Allow', 'GET');
+    return sendJson(res, 405, {
+      ok: false,
+      reason: 'method_not_allowed',
+      code: 'method_not_allowed',
+      message: 'Método no permitido. Usá GET en /api/prints/search.',
+      requestId,
+    });
+  }
+
+  ensureQuery(req);
+  const { status, body } = await searchPrintsHandler({
+    query: req.query,
+    headers: req.headers,
+  });
+  return sendJson(res, status, body);
+});

--- a/lib/api/handlers/printsSearch.js
+++ b/lib/api/handlers/printsSearch.js
@@ -90,11 +90,24 @@ function isPdfPath(path) {
 export async function searchPrintsHandler({ query, headers } = {}) {
   const diagId = randomUUID();
   const gate = verifyPrintsGate({ headers, diagId });
+  const respondError = (status, code, message, overrides = {}) => ({
+    status,
+    body: {
+      ok: false,
+      reason: overrides.reason ?? code,
+      code,
+      message,
+      requestId: diagId,
+      ...overrides.body,
+    },
+  });
   if (!gate.ok) {
-    return {
-      status: 401,
-      body: { ok: false, reason: 'unauthorized' },
-    };
+    console.error('prints_search_error', {
+      diagId,
+      type: 'unauthorized',
+      message: 'Acceso restringido.',
+    });
+    return respondError(401, 'unauthorized', 'Necesitás ingresar la contraseña temporal para buscar.');
   }
   const rawQuery = typeof query?.query === 'string' ? query.query.trim() : '';
 
@@ -110,14 +123,7 @@ export async function searchPrintsHandler({ query, headers } = {}) {
       type: 'bad_request',
       message: err?.message || 'Parámetros inválidos.',
     });
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        reason: 'bad_request',
-        message: err?.message || 'Parámetros inválidos.',
-      },
-    };
+    return respondError(400, 'bad_request', err?.message || 'Parámetros inválidos.');
   }
 
   if (!rawQuery) {
@@ -126,14 +132,7 @@ export async function searchPrintsHandler({ query, headers } = {}) {
       type: 'missing_query',
       message: 'Se requiere un término de búsqueda.',
     });
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        reason: 'missing_query',
-        message: 'Ingresá un término para buscar.',
-      },
-    };
+    return respondError(400, 'missing_query', 'Ingresá un término para buscar.');
   }
 
   let supabase;
@@ -145,14 +144,7 @@ export async function searchPrintsHandler({ query, headers } = {}) {
       type: 'supabase_init_failed',
       message: err?.message || err,
     });
-    return {
-      status: 502,
-      body: {
-        ok: false,
-        reason: 'supabase_init_failed',
-        message: 'Faltan credenciales de Supabase.',
-      },
-    };
+    return respondError(502, 'supabase_init_failed', 'Faltan credenciales de Supabase.');
   }
 
   const normalizedQuery = rawQuery.normalize('NFKC');
@@ -166,14 +158,7 @@ export async function searchPrintsHandler({ query, headers } = {}) {
       type: 'missing_query',
       message: 'Se requiere un término de búsqueda válido.',
     });
-    return {
-      status: 400,
-      body: {
-        ok: false,
-        reason: 'missing_query',
-        message: 'Ingresá un término para buscar.',
-      },
-    };
+    return respondError(400, 'missing_query', 'Ingresá un término para buscar.');
   }
 
   const measurement = parseMeasurement(effectiveQuery);
@@ -219,14 +204,7 @@ export async function searchPrintsHandler({ query, headers } = {}) {
       type: 'db_query_failed',
       message: err?.message || 'No se pudo consultar la base de datos.',
     });
-    return {
-      status: 502,
-      body: {
-        ok: false,
-        reason: 'db_query_failed',
-        message: 'No se pudo realizar la búsqueda en la base de datos.',
-      },
-    };
+    return respondError(502, 'db_query_failed', 'No se pudo realizar la búsqueda en la base de datos.');
   }
 
   const storage = supabase.storage.from(OUTPUT_BUCKET);

--- a/mgm-front/vite.config.js
+++ b/mgm-front/vite.config.js
@@ -2,6 +2,8 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { fileURLToPath, URL } from 'node:url'
 
+const devApiPort = process.env.DEV_API_PORT || process.env.API_PORT || '3001';
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -13,7 +15,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',
+        target: `http://localhost:${devApiPort}`,
         changeOrigin: true,
         secure: false,
         // sin "rewrite": que /api/cart/start llegue al backend tal cual

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "vercel-build": "node -e \"const fs=require('fs');fs.mkdirSync('public',{recursive:true});fs.writeFileSync('public/index.html','OK');console.log('no-build');\"",
     "vercel:link": "node scripts/vercel-link.mjs",
     "vercel:pull": "vercel pull --yes --environment=development",
-    "dev:vercel": "vercel dev --listen 0.0.0.0:3001",
+    "dev:vercel": "node ./scripts/dev-vercel.mjs",
     "dev:api": "node ./scripts/dev-api-server.mjs",
     "dev:front": "cd mgm-front && vite",
     "dev:all": "concurrently -k -n api,front -c blue,green \"npm:dev:api\" \"npm:dev:front\"",

--- a/scripts/dev-vercel.mjs
+++ b/scripts/dev-vercel.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+
+const envPort = process.env.DEV_API_PORT || process.env.API_PORT || process.env.PORT || '3001';
+const listen = envPort.includes(':') ? envPort : `0.0.0.0:${envPort}`;
+
+const child = spawn('vercel', ['dev', '--listen', listen], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
## Resumen
- Proxy de `/api` en Vite configurado vía `DEV_API_PORT` para apuntar al puerto expuesto por `vercel dev`.
- Nueva función serverless en `/api/prints/search` que reutiliza `searchPrintsHandler` y maneja errores con `requestId`.
- Healthcheck `/api/prints/health` disponible tanto en Express como en serverless.
- Script `dev:vercel` parametrizado con `DEV_API_PORT` para levantar `vercel dev` en el puerto correcto.
- Respuestas de errores en `searchPrintsHandler` enriquecidas con `code` y `requestId`.

## Archivos tocados
- `mgm-front/vite.config.js`: proxy configurable por puerto para `/api`.
- `package.json`: script `dev:vercel` usa wrapper que respeta `DEV_API_PORT`.
- `scripts/dev-vercel.mjs`: wrapper que invoca `vercel dev --listen` con el puerto indicado.
- `api/prints/search.js`: función serverless GET `/api/prints/search` compartiendo lógica con Express.
- `api/prints/health.js`: función serverless GET `/api/prints/health`.
- `api/[...slug].js`: healthcheck agregado y rate limit actualizado para `/api/prints/health`.
- `lib/api/handlers/printsSearch.js`: respuestas de error con `code` y `requestId`, más log de acceso restringido.

## Notas para reproducir
1. `DEV_API_PORT=3001 npm run dev:vercel`
2. En otra terminal: `cd mgm-front && DEV_API_PORT=3001 npm run dev`
3. Abrir `http://localhost:5173` y probar la ruta **/busqueda**.

## Confirmaciones
- [x] Express y la función serverless de `/api/prints/search` delegan en el mismo `searchPrintsHandler`.

## Testing
- `npm run dev:api` (manual, para lanzar el backend y validar llamadas con curl)


------
https://chatgpt.com/codex/tasks/task_e_68ddd9d383488327b54e85e11cdf9074