### PR TITLE
Refine image moderation pipeline and QA tooling

### DIFF
--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -1,38 +1,59 @@
 # Moderación de imágenes
 
-Este proyecto usa moderación **100% gratuita**: filtro rápido en el cliente con `nsfwjs` y verificación final en el servidor con heurísticas locales (`sharp`) y OCR con `tesseract.js`.
+El pipeline de moderación combina verificaciones estrictas para extremismo y desnudez real, e inhibidores para reducir falsos positivos con fondos rosados/mapas.
 
-El servidor clasifica cada imagen en **BLOCK**, **REVIEW** o **ALLOW** y devuelve `label`, `reasons` y `confidence` (0–1).
+## Flujo general
 
-Prioridad de las reglas:
+1. **Símbolos nazis** – Se ejecuta siempre primero. Plantillas `pHash` + correlación normalizada para distintos ángulos y variantes (banderas, invertidos). Si la confianza ≥ `SWASTIKA_DET_THRESH` o hay ≥ 2 coincidencias medias, se bloquea. Los `boundingBoxes` detectados se registran en los logs.
+2. **Clasificador real vs. ilustración** – Heurística basada en paleta/edges; si la probabilidad de foto real es `< REALNESS_THRESH` se permite inmediatamente (sin pasar por NSFW) pero se sigue monitoreando símbolos nazis.
+3. **Detección de piel/personas** – Se obtiene la máscara de piel (`sharp` en 256px) y se derivan candidatos de persona cuando los blobs son suficientemente grandes (≥2 % del frame) y con confianza ≥ `PERSON_DET_THRESH`.
+4. **NSFW (desnudez real)** – Sólo se evalúa cuando hay foto real **y** personas detectadas. El puntaje heurístico debe superar `NSFW_THRESH` y además pasar tres compuertas:
+   - `SKIN_RATIO_IN_PERSON` (mínimo 12 % de piel dentro de cada bbox),
+   - `SKIN_LARGE_REGION` (≥20 000 px aproximados en la región contigua mayor),
+   - `SKIN_INTERSECTION` (≥60 % de la máscara de piel dentro de las personas).
+5. **Inhibidores “rosa”** – Antes de confirmar el bloqueo por NSFW se revisan: dominancia rosa sin personas, OCR con ≥100 tokens y ≥5 topónimos, alta densidad de bordes finos sin blobs grandes y consistencia global de piel (fondos planos). Si alguno aplica, se permite la imagen y se archiva (opcional) en Supabase bajo `fp-rosa/<fecha>`.
 
-1. **BLOCK** – Desnudez/sexual de personas reales (detección de piel, heurísticas de blob y meta datos).
-2. **BLOCK** – Extremismo/Nazismo (pHash, colorimetría y OCR/texto).
-3. **ALLOW** – Contenido animado/dibujado con alta confianza de no ser personas reales.
-4. **REVIEW** – Casos ambiguos: rostros ocultos, baja resolución o dudas entre real/dibujado.
+Los resultados finales son `ALLOW` o `BLOCK` (no usamos `REVIEW` en la API). Cada respuesta incluye `label`, `reasons`, `confidence` y `details` para depuración.
+
+## Configuración
+
+Los umbrales viven en [`lib/moderation/config.js`](../lib/moderation/config.js) y se pueden ajustar vía variables de entorno (prefijo `MOD_...`). Ejemplo:
+
+```
+MOD_SWASTIKA_DET_THRESH=0.6
+MOD_REALNESS_THRESH=0.6
+MOD_PERSON_DET_THRESH=0.5
+MOD_NSFW_THRESH=0.7
+MOD_SKIN_RATIO_IN_PERSON=0.12
+MOD_SKIN_LARGE_REGION=20000
+MOD_SKIN_INTERSECTION=0.6
+MOD_PINK_DOMINANCE=0.55
+MOD_OCR_TOKEN_MIN=100
+MOD_OCR_GEOS_MIN=5
+MODERATION_STRICT=false    # eleva NSFW a 0.75 si suben los falsos positivos
+MODERATION_SKIP_OCR=1      # solo para CI/local; salta OCR
+```
+
+El flag `MODERATION_STRICT=false` relaja el umbral NSFW a 0.75 sin redeploy.
+
+## Logs y métricas
+
+Cada verificación escribe `console.info('moderation.image', {...})` con los campos claves: `{hasPerson, nsfw, skinInPerson, pinkRatio, ocrTokens, geoHits, naziScore, decision}`. Esto permite exportar métricas a herramientas externas (Datadog, Logflare, etc.).
+
+## QA
+
+El script [`scripts/moderation-qa-report.mjs`](../scripts/moderation-qa-report.mjs) procesa un dataset anotado (`annotations.json`) y reporta precisión/recall junto con la lista de falsos positivos corregidos por los inhibidores rosa. Ejecutar:
+
+```
+node scripts/moderation-qa-report.mjs tests/moderation/qa
+```
+
+El JSON de salida incluye `totals`, `precision`, `recall` y los archivos corregidos.
 
 ## Cliente
-- `nsfwjs` (TensorFlow.js 3.x) se carga de forma perezosa y sólo bloquea desnudos reales.
-- Se bloquea inmediatamente si el nombre del archivo o del modelo contiene términos nazis.
-- Anime o dibujos se permiten cuando el analizador tiene confianza ≥ 0.7 de que no son personas reales.
 
-## Servidor
-- Endpoint: `POST /api/moderate-image`.
-- No requiere claves externas ni proveedores pagos.
-- Se detecta discurso de odio nazi usando:
-  - Búsqueda de términos prohibidos en nombre del archivo/modelo y en el texto detectado vía OCR (`tesseract.js`).
-  - Búsqueda de símbolos de odio (esvásticas, banderas) con `pHash` y heurísticas de color.
-- Los desnudos se filtran mediante detección de piel. También se estima si la imagen es animada vs. real para aplicar las reglas anteriores.
-- Se penalizan automáticamente fondos de color muy uniforme y con poca textura (p. ej. wallpapers) para evitar falsos positivos de "desnudez real".
+El front usa `nsfwjs` de manera perezosa para bloquear casos evidentes antes de subirlos, pero la decisión final siempre proviene del endpoint `POST /api/moderate-image`.
 
-Variables opcionales en `.env`:
+## Objetivo
 
-```
-NUDE_REAL_THRESHOLD=0.75
-HATE_SPEECH_EXPLICIT_THRESHOLD=0.85
-MODERATION_SKIP_OCR=1
-```
-
-> `MODERATION_SKIP_OCR` se recomienda únicamente para pruebas locales/CI y evita que `tesseract.js` descargue datos pesados.
-
-El objetivo es bloquear únicamente desnudos reales y extremismo nazi; todo lo demás pasa o queda pendiente de revisión según la confianza calculada.
+Mantener bloqueados los desnudos de personas reales y cualquier símbolo nazi (en cualquier estilo) mientras se reducen los falsos positivos típicos de fondos o mapas rosados.

--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -1,6 +1,7 @@
 import sharp from 'sharp';
 import { pHashFromGray, hamming } from '../hashing.js';
 import { hateTextCheck } from '../moderation/hate.js';
+import { getModerationConfig } from '../moderation/config.js';
 
 const SKIP_OCR = process.env.MODERATION_SKIP_OCR === '1';
 
@@ -50,10 +51,10 @@ async function extractTextHints(buffer) {
   }
 }
 
-async function detectSkin(buffer) {
+async function detectSkin(buffer, { targetWidth = 256, originalMeta = null } = {}) {
   const { data, info } = await sharp(buffer)
     .removeAlpha()
-    .resize({ width: 256, withoutEnlargement: false })
+    .resize({ width: targetWidth, withoutEnlargement: false })
     .raw()
     .toBuffer({ resolveWithObject: true });
   const w = info.width, h = info.height;
@@ -69,6 +70,8 @@ async function detectSkin(buffer) {
   let centerTotal = 0;
   let centerSkin = 0;
   const skinToneSamples = [];
+
+  const components = [];
 
   for (let i = 0, p = 0; p < total; i += info.channels, p++) {
     const R = data[i], G = data[i + 1], B = data[i + 2];
@@ -134,10 +137,30 @@ async function detectSkin(buffer) {
         }
       }
     }
+    const bboxWidth = maxX - minX + 1;
+    const bboxHeight = maxY - minY + 1;
+    const bboxArea = bboxWidth * bboxHeight;
+    const bboxAreaRatio = bboxArea / total;
+    const component = {
+      area,
+      minX,
+      maxX,
+      minY,
+      maxY,
+      bboxWidth,
+      bboxHeight,
+      bboxArea,
+      bboxAreaRatio,
+      centerHits,
+      centerRatio: area ? centerHits / area : 0,
+      fillRatio: bboxArea ? area / bboxArea : 0,
+    };
+    components.push(component);
+
     if (area > maxBlob) {
       secondBlob = maxBlob;
       maxBlob = area;
-      maxBlobBox = { minX, maxX, minY, maxY };
+      maxBlobBox = { minX, maxX, minY, maxY, bboxArea, bboxAreaRatio };
       maxBlobCenterHits = centerHits;
     } else if (area > secondBlob) {
       secondBlob = area;
@@ -145,9 +168,7 @@ async function detectSkin(buffer) {
   }
 
   const centerSkinPercent = centerTotal ? centerSkin / centerTotal : 0;
-  const largestBlobBoxArea = maxBlobBox
-    ? (maxBlobBox.maxX - maxBlobBox.minX + 1) * (maxBlobBox.maxY - maxBlobBox.minY + 1)
-    : 0;
+  const largestBlobBoxArea = maxBlobBox ? maxBlobBox.bboxArea : 0;
   const largestBlobBoxCoverage = maxBlobBox && total ? largestBlobBoxArea / total : 0;
   const largestBlob = total ? maxBlob / total : 0;
   const secondLargestBlob = total ? secondBlob / total : 0;
@@ -174,14 +195,31 @@ async function detectSkin(buffer) {
     toneVariance = Math.sqrt((varCb + varCr) / (skinToneSamples.length - 1)) / 100;
   }
 
+  let pixelScale = 1;
+  if (originalMeta?.width && originalMeta?.height) {
+    const origPixels = originalMeta.width * originalMeta.height;
+    const resizedPixels = w * h;
+    if (resizedPixels > 0) {
+      pixelScale = origPixels / resizedPixels;
+    }
+  }
+
   return {
+    width: w,
+    height: h,
+    mask,
+    skinPixels: skinCount,
     skinPercent: total ? skinCount / total : 0,
     largestBlob,
+    largestBlobPixels: maxBlob,
     secondLargestBlob,
     centerSkinPercent,
     largestBlobBoxCoverage,
     largestBlobCenterRatio,
     toneVariance,
+    totalPixels: total,
+    components,
+    pixelScale,
   };
 }
 
@@ -240,89 +278,537 @@ function swastikaSVG({ size = 64, stroke = 10, invert = false, rotate = 0, flag 
   return `\n<svg xmlns="http://www.w3.org/2000/svg" width="${s}" height="${s}" viewBox="0 0 ${s} ${s}">\n  <rect width="100%" height="100%" fill="${bg}"/>\n  ${circle}\n  <g transform="rotate(${rotate}, ${m}, ${m})" fill="${c}">\n    <rect x="${m - stroke/2}" y="${m - s*0.35}" width="${stroke}" height="${s*0.7}"/>\n    <rect x="${m - s*0.35}" y="${m - stroke/2}" width="${s*0.7}" height="${stroke}"/>\n    <rect x="${m + stroke*0.5}" y="${m - s*0.35}" width="${s*0.2}" height="${stroke}"/>\n    <rect x="${m - stroke/2}" y="${m + stroke*0.5}" width="${stroke}" height="${s*0.2}"/>\n    <rect x="${m - s*0.35}" y="${m - stroke*0.5 - s*0.2}" width="${s*0.2}" height="${stroke}"/>\n    <rect x="${m - stroke*0.5 - s*0.2}" y="${m - stroke/2}" width="${stroke}" height="${s*0.2}"/>\n  </g>\n</svg>`;
 }
 
+function normalizeForCorrelation(data) {
+  const length = data.length;
+  const normalized = new Float64Array(length);
+  if (!length) return normalized;
+  let mean = 0;
+  for (let i = 0; i < length; i++) mean += data[i];
+  mean /= length;
+  let variance = 0;
+  for (let i = 0; i < length; i++) {
+    const diff = data[i] - mean;
+    normalized[i] = diff;
+    variance += diff * diff;
+  }
+  const denom = variance > 0 ? Math.sqrt(variance) : 1;
+  for (let i = 0; i < length; i++) normalized[i] /= denom;
+  return normalized;
+}
+
+function normalizedCorrelation(a, b) {
+  const len = Math.min(a.length, b.length);
+  if (!len) return 0;
+  let dot = 0;
+  for (let i = 0; i < len; i++) dot += a[i] * b[i];
+  return dot / len;
+}
+
 let TEMPLATES = null;
 async function getTemplates() {
   if (TEMPLATES) return TEMPLATES;
   const svgs = [];
   const rotations = [0, 45, 90, 135];
   const strokes = [8, 10, 12];
-  for (const r of rotations) for (const st of strokes) svgs.push(swastikaSVG({ rotate: r, stroke: st, invert: false, flag: false }));
-  // flags variants
-  for (const r of [0]) for (const st of [10]) svgs.push(swastikaSVG({ rotate: r, stroke: st, invert: false, flag: true }));
-  const hashes = [];
-  for (const svg of svgs) {
-    const buf = Buffer.from(svg);
-    const { data, info } = await sharp(buf).resize(64, 64).grayscale().raw().toBuffer({ resolveWithObject: true });
-    const hash = pHashFromGray(data, info.width, info.height);
-    hashes.push(hash);
+  for (const r of rotations) {
+    for (const st of strokes) {
+      svgs.push({ svg: swastikaSVG({ rotate: r, stroke: st, invert: false, flag: false }), rotate: r, stroke: st, flag: false });
+      svgs.push({ svg: swastikaSVG({ rotate: r, stroke: st, invert: true, flag: false }), rotate: r, stroke: st, flag: false, invert: true });
+    }
   }
-  TEMPLATES = hashes;
+  // flags variants
+  for (const r of [0]) {
+    for (const st of [10]) {
+      svgs.push({ svg: swastikaSVG({ rotate: r, stroke: st, invert: false, flag: true }), rotate: r, stroke: st, flag: true });
+    }
+  }
+
+  const templates = [];
+  for (const variant of svgs) {
+    const buf = Buffer.from(variant.svg);
+    const { data, info } = await sharp(buf)
+      .resize(72, 72, { fit: 'contain', background: { r: 255, g: 255, b: 255, alpha: 1 } })
+      .grayscale()
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+    const hash = pHashFromGray(data, info.width, info.height);
+    const normalized = normalizeForCorrelation(data);
+    templates.push({
+      hash,
+      data: normalized,
+      width: info.width,
+      height: info.height,
+      variant,
+    });
+  }
+  TEMPLATES = templates;
   return TEMPLATES;
 }
 
-async function detectNazi(buffer) {
-  const image = sharp(buffer).removeAlpha();
-  const { data, info } = await image.resize(64, 64).grayscale().raw().toBuffer({ resolveWithObject: true });
-  const hash = pHashFromGray(data, info.width, info.height);
-  const tmpls = await getTemplates();
+async function extractSwastikaBoxes(buffer, meta) {
+  try {
+    const { data, info } = await sharp(buffer)
+      .removeAlpha()
+      .resize({ width: 192, height: 192, fit: 'inside', withoutEnlargement: false, background: { r: 255, g: 255, b: 255 } })
+      .grayscale()
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+
+    const { width, height } = info;
+    const total = width * height;
+    const mask = new Uint8Array(total);
+    for (let i = 0; i < total; i++) {
+      const v = data[i];
+      mask[i] = v < 90 ? 1 : 0;
+    }
+
+    const visited = new Uint8Array(total);
+    const boxes = [];
+    const qx = new Int32Array(total);
+    const qy = new Int32Array(total);
+    for (let i = 0; i < total; i++) {
+      if (!mask[i] || visited[i]) continue;
+      let head = 0;
+      let tail = 0;
+      qx[tail] = i % width;
+      qy[tail] = Math.floor(i / width);
+      visited[i] = 1;
+      tail++;
+      let minX = width;
+      let minY = height;
+      let maxX = 0;
+      let maxY = 0;
+      let area = 0;
+      while (head < tail) {
+        const x = qx[head];
+        const y = qy[head];
+        head++;
+        area++;
+        if (x < minX) minX = x;
+        if (y < minY) minY = y;
+        if (x > maxX) maxX = x;
+        if (y > maxY) maxY = y;
+        const neighbors = [
+          [x + 1, y],
+          [x - 1, y],
+          [x, y + 1],
+          [x, y - 1],
+        ];
+        for (const [nx, ny] of neighbors) {
+          if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+          const idx = ny * width + nx;
+          if (!mask[idx] || visited[idx]) continue;
+          visited[idx] = 1;
+          qx[tail] = nx;
+          qy[tail] = ny;
+          tail++;
+        }
+      }
+
+      const bboxWidth = maxX - minX + 1;
+      const bboxHeight = maxY - minY + 1;
+      const bboxArea = bboxWidth * bboxHeight;
+      const areaRatio = bboxArea / total;
+      if (areaRatio < 0.01 || areaRatio > 0.4) continue;
+
+      const norm = {
+        x0: minX / width,
+        y0: minY / height,
+        x1: (maxX + 1) / width,
+        y1: (maxY + 1) / height,
+      };
+      const scaleX = meta?.width ? meta.width : width;
+      const scaleY = meta?.height ? meta.height : height;
+      boxes.push({
+        normalized: norm,
+        pixels: {
+          x: Math.round(norm.x0 * scaleX),
+          y: Math.round(norm.y0 * scaleY),
+          width: Math.round((norm.x1 - norm.x0) * scaleX),
+          height: Math.round((norm.y1 - norm.y0) * scaleY),
+        },
+        areaRatio,
+        area,
+      });
+    }
+    return boxes;
+  } catch {
+    return [];
+  }
+}
+
+async function detectNazi(buffer, { config, meta, originalBuffer } = {}) {
+  const templates = await getTemplates();
+  const analysisBuffer = await sharp(buffer)
+    .removeAlpha()
+    .resize({ width: 256, height: 256, fit: 'inside', withoutEnlargement: false, background: { r: 255, g: 255, b: 255 } })
+    .toBuffer();
+
+  const rotations = [0, 45, 90, 135, 180, 225, 270, 315];
+  const matches = [];
+  let topScore = 0;
   let minDist = Infinity;
-  for (const th of tmpls) {
-    const d = hamming(hash, th);
-    if (d < minDist) minDist = d;
-    if (d <= 12) return { nazi: true, reason: 'phash', score: d };
+
+  for (const rotation of rotations) {
+    const { data, info } = await sharp(analysisBuffer)
+      .rotate(rotation, { background: { r: 255, g: 255, b: 255, alpha: 1 } })
+      .resize(64, 64, { fit: 'fill' })
+      .grayscale()
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+
+    const hash = pHashFromGray(data, info.width, info.height);
+    const normalized = normalizeForCorrelation(data);
+
+    for (const template of templates) {
+      const dist = hamming(hash, template.hash);
+      const hashScore = clamp(1 - dist / 32);
+      if (dist < minDist) minDist = dist;
+      if (hashScore < 0.35) continue;
+      const corr = normalizedCorrelation(normalized, template.data);
+      const corrScore = clamp((corr - 0.35) / 0.65);
+      const confidence = clamp(hashScore * 0.6 + corrScore * 0.4);
+      if (confidence <= 0.2) continue;
+      matches.push({
+        confidence,
+        rotation,
+        hashScore,
+        corrScore,
+        dist,
+        template: template.variant,
+      });
+      if (confidence > topScore) topScore = confidence;
+    }
   }
-  const { data: d2, info: i2 } = await sharp(buffer).removeAlpha().resize({ width: 128 }).raw().toBuffer({ resolveWithObject: true });
-  const w = i2.width, h = i2.height, total = w * h;
-  let redDom = 0, whiteInCircle = 0, blackStroke = 0, inCircleCount = 0, inRingCount = 0;
-  const redMask = new Uint8Array(total);
-  const whiteMask = new Uint8Array(total);
-  const blackMask = new Uint8Array(total);
-  const cx = Math.floor(w / 2), cy = Math.floor(h / 2);
-  const r = Math.floor(Math.min(w, h) * 0.3);
-  for (let p = 0, idx = 0; p < total; p++, idx += i2.channels) {
-    const R = d2[idx], G = d2[idx + 1], B = d2[idx + 2];
-    const isRed = R > 200 && G < 90 && B < 90;
-    const isWhite = R > 220 && G > 220 && B > 220;
-    const isBlack = R < 55 && G < 55 && B < 55;
-    if (isRed) {
-      redDom++;
-      redMask[p] = 1;
+
+  matches.sort((a, b) => b.confidence - a.confidence);
+  const strongMatches = matches.filter((m) => m.confidence >= (config?.SWASTIKA_DET_THRESH ?? 0.6));
+  const mediumMatches = matches.filter((m) => m.confidence >= 0.5);
+  let block = strongMatches.length > 0 || mediumMatches.length >= 2;
+  const boxes = await extractSwastikaBoxes(analysisBuffer, meta);
+
+  let reason = block ? 'detector' : 'none';
+  let colorCheck = null;
+  if (!block) {
+    const colorSource = originalBuffer || buffer;
+    colorCheck = await detectNaziColors(colorSource, minDist);
+    if (colorCheck.block) {
+      block = true;
+      reason = colorCheck.reason;
     }
-    if (isWhite) {
-      whiteInCircle++;
-      whiteMask[p] = 1;
-    }
-    if (isBlack) {
-      blackStroke++;
-      blackMask[p] = 1;
-    }
-    const x = p % w, y = Math.floor(p / w);
-    const dist = Math.hypot(x - cx, y - cy);
-    if (dist <= r) inCircleCount++;
-    if (dist > r * 0.85 && dist < r * 1.1) inRingCount++;
   }
-  const redRatio = redDom / total;
-  const whiteCircleRatio = inCircleCount ? whiteInCircle / inCircleCount : 0;
-  const blackStrokeRatio = inRingCount ? blackStroke / inRingCount : 0;
-  const COLOR_MATCH_THRESHOLDS = {
-    red: 0.5,
-    white: 0.75,
-    black: 0.18,
-    minDist: 24,
+
+  return {
+    nazi: block,
+    block,
+    reason,
+    score: block ? Math.max(topScore, colorCheck?.scoreValue ?? 0) : topScore,
+    matches: matches.slice(0, 6),
+    boundingBoxes: boxes,
+    color: colorCheck,
   };
-  if (
-    minDist <= COLOR_MATCH_THRESHOLDS.minDist &&
-    redRatio >= COLOR_MATCH_THRESHOLDS.red &&
-    whiteCircleRatio >= COLOR_MATCH_THRESHOLDS.white &&
-    blackStrokeRatio >= COLOR_MATCH_THRESHOLDS.black
-  ) {
+}
+
+async function detectNaziColors(buffer, minDist) {
+  const { data, info } = await sharp(buffer)
+    .removeAlpha()
+    .resize({ width: 128, height: 128, fit: 'inside', withoutEnlargement: false })
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const w = info.width;
+  const h = info.height;
+  const total = w * h;
+  let redDom = 0;
+  let whiteInCircle = 0;
+  let blackStroke = 0;
+  let inCircle = 0;
+  let inRing = 0;
+  const cx = Math.floor(w / 2);
+  const cy = Math.floor(h / 2);
+  const r = Math.floor(Math.min(w, h) * 0.3);
+  for (let idx = 0, p = 0; p < total; p++, idx += info.channels) {
+    const R = data[idx];
+    const G = data[idx + 1];
+    const B = data[idx + 2];
+    const isRed = R > 180 && G < 110 && B < 110;
+    const isWhite = R > 215 && G > 215 && B > 215;
+    const isBlack = R < 70 && G < 70 && B < 70;
+    if (isRed) redDom++;
+    const x = p % w;
+    const y = Math.floor(p / w);
+    const dist = Math.hypot(x - cx, y - cy);
+    if (dist <= r) {
+      inCircle++;
+      if (isWhite) whiteInCircle++;
+    }
+    if (dist > r * 0.85 && dist < r * 1.15) {
+      inRing++;
+      if (isBlack) blackStroke++;
+    }
+  }
+  const redRatio = total ? redDom / total : 0;
+  const whiteCircleRatio = inCircle ? whiteInCircle / inCircle : 0;
+  const blackStrokeRatio = inRing ? blackStroke / inRing : 0;
+  const thresholds = {
+    red: 0.45,
+    white: 0.45,
+    black: 0.18,
+    minDist: 26,
+  };
+  const matchesColor =
+    redRatio >= thresholds.red &&
+    whiteCircleRatio >= thresholds.white &&
+    blackStrokeRatio >= thresholds.black &&
+    (minDist ?? Infinity) <= thresholds.minDist;
+  return {
+    block: matchesColor,
+    reason: matchesColor ? 'color_flag' : 'none',
+    metrics: { redRatio, whiteCircleRatio, blackStrokeRatio, minDist },
+    scoreValue: matchesColor ? Math.max(redRatio, whiteCircleRatio, blackStrokeRatio) : 0,
+  };
+}
+
+function toPersonFromComponent(component, skin, meta) {
+  const totalPixels = skin.totalPixels || 1;
+  const x0 = component.minX / skin.width;
+  const y0 = component.minY / skin.height;
+  const x1 = (component.maxX + 1) / skin.width;
+  const y1 = (component.maxY + 1) / skin.height;
+  const scaleX = meta?.width ? meta.width : skin.width;
+  const scaleY = meta?.height ? meta.height : skin.height;
+  const bboxPixels = component.bboxArea * skin.pixelScale;
+  const skinPixels = component.area * skin.pixelScale;
+  const aspect = component.bboxHeight / Math.max(1, component.bboxWidth);
+  const areaRatio = component.area / totalPixels;
+  const bboxAreaRatio = component.bboxArea / totalPixels;
+  const areaScore = clamp((areaRatio - 0.015) / 0.35);
+  const fillScore = clamp((component.fillRatio - 0.18) / 0.55);
+  const centerScore = clamp((component.centerRatio - 0.15) / 0.45);
+  const aspectScore = clamp(1 - Math.abs(Math.log(aspect || 1) / Math.log(3)));
+  const tallScore = clamp((component.bboxHeight / skin.height - 0.25) / 0.6);
+  const confidence = clamp(areaScore * 0.28 + fillScore * 0.24 + centerScore * 0.22 + aspectScore * 0.12 + tallScore * 0.14);
+  return {
+    confidence,
+    areaRatio,
+    bboxAreaRatio,
+    fillRatio: component.fillRatio,
+    centerRatio: component.centerRatio,
+    bbox: {
+      x0,
+      y0,
+      x1,
+      y1,
+      width: x1 - x0,
+      height: y1 - y0,
+    },
+    bboxPixels,
+    skinPixels,
+    aspect,
+    component,
+    originalPixels: {
+      x: Math.round(x0 * scaleX),
+      y: Math.round(y0 * scaleY),
+      width: Math.round((x1 - x0) * scaleX),
+      height: Math.round((y1 - y0) * scaleY),
+    },
+  };
+}
+
+function estimatePersonsFromSkin(skin, meta, config) {
+  if (!skin?.components?.length) return [];
+  const candidates = skin.components
+    .filter((c) => c.area / skin.totalPixels >= 0.01)
+    .map((component) => toPersonFromComponent(component, skin, meta));
+  candidates.sort((a, b) => b.confidence - a.confidence);
+  // Keep top components but limit to avoid noise
+  return candidates.slice(0, 8).map((person) => ({ ...person, threshold: config?.PERSON_DET_THRESH ?? 0.5 }));
+}
+
+function computePersonSkinStats(persons, skin) {
+  if (!persons?.length) {
     return {
-      nazi: true,
-      reason: 'flag_heuristic',
-      score: { redRatio, whiteCircleRatio, blackStrokeRatio, minDist },
+      maxSkinRatio: 0,
+      skinIntersection: 0,
+      totalSkinInPersons: 0,
+      largestRegionPixels: skin?.largestBlobPixels ? skin.largestBlobPixels * skin.pixelScale : 0,
     };
   }
-  return { nazi: false, reason: 'none', score: minDist };
+  let maxSkinRatio = 0;
+  let totalSkin = 0;
+  for (const person of persons) {
+    const skinRatio = person.component?.bboxArea ? person.component.area / person.component.bboxArea : 0;
+    if (skinRatio > maxSkinRatio) maxSkinRatio = skinRatio;
+    totalSkin += person.component?.area || 0;
+  }
+  const skinIntersection = skin?.skinPixels ? totalSkin / skin.skinPixels : 0;
+  return {
+    maxSkinRatio,
+    skinIntersection,
+    totalSkinInPersons: totalSkin * (skin?.pixelScale || 1),
+    largestRegionPixels: skin?.largestBlobPixels ? skin.largestBlobPixels * (skin?.pixelScale || 1) : 0,
+  };
+}
+
+async function computeColorStats(buffer) {
+  const { data, info } = await sharp(buffer)
+    .removeAlpha()
+    .resize({ width: 192, height: 192, fit: 'inside', withoutEnlargement: false })
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const total = info.width * info.height;
+  let pink = 0;
+  let lumaSum = 0;
+  let lumaSq = 0;
+  for (let i = 0; i < total; i++) {
+    const idx = i * info.channels;
+    const R = data[idx] / 255;
+    const G = data[idx + 1] / 255;
+    const B = data[idx + 2] / 255;
+    const max = Math.max(R, G, B);
+    const min = Math.min(R, G, B);
+    const delta = max - min;
+    let hue = 0;
+    if (delta > 1e-5) {
+      if (max === R) hue = ((G - B) / delta) % 6;
+      else if (max === G) hue = (B - R) / delta + 2;
+      else hue = (R - G) / delta + 4;
+      hue *= 60;
+      if (hue < 0) hue += 360;
+    }
+    const saturation = max === 0 ? 0 : delta / max;
+    const value = max;
+    const luma = 0.2126 * R + 0.7152 * G + 0.0722 * B;
+    lumaSum += luma;
+    lumaSq += luma * luma;
+    const isPink =
+      saturation >= 0.22 &&
+      value >= 0.25 &&
+      ((hue >= 285 && hue <= 345) || (hue >= 330 || hue <= 20) || (R > 0.7 && B > 0.4 && G < 0.6));
+    if (isPink) pink++;
+  }
+  const pinkRatio = total ? pink / total : 0;
+  const meanLuma = total ? lumaSum / total : 0;
+  const lumaVariance = total ? Math.max(0, lumaSq / total - meanLuma * meanLuma) : 0;
+  return { pinkRatio, meanLuma, lumaVariance };
+}
+
+async function analyzeTexture(buffer) {
+  const { data, info } = await sharp(buffer)
+    .removeAlpha()
+    .grayscale()
+    .resize({ width: 256, height: 256, fit: 'inside', withoutEnlargement: false })
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const { width, height } = info;
+  let strongEdges = 0;
+  let considered = 0;
+  const cells = 8;
+  const cellEdges = new Float64Array(cells * cells);
+  const cellTotals = new Float64Array(cells * cells);
+  const cellWidth = width / cells;
+  const cellHeight = height / cells;
+  for (let y = 1; y < height - 1; y++) {
+    for (let x = 1; x < width - 1; x++) {
+      const idx = y * width + x;
+      const gx =
+        -data[idx - width - 1] - 2 * data[idx - 1] - data[idx + width - 1] + data[idx - width + 1] + 2 * data[idx + 1] + data[idx + width + 1];
+      const gy =
+        -data[idx - width - 1] - 2 * data[idx - width] - data[idx - width + 1] + data[idx + width - 1] + 2 * data[idx + width] + data[idx + width + 1];
+      const magnitude = Math.sqrt(gx * gx + gy * gy);
+      const cellX = Math.min(cells - 1, Math.floor(x / cellWidth));
+      const cellY = Math.min(cells - 1, Math.floor(y / cellHeight));
+      const cellIndex = cellY * cells + cellX;
+      cellTotals[cellIndex] += 1;
+      if (magnitude >= 120) {
+        strongEdges++;
+        cellEdges[cellIndex] += 1;
+      }
+      considered++;
+    }
+  }
+  const edgeDensity = considered ? strongEdges / considered : 0;
+  let distributedCells = 0;
+  for (let i = 0; i < cellEdges.length; i++) {
+    const total = cellTotals[i] || 1;
+    const ratio = cellEdges[i] / total;
+    if (ratio >= 0.04) distributedCells++;
+  }
+  const distributedRatio = cellEdges.length ? distributedCells / cellEdges.length : 0;
+  return { edgeDensity, distributedRatio };
+}
+
+function analyzeOcrText(text, geoKeywords) {
+  const tokens = text.split(/\s+/).filter(Boolean);
+  const normalizedTokens = tokens.map((t) => t.replace(/[^\p{L}0-9]+/gu, '').toLowerCase()).filter(Boolean);
+  let geoHits = 0;
+  for (const token of normalizedTokens) {
+    for (const geo of geoKeywords) {
+      if (token.includes(geo.toLowerCase())) {
+        geoHits++;
+        break;
+      }
+    }
+  }
+  return { tokenCount: tokens.length, geoHits };
+}
+
+function evaluateInhibitors({
+  hasPerson,
+  pinkRatio,
+  colorStats,
+  texture,
+  skin,
+  ocr,
+  config,
+}) {
+  const reasons = [];
+  if (!hasPerson && pinkRatio >= (config?.PINK_DOMINANCE ?? 0.55)) {
+    reasons.push('pink_dominant_no_person');
+  }
+  if (!hasPerson && ocr?.tokenCount >= (config?.OCR_TOKEN_MIN ?? 100) && ocr?.geoHits >= (config?.OCR_GEOS_MIN ?? 5)) {
+    reasons.push('map_text_detected');
+  }
+  const largeRegionPixels = skin?.largestBlobPixels ? skin.largestBlobPixels * (skin?.pixelScale || 1) : 0;
+  if (
+    !hasPerson &&
+    texture?.edgeDensity >= 0.12 &&
+    texture?.distributedRatio >= 0.55 &&
+    largeRegionPixels < (config?.SKIN_LARGE_REGION ?? 20000)
+  ) {
+    reasons.push('dense_edges_document');
+  }
+  if (
+    !hasPerson &&
+    (skin?.skinPercent ?? 0) >= 0.45 &&
+    (skin?.toneVariance ?? 1) <= 0.15 &&
+    (colorStats?.lumaVariance ?? 0) <= 0.01
+  ) {
+    reasons.push('uniform_skin_like_background');
+  }
+
+  return { allow: reasons.length > 0, reasons };
+}
+
+async function persistFalsePositiveSample(buffer, meta = {}) {
+  const url = process.env.SUPABASE_URL;
+  const serviceRole = process.env.SUPABASE_SERVICE_ROLE;
+  if (!url || !serviceRole) return false;
+  try {
+    const { createClient } = await import('@supabase/supabase-js');
+    const supa = createClient(url, serviceRole, { auth: { persistSession: false } });
+    const bucket = process.env.MODERATION_FP_BUCKET || 'moderation';
+    const date = new Date();
+    const folder = `fp-rosa/${date.toISOString().slice(0, 10)}`;
+    const key = `${folder}/${(meta.filename || 'image').replace(/[^a-z0-9._-]+/gi, '_')}-${date.getTime()}.png`;
+    await supa.storage.from(bucket).upload(key, buffer, {
+      contentType: 'image/png',
+      upsert: false,
+    });
+    return true;
+  } catch (err) {
+    console.warn('moderation.fp_archive_failed', err?.message || err);
+    return false;
+  }
 }
 
 // Ensure the moderation heuristics evaluate at least a medium sized canvas.
@@ -432,11 +918,36 @@ function computeNudityConfidence({
 
 
 export async function evaluateImage(buffer, filename, designName = '', options = {}) {
-  const debug = { metadata: null, skin: null, illustration: null, nazi: null, textHints: 0, scores: {} };
+  const config = getModerationConfig(options?.thresholdOverrides);
+  const debug = {
+    metadata: null,
+    skin: null,
+    illustration: null,
+    nazi: null,
+    textHints: 0,
+    scores: {},
+    persons: [],
+    inhibitors: null,
+    ocr: null,
+    texture: null,
+    color: null,
+  };
+  const logRecord = {
+    hasPerson: false,
+    nsfw: 0,
+    skinInPerson: 0,
+    pinkRatio: 0,
+    ocrTokens: 0,
+    geoHits: 0,
+    naziScore: 0,
+    decision: 'ALLOW',
+  };
+
   let workingBuffer = buffer;
+  let prepared = null;
 
   try {
-    const prepared = await prepareModerationImage(buffer);
+    prepared = await prepareModerationImage(buffer);
     workingBuffer = prepared.buffer;
     debug.metadata = {
       original: prepared.originalMeta,
@@ -463,88 +974,128 @@ export async function evaluateImage(buffer, filename, designName = '', options =
     markBlocked('extremism_nazi_text', 0.85);
   }
 
-  const illustration = await detectIllustration(workingBuffer);
-  debug.illustration = illustration;
+  const nazi = await detectNazi(workingBuffer, { config, meta: prepared?.meta, originalBuffer: buffer });
+  debug.nazi = nazi;
+  logRecord.naziScore = nazi?.score ?? 0;
+  if (nazi?.block) {
+    const base = config?.SWASTIKA_DET_THRESH ?? 0.6;
+    const confidence = clamp(0.75 + Math.max(0, (nazi.score || base) - base) * 0.25);
+    markBlocked('extremism_nazi', confidence);
+  }
 
-  const skin = await detectSkin(workingBuffer);
+  const illustration = await detectIllustration(workingBuffer);
+  let realnessScore = clamp(1 - (illustration?.cartoonConfidence ?? 0));
+  debug.illustration = { ...illustration, realnessScore };
+  debug.scores.realness = realnessScore;
+
+  const skin = await detectSkin(workingBuffer, { targetWidth: 256, originalMeta: prepared?.meta });
   debug.skin = skin;
 
   const nudityConfidence = computeNudityConfidence(skin);
-  debug.scores.realNudity = nudityConfidence;
+  debug.scores.nudityHeuristic = nudityConfidence;
 
-  const skinPercent = skin?.skinPercent ?? 0;
-  const centerSkinPercent = skin?.centerSkinPercent ?? 0;
-  const largestBlob = skin?.largestBlob ?? 0;
-  const largestBlobBoxCoverage = skin?.largestBlobBoxCoverage ?? 0;
-  const largestBlobCenterRatio = skin?.largestBlobCenterRatio ?? 0;
-  const toneVariance = skin?.toneVariance ?? 0;
-  const paletteRatio = illustration?.paletteRatio ?? 0;
-  const edgeRatio = illustration?.edgeRatio ?? 0;
-  const cartoonConfidence = illustration?.cartoonConfidence ?? 0;
-
-  debug.scores.skinPercent = skinPercent;
-  debug.scores.centerSkinPercent = centerSkinPercent;
-  debug.scores.largestBlob = largestBlob;
-  debug.scores.paletteRatio = paletteRatio;
-  debug.scores.edgeRatio = edgeRatio;
-  debug.scores.cartoonConfidence = cartoonConfidence;
-
-  const meetsCoverage = (
-    skinPercent >= 0.35 &&
-    centerSkinPercent >= 0.28 &&
-    largestBlob >= 0.24
+  const persons = estimatePersonsFromSkin(skin, prepared?.meta, config);
+  debug.persons = persons;
+  const validPersons = persons.filter(
+    (p) => p.confidence >= (config?.PERSON_DET_THRESH ?? 0.5) && p.bboxAreaRatio >= 0.02
   );
+  const hasPerson = validPersons.length > 0;
+  logRecord.hasPerson = hasPerson;
 
-  const strongCenter = centerSkinPercent >= 0.55;
-  const strongBlob = largestBlob >= 0.42 || largestBlobBoxCoverage >= 0.38;
-  const highSkinCoverage = skinPercent >= 0.5;
-  const notCartoon =
-    cartoonConfidence < 0.65 ||
-    paletteRatio >= 0.015 ||
-    edgeRatio <= 0.03 ||
-    toneVariance <= 0.18;
+  const colorStats = await computeColorStats(workingBuffer);
+  debug.color = colorStats;
+  logRecord.pinkRatio = colorStats.pinkRatio;
 
-  debug.scores.notCartoon = notCartoon ? 1 : 0;
+  const texture = await analyzeTexture(workingBuffer);
+  debug.texture = texture;
 
-  const shouldBlockStrong = strongCenter && strongBlob && highSkinCoverage && notCartoon;
-  const shouldBlockByConfidence =
-    !shouldBlockStrong &&
-    nudityConfidence >= 0.72 &&
-    meetsCoverage &&
-    notCartoon &&
-    centerSkinPercent >= 0.4 &&
-    largestBlob >= 0.35;
+  const personSkinStats = computePersonSkinStats(validPersons, skin);
+  debug.personSkin = personSkinStats;
+  logRecord.skinInPerson = personSkinStats.maxSkinRatio;
 
-  if (shouldBlockStrong || shouldBlockByConfidence) {
-    const baseConfidence = shouldBlockStrong ? 0.78 : 0.7;
-    const confidence = clamp(baseConfidence + (nudityConfidence - 0.7) * 0.5);
-    markBlocked('real_nudity', confidence);
+  if (personSkinStats.maxSkinRatio >= 0.25 && (skin?.skinPercent ?? 0) >= 0.3) {
+    const boost = clamp(nudityConfidence * 0.7 + personSkinStats.maxSkinRatio * 0.4);
+    realnessScore = Math.max(realnessScore, boost);
+    debug.scores.realness = realnessScore;
+    debug.illustration = { ...illustration, realnessScore };
   }
 
-  const nazi = await detectNazi(workingBuffer);
-  debug.nazi = nazi;
-  if (nazi?.nazi) {
-    if (nazi.reason === 'phash') {
-      const score = typeof nazi.score === 'number' ? nazi.score : 0;
-      const conf = clamp(0.95 - score * 0.03, 0.6, 0.95);
-      markBlocked('extremism_nazi', conf);
-    } else {
-      markBlocked('extremism_nazi', 0.85);
+  const isRealPhoto = realnessScore >= (config?.REALNESS_THRESH ?? 0.6);
+  debug.flags = { isRealPhoto, hasPerson };
+
+  let nsfwScore = 0;
+  let nsfwCandidate = null;
+  let gateChecks = { meetsSkinRatio: false, meetsIntersection: false, meetsLargeRegion: false };
+
+  if (isRealPhoto && hasPerson) {
+    nsfwScore = nudityConfidence;
+    gateChecks = {
+      meetsSkinRatio: personSkinStats.maxSkinRatio >= (config?.SKIN_RATIO_IN_PERSON ?? 0.12),
+      meetsIntersection: personSkinStats.skinIntersection >= (config?.SKIN_INTERSECTION ?? 0.6),
+      meetsLargeRegion: personSkinStats.largestRegionPixels >= (config?.SKIN_LARGE_REGION ?? 20000),
+    };
+    if (nsfwScore >= (config?.NSFW_THRESH ?? 0.7) && gateChecks.meetsSkinRatio && gateChecks.meetsIntersection && gateChecks.meetsLargeRegion) {
+      const confidence = clamp(0.65 + (nsfwScore - (config?.NSFW_THRESH ?? 0.7)) * 0.35);
+      nsfwCandidate = { reason: 'real_nudity', confidence };
     }
   }
+  debug.scores.nsfw = nsfwScore;
+  debug.scores.nsfwGates = gateChecks;
+  logRecord.nsfw = nsfwScore;
 
-  if (!blockReasons.size && !metaGate.blocked) {
-    const textHints = await extractTextHints(workingBuffer);
+  let ocrStats = { tokenCount: 0, geoHits: 0 };
+  let textHints = '';
+  const shouldRunOcr = !hasPerson && colorStats.pinkRatio >= 0.4;
+  if (shouldRunOcr) {
+    textHints = await extractTextHints(workingBuffer);
     debug.textHints = textHints.length;
     if (textHints) {
+      ocrStats = analyzeOcrText(textHints, config.GEO_KEYWORDS || []);
       const ocrGate = hateTextCheck({ filename, designName, textHints });
       if (ocrGate.blocked) {
         markBlocked('extremism_nazi_text', 0.82);
       }
     }
+  } else {
+    debug.textHints = 0;
+  }
+  debug.ocr = ocrStats;
+  logRecord.ocrTokens = ocrStats.tokenCount;
+  logRecord.geoHits = ocrStats.geoHits;
+
+  const inhibitors = evaluateInhibitors({
+    hasPerson,
+    pinkRatio: colorStats.pinkRatio,
+    colorStats,
+    texture,
+    skin,
+    ocr: ocrStats,
+    config,
+  });
+  debug.inhibitors = inhibitors;
+
+  if (nsfwCandidate) {
+    if (inhibitors.allow) {
+      debug.scores.nsfwInhibited = true;
+      await persistFalsePositiveSample(workingBuffer, {
+        filename,
+        designName,
+        nsfwScore,
+      });
+      nsfwCandidate = null;
+    } else {
+      markBlocked(nsfwCandidate.reason, nsfwCandidate.confidence);
+    }
   }
 
+  const allowReasons = [];
+  if (!isRealPhoto) allowReasons.push('non_real_photo');
+  if (isRealPhoto && !hasPerson) allowReasons.push('no_person_detected');
+  if (inhibitors.allow) allowReasons.push('pink_inhibitor');
+
   if (blockReasons.size) {
+    logRecord.decision = 'BLOCK';
+    console.info('moderation.image', { ...logRecord, filename });
     return {
       label: 'BLOCK',
       reasons: Array.from(blockReasons),
@@ -553,10 +1104,17 @@ export async function evaluateImage(buffer, filename, designName = '', options =
     };
   }
 
+  const confidenceBase = isRealPhoto ? 0.72 : 0.78;
+  const confidence = clamp(confidenceBase + Math.max(0, 0.5 - colorStats.pinkRatio) * 0.06);
+  const reasons = allowReasons.length ? allowReasons : ['no_violation_detected'];
+
+  logRecord.decision = 'ALLOW';
+  console.info('moderation.image', { ...logRecord, filename });
+
   return {
     label: 'ALLOW',
-    reasons: ['no_violation_detected'],
-    confidence: clamp(0.78 + Math.max(0, 0.5 - cartoonConfidence) * 0.08),
+    reasons,
+    confidence,
     details: debug,
   };
 }

--- a/lib/moderation/config.js
+++ b/lib/moderation/config.js
@@ -1,0 +1,82 @@
+const DEFAULT_THRESHOLDS = {
+  SWASTIKA_DET_THRESH: 0.6,
+  REALNESS_THRESH: 0.6,
+  PERSON_DET_THRESH: 0.5,
+  NSFW_THRESH: 0.7,
+  SKIN_RATIO_IN_PERSON: 0.12,
+  SKIN_LARGE_REGION: 20000,
+  SKIN_INTERSECTION: 0.6,
+  PINK_DOMINANCE: 0.55,
+  OCR_TOKEN_MIN: 100,
+  OCR_GEOS_MIN: 5,
+};
+
+const GEO_KEYWORDS = [
+  'Argentina',
+  'Brazil',
+  'Canada',
+  'United',
+  'Ocean',
+  'Pacific',
+  'Atlantic',
+  'Africa',
+  'Europe',
+  'Asia',
+  'Oceania',
+];
+
+function parseBoolean(value, defaultValue = true) {
+  if (value == null) return defaultValue;
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  return defaultValue;
+}
+
+function parseNumber(value, fallback) {
+  if (value == null) return fallback;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+const ENV_MAP = {
+  SWASTIKA_DET_THRESH: 'MOD_SWASTIKA_DET_THRESH',
+  REALNESS_THRESH: 'MOD_REALNESS_THRESH',
+  PERSON_DET_THRESH: 'MOD_PERSON_DET_THRESH',
+  NSFW_THRESH: 'MOD_NSFW_THRESH',
+  SKIN_RATIO_IN_PERSON: 'MOD_SKIN_RATIO_IN_PERSON',
+  SKIN_LARGE_REGION: 'MOD_SKIN_LARGE_REGION',
+  SKIN_INTERSECTION: 'MOD_SKIN_INTERSECTION',
+  PINK_DOMINANCE: 'MOD_PINK_DOMINANCE',
+  OCR_TOKEN_MIN: 'MOD_OCR_TOKEN_MIN',
+  OCR_GEOS_MIN: 'MOD_OCR_GEOS_MIN',
+};
+
+export function getModerationConfig(overrides = {}) {
+  const config = { ...DEFAULT_THRESHOLDS, ...overrides };
+
+  for (const [key, envName] of Object.entries(ENV_MAP)) {
+    if (!envName) continue;
+    const envValue = process.env[envName];
+    if (envValue != null) {
+      config[key] = parseNumber(envValue, config[key]);
+    }
+  }
+
+  const strict = parseBoolean(process.env.MODERATION_STRICT, true);
+
+  config.strict = strict;
+  if (!strict) {
+    config.NSFW_THRESH = Math.max(config.NSFW_THRESH, 0.75);
+  }
+
+  config.GEO_KEYWORDS = overrides.GEO_KEYWORDS || GEO_KEYWORDS;
+
+  return config;
+}
+
+export { DEFAULT_THRESHOLDS, GEO_KEYWORDS };
+
+export default { getModerationConfig, DEFAULT_THRESHOLDS, GEO_KEYWORDS };
+

--- a/scripts/moderation-qa-report.mjs
+++ b/scripts/moderation-qa-report.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import sharp from 'sharp';
+
+const { evaluateImage } = await import('../lib/handlers/moderateImage.js');
+
+async function loadImageBuffer(filePath) {
+  const buf = await fs.readFile(filePath);
+  // Normalize to PNG for consistency without mutating original file on disk
+  return sharp(buf).png().toBuffer();
+}
+
+function summarize(results) {
+  const totals = {
+    tp: 0,
+    tn: 0,
+    fp: 0,
+    fn: 0,
+  };
+  const corrected = [];
+  for (const item of results) {
+    if (item.expected === 'BLOCK' && item.result.label === 'BLOCK') totals.tp++;
+    else if (item.expected === 'ALLOW' && item.result.label === 'ALLOW') totals.tn++;
+    else if (item.expected === 'ALLOW' && item.result.label === 'BLOCK') totals.fp++;
+    else if (item.expected === 'BLOCK' && item.result.label === 'ALLOW') totals.fn++;
+
+    if (item.expected === 'ALLOW' && item.result.label === 'ALLOW') {
+      const inhibited = item.result.reasons?.includes('pink_inhibitor');
+      if (inhibited) {
+        corrected.push({ file: item.file, reasons: item.result.reasons });
+      }
+    }
+  }
+  const precision = totals.tp + totals.fp === 0 ? 1 : totals.tp / (totals.tp + totals.fp);
+  const recall = totals.tp + totals.fn === 0 ? 1 : totals.tp / (totals.tp + totals.fn);
+  return { totals, precision, recall, corrected };
+}
+
+async function run() {
+  const targetDir = process.argv[2] || process.env.MOD_QA_DIR || 'tests/moderation/qa';
+  const manifestPath = path.resolve(targetDir, 'annotations.json');
+  let manifest;
+  try {
+    const raw = await fs.readFile(manifestPath, 'utf8');
+    manifest = JSON.parse(raw);
+  } catch (err) {
+    console.error('moderation.qa', {
+      ok: false,
+      reason: 'manifest_missing',
+      message: err?.message || String(err),
+      expectedPath: manifestPath,
+    });
+    process.exit(1);
+  }
+
+  if (!Array.isArray(manifest) || manifest.length < 1) {
+    console.error('moderation.qa', { ok: false, reason: 'manifest_empty', count: Array.isArray(manifest) ? manifest.length : 0 });
+    process.exit(1);
+  }
+
+  const results = [];
+  for (const entry of manifest) {
+    const rel = entry.file || entry.path;
+    if (!rel) continue;
+    const expected = (entry.label || entry.expected || 'ALLOW').toUpperCase();
+    const absolute = path.resolve(targetDir, rel);
+    try {
+      const buffer = await loadImageBuffer(absolute);
+      const result = await evaluateImage(buffer, path.basename(rel), entry.designName || '');
+      results.push({ file: rel, expected, result });
+    } catch (err) {
+      console.error('moderation.qa_entry_failed', {
+        file: rel,
+        error: err?.message || String(err),
+      });
+    }
+  }
+
+  const summary = summarize(results);
+  console.log(JSON.stringify({ ok: true, dataset: targetDir, count: results.length, ...summary }, null, 2));
+}
+
+run().catch((err) => {
+  console.error('moderation.qa_failed', err?.message || err);
+  process.exit(1);
+});
+

--- a/tests/moderation.test.js
+++ b/tests/moderation.test.js
@@ -172,14 +172,15 @@ test('evaluateImage allows neutral graphics', async () => {
   const buf = await createNeutralBuffer();
   const result = await evaluateImage(buf, 'poster.png');
   assert.equal(result.label, 'ALLOW');
-  assert.equal(result.reasons.includes('no_violation_detected'), true);
+  assert.equal(result.reasons.includes('non_real_photo'), true);
 });
 
 test('evaluateImage allows stylized explicit art', async () => {
   const buf = await createCartoonBuffer();
   const result = await evaluateImage(buf, 'stylized.png', '', { approxDpi: 320 });
   assert.equal(result.label, 'ALLOW');
-  assert.equal(result.reasons.includes('no_violation_detected'), true);
+  assert.equal(result.reasons.includes('non_real_photo'), true);
+  assert.equal(result.reasons.includes('pink_inhibitor'), true);
   assert(result.confidence >= 0.7);
 });
 
@@ -187,7 +188,7 @@ test('evaluateImage allows stylized character renders', async () => {
   const buf = await createStylizedCharacterBuffer();
   const result = await evaluateImage(buf, 'character.png', '', { approxDpi: 320 });
   assert.equal(result.label, 'ALLOW');
-  assert.equal(result.reasons.includes('no_violation_detected'), true);
+  assert.equal(result.reasons.includes('non_real_photo'), true);
   assert(result.confidence >= 0.7);
 });
 


### PR DESCRIPTION
## Summary
- Centralize moderation thresholds and geo keyword lists so they can be tuned via environment overrides.
- Overhaul the server moderation pipeline with Nazi detection fallbacks, illustration gating, person-aware NSFW heuristics, and pink/map inhibitors plus structured logging.
- Document the new workflow, add a QA report script, and align tests with the updated allow reasons.

## Testing
- node --test tests/moderation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ddeae57410832780b0f1fc6edd613a