### PR TITLE
Fix dev server script to use local Vercel CLI

### DIFF
--- a/scripts/dev-vercel.mjs
+++ b/scripts/dev-vercel.mjs
@@ -4,7 +4,9 @@ import { spawn } from 'node:child_process';
 const envPort = process.env.DEV_API_PORT || process.env.API_PORT || process.env.PORT || '3001';
 const listen = envPort.includes(':') ? envPort : `0.0.0.0:${envPort}`;
 
-const child = spawn('vercel', ['dev', '--listen', listen], {
+const npmExec = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+
+const child = spawn(npmExec, ['vercel', 'dev', '--listen', listen], {
   stdio: 'inherit',
   env: process.env,
 });


### PR DESCRIPTION
## Summary
- update the dev Vercel script to invoke the CLI through npx so that the bundled binary is located automatically
- keep the existing argument forwarding and environment handling unchanged

## Testing
- not run (dev server requires interactive Vercel session)


------
https://chatgpt.com/codex/tasks/task_e_68dddbf7113c8327bf642fd6b3f85349