### PR TITLE
Fix const reassignment in publishProduct handler

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1,3 +1,5 @@
+/* eslint no-const-assign: "error" */
+
 import sharp from 'sharp';
 import os from 'node:os';
 import path from 'node:path';
@@ -1990,6 +1992,11 @@ export async function publishProduct(req, res) {
     }
 
     let body;
+    let productId;
+    let variantId;
+    let checkoutUrl;
+    let cartId;
+    let isPrivate = false;
     try {
       body = await parseJsonBody(req, { limit: PUBLISH_PRODUCT_BODY_LIMIT });
     } catch (err) {
@@ -2004,7 +2011,7 @@ export async function publishProduct(req, res) {
     }
     body = body && typeof body === 'object' ? body : {};
 
-    const mockupDataUrl = typeof body.mockupDataUrl === 'string' ? body.mockupDataUrl : '';
+    let mockupDataUrl = typeof body.mockupDataUrl === 'string' ? body.mockupDataUrl : '';
     const filename = typeof body.filename === 'string' && body.filename ? body.filename : 'mockup.png';
     const warnings = [];
     let variantInventoryMode = 'not_tracked';
@@ -2013,7 +2020,7 @@ export async function publishProduct(req, res) {
     if (!mockupDataUrl) {
       return res.status(400).json({ ok: false, reason: 'missing_mockup_dataurl' });
     }
-    const b64 = (mockupDataUrl.split(',')[1] || '').trim();
+    let b64 = (mockupDataUrl.split(',')[1] || '').trim();
     if (!b64) return res.status(400).json({ ok: false, reason: 'invalid_mockup_dataurl' });
 
     const designNameRaw = typeof body.designName === 'string' ? body.designName.trim() : '';
@@ -2062,7 +2069,7 @@ export async function publishProduct(req, res) {
     const visibility = isPrivateExplicit === true || visibilityRaw === 'private' || visibilityRaw === 'draft'
       ? 'private'
       : 'public';
-    const isPrivate = visibility === 'private';
+    isPrivate = visibility === 'private';
 
     const imageAlt = typeof body.imageAlt === 'string' && body.imageAlt.trim()
       ? body.imageAlt.trim().slice(0, 254)
@@ -2519,6 +2526,8 @@ export async function publishProduct(req, res) {
     }
     const product = productPayload.product || {};
     let meta = buildProductMeta(product, {});
+    productId = meta.productId;
+    variantId = meta.variantId;
     let statusRequestId = null;
     let statusRequestIds = [];
     try {
@@ -2936,6 +2945,8 @@ export async function publishProduct(req, res) {
 
     product.variants = { nodes: [updatedVariant] };
     meta = buildProductMeta(product, updatedVariant);
+    productId = meta.productId;
+    variantId = meta.variantId;
 
     try {
       const variantSuccessLog = {
@@ -3331,6 +3342,8 @@ export async function publishProduct(req, res) {
       }
 
       meta = buildProductMeta(product, {});
+      productId = meta.productId;
+      variantId = meta.variantId;
 
       try {
         console.info('product_status_update_success', {
@@ -3610,6 +3623,9 @@ export async function publishProduct(req, res) {
       });
     }
 
+    productId = productId ?? meta.productId ?? null;
+    variantId = variantId ?? meta.variantId ?? null;
+
     const warningMessages = warnings
       .map((entry) => (entry && typeof entry.message === 'string' ? entry.message : typeof entry === 'string' ? entry : ''))
       .filter((entry) => entry);
@@ -3620,12 +3636,22 @@ export async function publishProduct(req, res) {
     const responsePayload = {
       ok: true,
       ...meta,
+      productId,
+      variantId,
       status: product?.status,
       visibility,
       ...(warnings.length ? { warnings } : {}),
       ...(warningMessages.length ? { warningMessages } : {}),
       ...(warningCodes.length ? { warningCodes } : {}),
     };
+
+    if (typeof checkoutUrl === 'string' && checkoutUrl.trim()) {
+      responsePayload.checkoutUrl = checkoutUrl.trim();
+    }
+
+    if (typeof cartId === 'string' && cartId.trim()) {
+      responsePayload.cartId = cartId.trim();
+    }
 
     if (pdfAsset) {
       const downloadUrl = pdfAsset.publicUrl || pdfAsset.signedUrl || null;


### PR DESCRIPTION
## Summary
- lib/handlers/publishProduct.js: enforce `no-const-assign`, replace mutable constants with sentinels, and ensure response payload reflects resolved product/variant identifiers

## Testing
- npm test *(fails: missing optional fixture dependencies `ssim.js`, moderation expectation mismatch in existing suite)*
- npx eslint lib/handlers/publishProduct.js *(fails: repository is not yet configured with an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ddebf8bf5483278e7103bec7876136