### PR TITLE
Fix dev vercel script on Windows

### DIFF
--- a/scripts/dev-vercel.mjs
+++ b/scripts/dev-vercel.mjs
@@ -1,14 +1,28 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
 
 const envPort = process.env.DEV_API_PORT || process.env.API_PORT || process.env.PORT || '3001';
 const listen = envPort.includes(':') ? envPort : `0.0.0.0:${envPort}`;
 
-const npmExec = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+const require = createRequire(import.meta.url);
 
-const child = spawn(npmExec, ['vercel', 'dev', '--listen', listen], {
+let command = process.execPath;
+let args = [];
+
+try {
+  const vercelBin = require.resolve('vercel/dist/index.js');
+  args = [vercelBin, 'dev', '--listen', listen];
+} catch (error) {
+  const npmExec = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+  command = npmExec;
+  args = ['vercel', 'dev', '--listen', listen];
+}
+
+const child = spawn(command, args, {
   stdio: 'inherit',
   env: process.env,
+  shell: process.platform === 'win32' && command !== process.execPath,
 });
 
 child.on('exit', (code, signal) => {


### PR DESCRIPTION
## Summary
- resolve the local Vercel CLI path when available and fall back to npx otherwise
- ensure the dev:vercel helper spawns the command in a Windows-friendly way

## Testing
- node ./scripts/dev-vercel.mjs

------
https://chatgpt.com/codex/tasks/task_e_68dddc71db2083278d150bcfd0c1bae6