### PR TITLE
Implement streaming Shopify media upload pipeline

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1,5 +1,11 @@
 import sharp from 'sharp';
-import { createHash } from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { promises as fsPromises } from 'node:fs';
+import { PassThrough, Readable, Transform } from 'node:stream';
+import { pipeline as streamPipeline } from 'node:stream/promises';
 import { shopifyAdmin, shopifyAdminGraphQL } from '../shopify.js';
 import { buildProductUrl } from '../publicStorefront.js';
 import { publishToOnlineStore, resolveOnlineStorePublicationId } from '../shopify/publication.js';
@@ -18,6 +24,200 @@ const ONLINE_STORE_MISSING_MESSAGE = [
   'Luego probÃ¡ de nuevo.',
 ].join('\n');
 const ONLINE_STORE_DISABLED_MESSAGE = 'Tu tienda no tiene el canal Online Store habilitado. Instalalo o bien omitÃ­ la publicaciÃ³n y usa Storefront para el carrito.';
+
+const BYTES_PER_MB = 1024 * 1024;
+const MAX_IMAGE_PIXEL_AREA = 12000 * 12000;
+const MEMORY_HEAP_LIMIT = 1.2 * 1024 * 1024 * 1024;
+const MEMORY_RSS_LIMIT = 2 * 1024 * 1024 * 1024;
+const BASE64_CHUNK_CHAR_SIZE = Math.max(4, Math.floor((256 * 1024) / 3) * 4);
+
+sharp.cache({ files: 0, items: 0, memory: 0 });
+sharp.concurrency(1);
+
+function bytesToMb(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return 0;
+  return Number((bytes / BYTES_PER_MB).toFixed(2));
+}
+
+function estimateBase64Size(base64) {
+  if (typeof base64 !== 'string' || !base64) return 0;
+  const cleaned = base64.replace(/\s+/g, '');
+  const padding = (cleaned.endsWith('==') ? 2 : cleaned.endsWith('=') ? 1 : 0);
+  return Math.max(0, Math.floor((cleaned.length * 3) / 4) - padding);
+}
+
+function createBase64DecodeStream(base64) {
+  if (typeof base64 !== 'string' || !base64) {
+    throw new Error('missing_base64_source');
+  }
+
+  let index = 0;
+  let closed = false;
+
+  const source = new Readable({
+    read() {
+      if (closed) return;
+      if (index >= base64.length) {
+        closed = true;
+        this.push(null);
+        return;
+      }
+      const nextIndex = Math.min(base64.length, index + BASE64_CHUNK_CHAR_SIZE);
+      const slice = base64.slice(index, nextIndex);
+      index = nextIndex;
+      this.push(slice);
+    },
+    destroy(err, callback) {
+      closed = true;
+      callback(err);
+    },
+  });
+  source.setEncoding('utf8');
+
+  const decoder = new Transform({
+    readableHighWaterMark: 64 * 1024,
+    writableHighWaterMark: 64 * 1024,
+    transform(chunk, encoding, callback) {
+      let chunkString = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      if (!chunkString) {
+        callback();
+        return;
+      }
+
+      if (this._carry) {
+        chunkString = this._carry + chunkString;
+        this._carry = '';
+      }
+
+      const remainder = chunkString.length % 4;
+      let slice = chunkString;
+      if (remainder) {
+        this._carry = chunkString.slice(chunkString.length - remainder);
+        slice = chunkString.slice(0, chunkString.length - remainder);
+      }
+
+      if (slice.length) {
+        try {
+          const buffer = Buffer.from(slice, 'base64');
+          if (buffer.length) this.push(buffer);
+        } catch (err) {
+          callback(err);
+          return;
+        }
+      }
+
+      callback();
+    },
+    flush(callback) {
+      if (this._carry) {
+        try {
+          const buffer = Buffer.from(this._carry, 'base64');
+          if (buffer.length) this.push(buffer);
+        } catch (err) {
+          callback(err);
+          return;
+        }
+      }
+      this._carry = '';
+      callback();
+    },
+  });
+  decoder._carry = '';
+
+  return source.pipe(decoder);
+}
+
+function logMemoryCheckpoint(label, extra = {}) {
+  const usage = process.memoryUsage();
+  const payload = {
+    label,
+    heapUsedMB: bytesToMb(usage.heapUsed),
+    rssMB: bytesToMb(usage.rss),
+    ...extra,
+  };
+  try {
+    console.info('publish_product_memory_checkpoint', payload);
+  } catch {}
+  return usage;
+}
+
+function enforceMemoryLimits(label, extra = {}) {
+  const usage = process.memoryUsage();
+  if (usage.heapUsed > MEMORY_HEAP_LIMIT || usage.rss > MEMORY_RSS_LIMIT) {
+    const err = new Error('image_too_large_streaming_required');
+    err.code = 'image_too_large_streaming_required';
+    err.heapUsed = usage.heapUsed;
+    err.rss = usage.rss;
+    err.label = label;
+    if (extra && typeof extra === 'object' && extra.requestId) {
+      err.requestId = extra.requestId;
+    }
+    throw err;
+  }
+  return usage;
+}
+
+async function createPreviewImageFile({
+  sourceFactory,
+  applyBlur = false,
+  targetWidth = 600,
+  targetHeight = 600,
+}) {
+  if (typeof sourceFactory !== 'function') {
+    throw new Error('missing_source_factory');
+  }
+
+  const tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'mgm-preview-'));
+  const tempPath = path.join(tempDir, `${randomUUID()}.png`);
+  const source = sourceFactory();
+
+  const transformer = sharp({
+    failOnError: false,
+    sequentialRead: true,
+    limitInputPixels: MAX_IMAGE_PIXEL_AREA,
+  }).rotate();
+
+  if (applyBlur) {
+    transformer.blur(2);
+  }
+
+  transformer.resize(targetWidth, targetHeight, { fit: 'inside', withoutEnlargement: true });
+  transformer.png({ compressionLevel: 9, progressive: true, adaptiveFiltering: true });
+
+  const byteCounter = new PassThrough();
+  let totalBytes = 0;
+  byteCounter.on('data', (chunk) => {
+    totalBytes += chunk.length;
+  });
+
+  const writeStream = createWriteStream(tempPath);
+
+  try {
+    await streamPipeline(source, transformer, byteCounter, writeStream);
+  } catch (err) {
+    source?.destroy?.();
+    transformer?.destroy?.();
+    byteCounter.destroy();
+    writeStream.destroy();
+    await fsPromises.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    if (err && /Input image exceeds pixel limit/i.test(err.message || '')) {
+      const limitErr = new Error('mockup_pixel_limit_exceeded');
+      limitErr.code = 'mockup_pixel_limit_exceeded';
+      limitErr.limit = MAX_IMAGE_PIXEL_AREA;
+      throw limitErr;
+    }
+    throw err;
+  }
+
+  return {
+    path: tempPath,
+    size: totalBytes,
+    mimeType: 'image/png',
+    cleanup: async () => {
+      await fsPromises.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    },
+  };
+}
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
@@ -1411,15 +1611,19 @@ const INVENTORY_SET_ON_HAND_QUANTITIES_MUTATION = `mutation InventorySetOnHandQu
   }
 }`;
 
-async function stagedUploadImage({ filename, buffer, mimeType, maxUploadAttempts = 3 }) {
-  if (!buffer || !(buffer instanceof Buffer) || buffer.length === 0) {
-    throw new Error('staged_upload_empty_buffer');
+async function stagedUploadImage({ filename, mimeType, fileSize, createReadStream, maxUploadAttempts = 3 }) {
+  const normalizedSize = Number(fileSize);
+  if (!Number.isFinite(normalizedSize) || normalizedSize <= 0) {
+    throw new Error('staged_upload_invalid_size');
+  }
+  if (typeof createReadStream !== 'function') {
+    throw new Error('staged_upload_missing_stream_factory');
   }
   const input = [{
     resource: 'IMAGE',
     filename,
     mimeType: mimeType || 'image/png',
-    fileSize: String(buffer.length),
+    fileSize: String(Math.max(1, Math.round(normalizedSize))),
     httpMethod: 'POST',
   }];
   const resp = await shopifyAdminGraphQL(STAGED_UPLOADS_CREATE_MUTATION, { input });
@@ -1468,7 +1672,6 @@ async function stagedUploadImage({ filename, buffer, mimeType, maxUploadAttempts
   }
 
   const parameters = Array.isArray(target.parameters) ? target.parameters : [];
-  const blob = new Blob([buffer], { type: mimeType || 'image/png' });
   const buildFormData = () => {
     const formData = new FormData();
     for (const param of parameters) {
@@ -1478,8 +1681,9 @@ async function stagedUploadImage({ filename, buffer, mimeType, maxUploadAttempts
       const value = typeof param.value === 'string' ? param.value : '';
       formData.append(name, value);
     }
-    formData.append('file', blob, filename);
-    return formData;
+    const bodyStream = createReadStream();
+    formData.append('file', bodyStream, { filename, contentType: mimeType || 'image/png' });
+    return { formData, bodyStream };
   };
 
   const attempts = Math.max(1, Number.isFinite(maxUploadAttempts) ? Number(maxUploadAttempts) : 3);
@@ -1488,11 +1692,19 @@ async function stagedUploadImage({ filename, buffer, mimeType, maxUploadAttempts
   let lastBody = '';
 
   for (let attempt = 0; attempt < attempts; attempt += 1) {
-    const form = buildFormData();
+    const { formData, bodyStream } = buildFormData();
+    logMemoryCheckpoint('staged_upload_post_start', {
+      requestId: requestId || null,
+      uploadRequestId: uploadRequestId || null,
+      attempt: attempt + 1,
+      fileSizeMB: bytesToMb(normalizedSize),
+    });
+    enforceMemoryLimits('staged_upload_post_start', { requestId });
     let uploadResp;
     try {
-      uploadResp = await fetch(target.url, { method: 'POST', body: form });
+      uploadResp = await fetch(target.url, { method: 'POST', body: formData });
     } catch (err) {
+      bodyStream?.destroy?.();
       lastStatus = 0;
       lastBody = err?.message || '';
       if (attempt < attempts - 1) {
@@ -1522,6 +1734,14 @@ async function stagedUploadImage({ filename, buffer, mimeType, maxUploadAttempts
     }
 
     if (uploadResp.ok) {
+      bodyStream?.destroy?.();
+      logMemoryCheckpoint('staged_upload_post_complete', {
+        requestId: requestId || null,
+        uploadRequestId: uploadRequestId || null,
+        attempt: attempt + 1,
+        fileSizeMB: bytesToMb(normalizedSize),
+      });
+      enforceMemoryLimits('staged_upload_post_complete', { requestId });
       try {
         console.info('staged_upload_success', {
           requestId,
@@ -1536,6 +1756,7 @@ async function stagedUploadImage({ filename, buffer, mimeType, maxUploadAttempts
     lastStatus = uploadResp.status;
     const text = await uploadResp.text().catch(() => '');
     lastBody = text.slice(0, 2000);
+    bodyStream?.destroy?.();
 
     if (uploadResp.status >= 500 && uploadResp.status < 600 && attempt < attempts - 1) {
       try {
@@ -1848,25 +2069,99 @@ export async function publishProduct(req, res) {
       : title;
 
     const { mimeType } = parseDataUrlMeta(mockupDataUrl);
-    let imageBuffer = Buffer.from(b64, 'base64');
-    if (!imageBuffer.length) {
-      return res.status(400).json({ ok: false, reason: 'invalid_mockup_dataurl' });
+    const approxInputBytes = estimateBase64Size(b64);
+    logMemoryCheckpoint('mockup_preview_start', {
+      requestId: null,
+      approxInputMB: bytesToMb(approxInputBytes),
+    });
+    try {
+      enforceMemoryLimits('mockup_preview_start');
+    } catch (limitErr) {
+      if (limitErr?.code === 'image_too_large_streaming_required') {
+        return res.status(503).json({
+          ok: false,
+          reason: 'image_too_large_streaming_required',
+          message: 'La imagen requiriÃ³ mÃ¡s memoria de la disponible. SubÃ­ un mockup mÃ¡s chico o reenviÃ¡ en streaming.',
+        });
+      }
+      throw limitErr;
     }
 
-    if (productTypeKey === 'glasspad') {
-      try {
-        imageBuffer = await sharp(imageBuffer)
-          .blur(2)
-          .toBuffer();
-      } catch (glassErr) {
-        console.warn('publish_product_mockup_blur_failed', glassErr);
+    let previewFile = null;
+    try {
+      previewFile = await createPreviewImageFile({
+        sourceFactory: () => createBase64DecodeStream(b64),
+        applyBlur: productTypeKey === 'glasspad',
+      });
+    } catch (previewErr) {
+      if (previewErr?.code === 'mockup_pixel_limit_exceeded') {
+        return res.status(422).json({
+          ok: false,
+          reason: 'mockup_pixel_limit_exceeded',
+          limit: MAX_IMAGE_PIXEL_AREA,
+          message: 'La imagen es demasiado grande para generar una vista previa. SubÃ­ un mockup mÃ¡s chico.',
+        });
       }
+      if (previewErr?.code === 'missing_base64_source' || /invalid/i.test(previewErr?.message || '')) {
+        return res.status(400).json({ ok: false, reason: 'invalid_mockup_dataurl' });
+      }
+      if (previewErr?.code === 'image_too_large_streaming_required') {
+        return res.status(503).json({
+          ok: false,
+          reason: 'image_too_large_streaming_required',
+          message: 'La imagen requiriÃ³ mÃ¡s memoria de la disponible. SubÃ­ un mockup mÃ¡s chico o reenviÃ¡ en streaming.',
+        });
+      }
+      throw previewErr;
+    }
+
+    const previewSizeMB = bytesToMb(previewFile?.size || 0);
+    logMemoryCheckpoint('mockup_preview_complete', {
+      requestId: null,
+      approxInputMB: bytesToMb(approxInputBytes),
+      previewSizeMB,
+    });
+    try {
+      enforceMemoryLimits('mockup_preview_complete');
+    } catch (limitErr) {
+      if (limitErr?.code === 'image_too_large_streaming_required') {
+        await previewFile?.cleanup?.().catch(() => {});
+        return res.status(503).json({
+          ok: false,
+          reason: 'image_too_large_streaming_required',
+          message: 'La imagen requiriÃ³ mÃ¡s memoria de la disponible. SubÃ­ un mockup mÃ¡s chico o reenviÃ¡ en streaming.',
+        });
+      }
+      throw limitErr;
+    }
+
+    b64 = null;
+    mockupDataUrl = '';
+
+    if (!previewFile || !previewFile.size) {
+      await previewFile?.cleanup?.();
+      return res.status(400).json({ ok: false, reason: 'invalid_mockup_preview' });
     }
 
     let stagedImage;
     try {
-      stagedImage = await stagedUploadImage({ filename, buffer: imageBuffer, mimeType });
+      stagedImage = await stagedUploadImage({
+        filename,
+        mimeType: previewFile.mimeType || mimeType,
+        fileSize: previewFile.size,
+        createReadStream: () => createReadStream(previewFile.path),
+      });
     } catch (err) {
+      if (err?.code === 'image_too_large_streaming_required') {
+        await previewFile?.cleanup?.().catch(() => {});
+        return res.status(503).json({
+          ok: false,
+          reason: 'image_too_large_streaming_required',
+          heapUsed: err?.heapUsed,
+          rss: err?.rss,
+          message: 'No se pudo subir el mockup porque se agotÃ³ la memoria disponible. ProbÃ¡ con una imagen mÃ¡s liviana.',
+        });
+      }
       const status = typeof err?.status === 'number' ? err.status : 502;
       const formattedErrors = Array.isArray(err?.errors) && err.errors.length
         ? err.errors
@@ -1929,6 +2224,9 @@ export async function publishProduct(req, res) {
 
       stagedImage = null;
     }
+
+    await previewFile?.cleanup?.().catch(() => {});
+    previewFile = null;
 
 
     const basePrice = isFiniteNumber(priceTransfer) ? Math.max(priceTransfer, 0) : 0;
@@ -2772,12 +3070,26 @@ export async function publishProduct(req, res) {
       let mediaWarningPayload = null;
 
       try {
+        logMemoryCheckpoint('product_create_media_start', {
+          requestId: null,
+          mediaCount: productMediaInput.length,
+          previewSizeMB,
+        });
+        enforceMemoryLimits('product_create_media_start');
+
         const {
           resp: mediaResp,
           json: mediaJson,
           requestId: mediaRequestId,
           attempts: mediaAttempts,
         } = await executeProductCreateMedia({ productId: productIdForVariants, media: productMediaInput });
+
+        logMemoryCheckpoint('product_create_media_complete', {
+          requestId: mediaRequestId || null,
+          mediaCount: productMediaInput.length,
+          previewSizeMB,
+        });
+        enforceMemoryLimits('product_create_media_complete', { requestId: mediaRequestId || null });
 
         const mediaRequestIds = Array.isArray(mediaAttempts)
           ? mediaAttempts.map((entry) => entry?.requestId).filter(Boolean)
@@ -2840,6 +3152,16 @@ export async function publishProduct(req, res) {
           }
         }
       } catch (err) {
+        if (err?.code === 'image_too_large_streaming_required') {
+          return res.status(503).json({
+            ok: false,
+            reason: 'image_too_large_streaming_required',
+            heapUsed: err?.heapUsed,
+            rss: err?.rss,
+            message: 'No se pudo asociar la imagen porque se alcanzÃ³ el lÃ­mite de memoria disponible.',
+          });
+        }
+
         try {
           console.warn('product_create_media_exception', {
             message: err?.message || String(err),


### PR DESCRIPTION
## Summary
- switch the product media pipeline to decode base64 mockups through streaming helpers that resize and blur with sharp without loading full buffers
- upload Shopify staged media from temp files via streaming form-data with memory checkpoints and guard rails to abort when limits are exceeded
- instrument the publish flow with rss/heap logs and staged upload telemetry while keeping the existing checkout contract intact

## Testing
- `npm test` *(fails: missing optional dependency ssim.js in imageToPdf tests and pre-existing moderation expectation)*

## QA / Notas
- Archivos tocados:
  - lib/handlers/publishProduct.js — staged upload streaming, sharp preview streaming, e instrumentación de memoria.
- Cómo reproducir QA A–D:
  - A) Ejecutar `npm run dev:api`, enviar a `/api/publish-product` un mockup JPG 12000×12000 dentro del JSON actual. Verificar en logs `publish_product_memory_checkpoint` que heapUsedMB < 300 y que aparece `product_create_media_success`.
  - B) Repetir con PNG 20000×20000: el endpoint responde 422 `mockup_pixel_limit_exceeded` y no hay OOM.
  - C) Probar con PDF pesado (usar DataURL actual): logs muestran `mockup_preview_complete` con heapUsedMB < 350 y media asociada correctamente.
  - D) Forzar 500 del S3 firmado (simular con proxy o interceptar fetch) y repetir; ver que cada reintento abre un nuevo stream y la memoria no crece.
- Logs esperados: `publish_product_memory_checkpoint` antes/después de preview y uploads, con `heapUsedMB`/`rssMB`; `staged_upload_post_start`/`complete` y `product_create_media_*` mantienen los requestId/uploadRequestId.
- `/api/private/checkout` conserva el contrato y el flujo aún registra `product_create_media_success` cuando Shopify acepta la media.


------
https://chatgpt.com/codex/tasks/task_e_68dddfb916fc8327af0fa900db530950