### PR TITLE
Add memory budget guard to publish product flow

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -28,10 +28,19 @@ const ONLINE_STORE_MISSING_MESSAGE = [
 const ONLINE_STORE_DISABLED_MESSAGE = 'Tu tienda no tiene el canal Online Store habilitado. Instalalo o bien omitÃ­ la publicaciÃ³n y usa Storefront para el carrito.';
 
 const BYTES_PER_MB = 1024 * 1024;
-const MAX_IMAGE_PIXEL_AREA = 12000 * 12000;
-const MEMORY_HEAP_LIMIT = 1.2 * 1024 * 1024 * 1024;
-const MEMORY_RSS_LIMIT = 2 * 1024 * 1024 * 1024;
+const DEFAULT_MEMORY_HEAP_BUDGET_MB = 350;
+const DEFAULT_MEMORY_RSS_BUDGET_MB = 700;
+const DEFAULT_MAX_IMAGE_PIXEL_AREA = 12000 * 10000;
+const RAW_MEDIA_MAX_PIXELS = Number(process.env.MEDIA_MAX_PIXELS);
+const MAX_IMAGE_PIXEL_AREA = Number.isFinite(RAW_MEDIA_MAX_PIXELS) && RAW_MEDIA_MAX_PIXELS > 0
+  ? RAW_MEDIA_MAX_PIXELS
+  : DEFAULT_MAX_IMAGE_PIXEL_AREA;
+const MEMORY_HEAP_LIMIT = DEFAULT_MEMORY_HEAP_BUDGET_MB * BYTES_PER_MB;
+const MEMORY_RSS_LIMIT = DEFAULT_MEMORY_RSS_BUDGET_MB * BYTES_PER_MB;
 const BASE64_CHUNK_CHAR_SIZE = Math.max(4, Math.floor((256 * 1024) / 3) * 4);
+const ENABLE_GC_DEV = String(process.env.ENABLE_GC_DEV || '').toLowerCase() === 'true';
+const PUBLISH_LIGHT_MODE = String(process.env.PUBLISH_LIGHT_MODE || '').toLowerCase() === 'true';
+const STAGED_UPLOAD_TIMEOUT_MS = 45_000;
 
 sharp.cache({ files: 0, items: 0, memory: 0 });
 sharp.concurrency(1);
@@ -143,18 +152,139 @@ function logMemoryCheckpoint(label, extra = {}) {
   return usage;
 }
 
+function resolveRequestId(resolver, result, error) {
+  if (typeof resolver === 'function') {
+    try {
+      const value = resolver(result, error);
+      if (typeof value === 'string' && value.trim()) return value.trim();
+      if (value == null) return null;
+      return value;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof resolver === 'string' && resolver.trim()) {
+    return resolver.trim();
+  }
+  return resolver ?? null;
+}
+
+function buildOOMGuardError({ label, usage, budgetMB, rssBudgetMB, requestId, phase, cause }) {
+  const err = new Error('OOM_GUARD');
+  err.code = 'OOM_GUARD';
+  err.status = 503;
+  err.label = label;
+  err.phase = phase;
+  err.heapUsed = usage?.heapUsed ?? null;
+  err.heapUsedMB = bytesToMb(usage?.heapUsed ?? 0);
+  err.rss = usage?.rss ?? null;
+  err.rssMB = bytesToMb(usage?.rss ?? 0);
+  err.budgetMB = budgetMB;
+  err.rssBudgetMB = rssBudgetMB;
+  if (requestId) err.requestId = requestId;
+  if (cause) err.cause = cause;
+  err.legacyCode = 'image_too_large_streaming_required';
+  return err;
+}
+
+async function withMemoryBudget(label, fn, options = {}) {
+  if (typeof fn !== 'function') {
+    throw new Error('withMemoryBudget_requires_function');
+  }
+
+  const budgetMB = Number.isFinite(options.budgetMB) && options.budgetMB > 0
+    ? options.budgetMB
+    : DEFAULT_MEMORY_HEAP_BUDGET_MB;
+  const rssBudgetMB = Number.isFinite(options.rssBudgetMB) && options.rssBudgetMB > 0
+    ? options.rssBudgetMB
+    : DEFAULT_MEMORY_RSS_BUDGET_MB;
+  const budgetBytes = budgetMB * BYTES_PER_MB;
+  const rssBudgetBytes = rssBudgetMB * BYTES_PER_MB;
+  const extraLog = options.extra && typeof options.extra === 'object' ? options.extra : null;
+
+  const usageBefore = process.memoryUsage();
+  const initialRequestId = resolveRequestId(options.initialRequestId, undefined, undefined);
+  try {
+    console.info('publish_product_memory_budget', {
+      label,
+      phase: 'before',
+      requestId: initialRequestId || null,
+      heapUsedMB: bytesToMb(usageBefore.heapUsed),
+      rssMB: bytesToMb(usageBefore.rss),
+      budgetMB,
+      rssBudgetMB,
+      ...(extraLog || {}),
+    });
+  } catch {}
+
+  if (usageBefore.heapUsed > budgetBytes || usageBefore.rss > rssBudgetBytes) {
+    throw buildOOMGuardError({
+      label,
+      usage: usageBefore,
+      budgetMB,
+      rssBudgetMB,
+      requestId: initialRequestId,
+      phase: 'before',
+    });
+  }
+
+  let result;
+  let error;
+  try {
+    result = await fn();
+  } catch (err) {
+    error = err;
+  }
+
+  const resolvedRequestId = resolveRequestId(options.requestId, result, error);
+  const usageAfter = process.memoryUsage();
+  try {
+    console.info('publish_product_memory_budget', {
+      label,
+      phase: 'after',
+      requestId: resolvedRequestId || null,
+      heapUsedMB: bytesToMb(usageAfter.heapUsed),
+      rssMB: bytesToMb(usageAfter.rss),
+      budgetMB,
+      rssBudgetMB,
+      ...(extraLog || {}),
+    });
+  } catch {}
+
+  if (usageAfter.heapUsed > budgetBytes || usageAfter.rss > rssBudgetBytes) {
+    const guardError = buildOOMGuardError({
+      label,
+      usage: usageAfter,
+      budgetMB,
+      rssBudgetMB,
+      requestId: resolvedRequestId,
+      phase: 'after',
+      cause: error,
+    });
+    throw guardError;
+  }
+
+  if (ENABLE_GC_DEV && typeof global?.gc === 'function') {
+    try {
+      global.gc();
+    } catch {}
+  }
+
+  if (error) throw error;
+  return result;
+}
+
 function enforceMemoryLimits(label, extra = {}) {
   const usage = process.memoryUsage();
   if (usage.heapUsed > MEMORY_HEAP_LIMIT || usage.rss > MEMORY_RSS_LIMIT) {
-    const err = new Error('image_too_large_streaming_required');
-    err.code = 'image_too_large_streaming_required';
-    err.heapUsed = usage.heapUsed;
-    err.rss = usage.rss;
-    err.label = label;
-    if (extra && typeof extra === 'object' && extra.requestId) {
-      err.requestId = extra.requestId;
-    }
-    throw err;
+    throw buildOOMGuardError({
+      label,
+      usage,
+      budgetMB: DEFAULT_MEMORY_HEAP_BUDGET_MB,
+      rssBudgetMB: DEFAULT_MEMORY_RSS_BUDGET_MB,
+      requestId: extra && typeof extra === 'object' ? extra.requestId : null,
+      phase: 'instant',
+    });
   }
   return usage;
 }
@@ -1462,7 +1592,7 @@ const PRODUCT_CREATE_MUTATION = `mutation ProductCreate($input: ProductInput!) {
       legacyResourceId
       handle
       status
-      variants(first: 5) {
+      variants(first: 1) {
         nodes {
           id
           legacyResourceId
@@ -1703,12 +1833,20 @@ async function stagedUploadImage({ filename, mimeType, fileSize, createReadStrea
     });
     enforceMemoryLimits('staged_upload_post_start', { requestId });
     let uploadResp;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      try {
+        controller.abort();
+      } catch {}
+    }, STAGED_UPLOAD_TIMEOUT_MS);
     try {
-      uploadResp = await fetch(target.url, { method: 'POST', body: formData });
+      uploadResp = await fetch(target.url, { method: 'POST', body: formData, signal: controller.signal });
     } catch (err) {
+      const isAbort = err?.name === 'AbortError';
+      clearTimeout(timeoutId);
       bodyStream?.destroy?.();
       lastStatus = 0;
-      lastBody = err?.message || '';
+      lastBody = isAbort ? 'upload_timeout' : err?.message || '';
       if (attempt < attempts - 1) {
         try {
           console.warn('staged_upload_post_retry', {
@@ -1717,18 +1855,23 @@ async function stagedUploadImage({ filename, mimeType, fileSize, createReadStrea
             requestId: requestId || null,
             uploadRequestId: uploadRequestId || null,
             reason: err?.message || 'exception',
+            timeout: isAbort || undefined,
           });
         } catch {}
         await sleep(200 * 2 ** attempt);
         continue;
       }
-      const finalErr = new Error('staged_upload_failed');
+      const finalErr = new Error(isAbort ? 'staged_upload_timeout' : 'staged_upload_failed');
       finalErr.status = 0;
       finalErr.body = lastBody;
       finalErr.requestId = requestId;
       finalErr.attempt = attempt + 1;
+      if (isAbort) {
+        finalErr.code = 'staged_upload_timeout';
+      }
       throw finalErr;
     }
+    clearTimeout(timeoutId);
 
     const attemptUploadRequestId = extractRequestId(uploadResp);
     if (attemptUploadRequestId) {
@@ -2075,177 +2218,198 @@ export async function publishProduct(req, res) {
       ? body.imageAlt.trim().slice(0, 254)
       : title;
 
-    const { mimeType } = parseDataUrlMeta(mockupDataUrl);
-    const approxInputBytes = estimateBase64Size(b64);
-    logMemoryCheckpoint('mockup_preview_start', {
-      requestId: null,
-      approxInputMB: bytesToMb(approxInputBytes),
-    });
-    try {
-      enforceMemoryLimits('mockup_preview_start');
-    } catch (limitErr) {
-      if (limitErr?.code === 'image_too_large_streaming_required') {
-        return res.status(503).json({
-          ok: false,
-          reason: 'image_too_large_streaming_required',
-          message: 'La imagen requiriÃ³ mÃ¡s memoria de la disponible. SubÃ­ un mockup mÃ¡s chico o reenviÃ¡ en streaming.',
-        });
-      }
-      throw limitErr;
-    }
+    const previewResourceCandidates = [
+      typeof body.previewResourceUrl === 'string' ? body.previewResourceUrl.trim() : '',
+      typeof body.mockupPreviewResourceUrl === 'string' ? body.mockupPreviewResourceUrl.trim() : '',
+      typeof body.mockupResourceUrl === 'string' ? body.mockupResourceUrl.trim() : '',
+    ].filter(Boolean);
+    const reusePreviewSource = previewResourceCandidates.find((value) => /^https?:\/\//i.test(value));
+    const shouldReusePreview = Boolean(PUBLISH_LIGHT_MODE && reusePreviewSource);
 
     let previewFile = null;
-    try {
-      previewFile = await createPreviewImageFile({
-        sourceFactory: () => createBase64DecodeStream(b64),
-        applyBlur: productTypeKey === 'glasspad',
+    let stagedImage = null;
+    let previewSizeMB = 0;
+
+    if (shouldReusePreview) {
+      stagedImage = { originalSource: reusePreviewSource, requestId: null, uploadRequestId: null };
+      b64 = null;
+      mockupDataUrl = '';
+      try {
+        console.info('mockup_preview_reused', { source: 'light_mode', reuseUrl: reusePreviewSource });
+      } catch {}
+    } else {
+      const { mimeType } = parseDataUrlMeta(mockupDataUrl);
+      const approxInputBytes = estimateBase64Size(b64);
+      logMemoryCheckpoint('mockup_preview_start', {
+        requestId: null,
+        approxInputMB: bytesToMb(approxInputBytes),
       });
-    } catch (previewErr) {
-      if (previewErr?.code === 'mockup_pixel_limit_exceeded') {
-        return res.status(422).json({
-          ok: false,
-          reason: 'mockup_pixel_limit_exceeded',
-          limit: MAX_IMAGE_PIXEL_AREA,
-          message: 'La imagen es demasiado grande para generar una vista previa. SubÃ­ un mockup mÃ¡s chico.',
-        });
+      try {
+        enforceMemoryLimits('mockup_preview_start');
+      } catch (limitErr) {
+        if (limitErr?.code === 'OOM_GUARD' || limitErr?.code === 'image_too_large_streaming_required' || limitErr?.legacyCode === 'image_too_large_streaming_required') {
+          return res.status(503).json({
+            ok: false,
+            reason: 'image_too_large_streaming_required',
+            message: 'La imagen requiriÃ³ mÃ¡s memoria de la disponible. SubÃ­ un mockup mÃ¡s chico o reenviÃ¡ en streaming.',
+          });
+        }
+        throw limitErr;
       }
-      if (previewErr?.code === 'missing_base64_source' || /invalid/i.test(previewErr?.message || '')) {
-        return res.status(400).json({ ok: false, reason: 'invalid_mockup_dataurl' });
-      }
-      if (previewErr?.code === 'image_too_large_streaming_required') {
-        return res.status(503).json({
-          ok: false,
-          reason: 'image_too_large_streaming_required',
-          message: 'La imagen requiriÃ³ mÃ¡s memoria de la disponible. SubÃ­ un mockup mÃ¡s chico o reenviÃ¡ en streaming.',
-        });
-      }
-      throw previewErr;
-    }
-
-    const previewSizeMB = bytesToMb(previewFile?.size || 0);
-    logMemoryCheckpoint('mockup_preview_complete', {
-      requestId: null,
-      approxInputMB: bytesToMb(approxInputBytes),
-      previewSizeMB,
-    });
-    try {
-      enforceMemoryLimits('mockup_preview_complete');
-    } catch (limitErr) {
-      if (limitErr?.code === 'image_too_large_streaming_required') {
-        await previewFile?.cleanup?.().catch(() => {});
-        return res.status(503).json({
-          ok: false,
-          reason: 'image_too_large_streaming_required',
-          message: 'La imagen requiriÃ³ mÃ¡s memoria de la disponible. SubÃ­ un mockup mÃ¡s chico o reenviÃ¡ en streaming.',
-        });
-      }
-      throw limitErr;
-    }
-
-    b64 = null;
-    mockupDataUrl = '';
-
-    if (!previewFile || !previewFile.size) {
-      await previewFile?.cleanup?.();
-      return res.status(400).json({ ok: false, reason: 'invalid_mockup_preview' });
-    }
-
-    let stagedImage;
-    try {
-      stagedImage = await stagedUploadImage({
-        filename,
-        mimeType: previewFile.mimeType || mimeType,
-        fileSize: previewFile.size,
-        createReadStream: () => createReadStream(previewFile.path),
-      });
-    } catch (err) {
-      if (err?.code === 'image_too_large_streaming_required') {
-        await previewFile?.cleanup?.().catch(() => {});
-        return res.status(503).json({
-          ok: false,
-          reason: 'image_too_large_streaming_required',
-          heapUsed: err?.heapUsed,
-          rss: err?.rss,
-          message: 'No se pudo subir el mockup porque se agotÃ³ la memoria disponible. ProbÃ¡ con una imagen mÃ¡s liviana.',
-        });
-      }
-      const status = typeof err?.status === 'number' ? err.status : 502;
-      const formattedErrors = Array.isArray(err?.errors) && err.errors.length
-        ? err.errors
-        : formatGraphQLErrors(err?.body?.errors);
-      const stagedUserErrors = Array.isArray(err?.userErrors) && err.userErrors.length
-        ? err.userErrors
-        : sanitizeUserErrors(err?.body?.userErrors);
-      const combined = [
-        ...(Array.isArray(formattedErrors) ? formattedErrors : []),
-        ...(Array.isArray(stagedUserErrors) ? stagedUserErrors : []),
-      ];
-      const extraMessages = [
-        typeof err?.message === 'string' ? err.message : '',
-        typeof err?.body === 'string' ? err.body : '',
-        typeof err?.body?.message === 'string' ? err.body.message : '',
-      ];
-      const missingFilesScope = detectMissingFilesScope(combined)
-        || extraMessages.some((msg) => isMissingFilesScopeMessage(msg));
-
-      const stageRequestId = err?.requestId || null;
-      const uploadRequestId = err?.uploadRequestId || null;
-
-      const warningBase = {
-        code: missingFilesScope ? 'missing_write_files_scope' : 'image_upload_failed',
-        status,
-        requestId: stageRequestId,
-        uploadRequestId,
-        detail: formattedErrors?.length || stagedUserErrors?.length
-          ? {
-            ...(formattedErrors?.length ? { errors: formattedErrors } : {}),
-            ...(stagedUserErrors?.length ? { userErrors: stagedUserErrors } : {}),
-          }
-          : err?.body || null,
-      };
-
-      const message = missingFilesScope
-        ? 'No se pudo subir la imagen porque falta el scope write_files. Se seguirÃ¡ sin mockup.'
-        : 'No se pudo subir la imagen, se seguirÃ¡ sin mockup.';
-
-      const warningPayload = {
-        ...warningBase,
-        message,
-        ...(missingFilesScope ? { missing: ['write_files'] } : {}),
-      };
-
-      warnings.push(warningPayload);
 
       try {
-        console.warn('product_image_upload_warning', {
-          message,
+        previewFile = await createPreviewImageFile({
+          sourceFactory: () => createBase64DecodeStream(b64),
+          applyBlur: productTypeKey === 'glasspad',
+        });
+      } catch (previewErr) {
+        if (previewErr?.code === 'mockup_pixel_limit_exceeded') {
+          return res.status(413).json({
+            ok: false,
+            reason: 'mockup_pixel_limit_exceeded',
+            limit: MAX_IMAGE_PIXEL_AREA,
+            message: 'La imagen supera el lÃ­mite permitido de pixeles para generar la vista previa.',
+          });
+        }
+        if (previewErr?.code === 'missing_base64_source' || /invalid/i.test(previewErr?.message || '')) {
+          return res.status(400).json({ ok: false, reason: 'invalid_mockup_dataurl' });
+        }
+        if (previewErr?.code === 'OOM_GUARD' || previewErr?.code === 'image_too_large_streaming_required' || previewErr?.legacyCode === 'image_too_large_streaming_required') {
+          return res.status(503).json({
+            ok: false,
+            reason: 'image_too_large_streaming_required',
+            message: 'La imagen requiriÃ³ mÃ¡s memoria de la disponible. SubÃ­ un mockup mÃ¡s chico o reenviÃ¡ en streaming.',
+          });
+        }
+        throw previewErr;
+      }
+
+      previewSizeMB = bytesToMb(previewFile?.size || 0);
+      logMemoryCheckpoint('mockup_preview_complete', {
+        requestId: null,
+        approxInputMB: bytesToMb(approxInputBytes),
+        previewSizeMB,
+      });
+      try {
+        enforceMemoryLimits('mockup_preview_complete');
+      } catch (limitErr) {
+        if (limitErr?.code === 'OOM_GUARD' || limitErr?.code === 'image_too_large_streaming_required' || limitErr?.legacyCode === 'image_too_large_streaming_required') {
+          await previewFile?.cleanup?.().catch(() => {});
+          return res.status(503).json({
+            ok: false,
+            reason: 'image_too_large_streaming_required',
+            message: 'La imagen requiriÃ³ mÃ¡s memoria de la disponible. SubÃ­ un mockup mÃ¡s chico o reenviÃ¡ en streaming.',
+          });
+        }
+        throw limitErr;
+      }
+
+      b64 = null;
+      mockupDataUrl = '';
+
+      if (!previewFile || !previewFile.size) {
+        await previewFile?.cleanup?.();
+        return res.status(400).json({ ok: false, reason: 'invalid_mockup_preview' });
+      }
+
+      try {
+        stagedImage = await withMemoryBudget(
+          'staged_upload_image',
+          () => stagedUploadImage({
+            filename,
+            mimeType: previewFile.mimeType || mimeType,
+            fileSize: previewFile.size,
+            createReadStream: () => createReadStream(previewFile.path),
+          }),
+          {
+            requestId: (result) => result?.requestId || null,
+            extra: { filename },
+          },
+        );
+      } catch (err) {
+        if (err?.code === 'OOM_GUARD' || err?.code === 'image_too_large_streaming_required' || err?.legacyCode === 'image_too_large_streaming_required') {
+          await previewFile?.cleanup?.().catch(() => {});
+          return res.status(503).json({
+            ok: false,
+            reason: 'image_too_large_streaming_required',
+            heapUsed: err?.heapUsed ?? err?.heapUsedBytes ?? null,
+            heapUsedMB: err?.heapUsedMB ?? null,
+            rss: err?.rss ?? null,
+            rssMB: err?.rssMB ?? null,
+            message: 'No se pudo subir el mockup porque se agotÃ³ la memoria disponible. ProbÃ¡ con una imagen mÃ¡s liviana.',
+          });
+        }
+        const status = typeof err?.status === 'number' ? err.status : 502;
+        const formattedErrors = Array.isArray(err?.errors) && err.errors.length
+          ? err.errors
+          : formatGraphQLErrors(err?.body?.errors);
+        const stagedUserErrors = Array.isArray(err?.userErrors) && err.userErrors.length
+          ? err.userErrors
+          : sanitizeUserErrors(err?.body?.userErrors);
+        const combined = [
+          ...(Array.isArray(formattedErrors) ? formattedErrors : []),
+          ...(Array.isArray(stagedUserErrors) ? stagedUserErrors : []),
+        ];
+        const extraMessages = [
+          typeof err?.message === 'string' ? err.message : '',
+          typeof err?.body === 'string' ? err.body : '',
+          typeof err?.body?.message === 'string' ? err.body.message : '',
+        ];
+        const missingFilesScope = detectMissingFilesScope(combined)
+          || extraMessages.some((msg) => isMissingFilesScopeMessage(msg));
+
+        const stageRequestId = err?.requestId || null;
+        const uploadRequestId = err?.uploadRequestId || null;
+
+        const warningBase = {
+          code: missingFilesScope ? 'missing_write_files_scope' : 'image_upload_failed',
           status,
           requestId: stageRequestId,
           uploadRequestId,
-          missingFilesScope,
-          attempt: typeof err?.attempt === 'number' ? err.attempt : null,
-          errors: Array.isArray(formattedErrors) && formattedErrors.length ? formattedErrors : undefined,
-          userErrors: Array.isArray(stagedUserErrors) && stagedUserErrors.length ? stagedUserErrors : undefined,
-        });
-      } catch {}
+          detail: formattedErrors?.length || stagedUserErrors?.length
+            ? {
+              ...(formattedErrors?.length ? { errors: formattedErrors } : {}),
+              ...(stagedUserErrors?.length ? { userErrors: stagedUserErrors } : {}),
+            }
+            : err?.body || null,
+        };
 
-      stagedImage = null;
+        const message = missingFilesScope
+          ? 'No se pudo subir la imagen porque falta el scope write_files. Se seguirÃ¡ sin mockup.'
+          : 'No se pudo subir la imagen, se seguirÃ¡ sin mockup.';
+
+        const warningPayload = {
+          ...warningBase,
+          message,
+          ...(missingFilesScope ? { missing: ['write_files'] } : {}),
+        };
+
+        warnings.push(warningPayload);
+
+        try {
+          console.warn('product_image_upload_warning', {
+            message,
+            status,
+            requestId: stageRequestId,
+            uploadRequestId,
+            missingFilesScope,
+            attempt: typeof err?.attempt === 'number' ? err.attempt : null,
+            errors: Array.isArray(formattedErrors) && formattedErrors.length ? formattedErrors : undefined,
+            userErrors: Array.isArray(stagedUserErrors) && stagedUserErrors.length ? stagedUserErrors : undefined,
+          });
+        } catch {}
+
+        stagedImage = null;
+      }
+
+      await previewFile?.cleanup?.().catch(() => {});
+      previewFile = null;
     }
-
-    await previewFile?.cleanup?.().catch(() => {});
-    previewFile = null;
 
 
     const basePrice = isFiniteNumber(priceTransfer) ? Math.max(priceTransfer, 0) : 0;
     const computedPrice = isPrivate ? basePrice * 1.25 : basePrice;
     const priceValue = formatMoney(computedPrice) || '0.00';
-
-    const variantUpdateInputBase = {
-      price: priceValue,
-      taxable: true,
-      inventoryPolicy: 'CONTINUE',
-      inventoryManagement: null,
-    };
 
     try {
       console.info('variant_price_computed', {
@@ -2266,6 +2430,40 @@ export async function publishProduct(req, res) {
         isPrivate,
       });
     } catch {}
+
+    const {
+      variantUpdateInputBase,
+      productMediaInput,
+      productInput,
+    } = await withMemoryBudget(
+      'build_product_variant_payload',
+      async () => {
+        const variantInput = {
+          price: priceValue,
+          taxable: true,
+          inventoryPolicy: 'CONTINUE',
+          inventoryManagement: null,
+        };
+        const mediaInput = stagedImage?.originalSource
+          ? [{ mediaContentType: 'IMAGE', originalSource: stagedImage.originalSource, alt: imageAlt }]
+          : [];
+        const productInputPayload = {
+          title,
+          // Private checkouts rely on draft products + draft orders, while the public
+          // flow still expects active products available on the storefront. Switch
+          // the status depending on the visibility that was requested.
+          status: isPrivate ? 'DRAFT' : 'ACTIVE',
+          vendor: DEFAULT_VENDOR,
+          templateSuffix: 'mousepads',
+        };
+        return {
+          variantUpdateInputBase: variantInput,
+          productMediaInput: mediaInput,
+          productInput: productInputPayload,
+        };
+      },
+      { extra: { isPrivate } },
+    );
 
     let primaryLocationId = null;
     let primaryLocationName = '';
@@ -2393,20 +2591,6 @@ export async function publishProduct(req, res) {
         message: 'No se pudo obtener la ubicaciÃ³n principal de la tienda en Shopify.',
       });
     }
-
-    const productMediaInput = stagedImage?.originalSource
-      ? [{ mediaContentType: 'IMAGE', originalSource: stagedImage.originalSource, alt: imageAlt }]
-      : [];
-
-    const productInput = {
-      title,
-      // Private checkouts rely on draft products + draft orders, while the public
-      // flow still expects active products available on the storefront. Switch
-      // the status depending on the visibility that was requested.
-      status: isPrivate ? 'DRAFT' : 'ACTIVE',
-      vendor: DEFAULT_VENDOR,
-      templateSuffix: 'mousepads',
-    };
 
     const {
       resp: productResp,
@@ -2989,12 +3173,21 @@ export async function publishProduct(req, res) {
     let inventoryTrackWarning = null;
 
     try {
+      const trackResult = await withMemoryBudget(
+        'inventory_item_update',
+        () => executeInventoryItemUpdate({ id: variantInventoryItemId, input: inventoryItemUpdateInput }),
+        {
+          requestId: (result) => result?.requestId || null,
+          extra: { inventoryItemId: variantInventoryItemId },
+        },
+      );
+
       const {
         resp: trackResp,
         json: trackJson,
         requestId: trackRequestId,
         attempts: trackAttempts,
-      } = await executeInventoryItemUpdate({ id: variantInventoryItemId, input: inventoryItemUpdateInput });
+      } = trackResult;
 
       const trackRequestIds = Array.isArray(trackAttempts)
         ? trackAttempts.map((entry) => entry?.requestId).filter(Boolean)
@@ -3088,12 +3281,21 @@ export async function publishProduct(req, res) {
         });
         enforceMemoryLimits('product_create_media_start');
 
+        const mediaResult = await withMemoryBudget(
+          'product_create_media',
+          () => executeProductCreateMedia({ productId: productIdForVariants, media: productMediaInput }),
+          {
+            requestId: (result) => result?.requestId || null,
+            extra: { mediaCount: productMediaInput.length },
+          },
+        );
+
         const {
           resp: mediaResp,
           json: mediaJson,
           requestId: mediaRequestId,
           attempts: mediaAttempts,
-        } = await executeProductCreateMedia({ productId: productIdForVariants, media: productMediaInput });
+        } = mediaResult;
 
         logMemoryCheckpoint('product_create_media_complete', {
           requestId: mediaRequestId || null,
@@ -3163,12 +3365,14 @@ export async function publishProduct(req, res) {
           }
         }
       } catch (err) {
-        if (err?.code === 'image_too_large_streaming_required') {
+        if (err?.code === 'OOM_GUARD' || err?.code === 'image_too_large_streaming_required' || err?.legacyCode === 'image_too_large_streaming_required') {
           return res.status(503).json({
             ok: false,
             reason: 'image_too_large_streaming_required',
-            heapUsed: err?.heapUsed,
-            rss: err?.rss,
+            heapUsed: err?.heapUsed ?? err?.heapUsedBytes ?? null,
+            heapUsedMB: err?.heapUsedMB ?? null,
+            rss: err?.rss ?? null,
+            rssMB: err?.rssMB ?? null,
             message: 'No se pudo asociar la imagen porque se alcanzÃ³ el lÃ­mite de memoria disponible.',
           });
         }
@@ -3414,12 +3618,41 @@ export async function publishProduct(req, res) {
         throw err;
       }
 
-      publishResult = await publishToOnlineStore(meta.productAdminId, publicationInfo?.id, {
-        maxAttempts: 5,
-        initialDelayMs: 200,
-        maxDelayMs: 3200,
-        preferEnv: publicationInfo?.source === 'env' || publicationInfo?.source === 'override',
-      });
+      try {
+        publishResult = await withMemoryBudget(
+          'online_store_publication',
+          () => publishToOnlineStore(meta.productAdminId, publicationInfo?.id, {
+            maxAttempts: 5,
+            initialDelayMs: 200,
+            maxDelayMs: 3200,
+            preferEnv: publicationInfo?.source === 'env' || publicationInfo?.source === 'override',
+          }),
+          {
+            requestId: (result) => {
+              if (!result) return null;
+              const ids = Array.isArray(result.requestIds) ? result.requestIds : [];
+              if (!ids.length) return null;
+              const last = ids[ids.length - 1];
+              return typeof last === 'string' && last ? last : null;
+            },
+            extra: { publicationId: publicationInfo?.id || null },
+          },
+        );
+      } catch (err) {
+        if (err?.code === 'OOM_GUARD' || err?.legacyCode === 'image_too_large_streaming_required') {
+          logPublicationAbort(meta, 'oom_guard', { publicationId: publicationInfo?.id || null });
+          return res.status(503).json({
+            ok: false,
+            reason: 'image_too_large_streaming_required',
+            message: 'No se pudo publicar el producto porque se alcanzÃ³ el lÃ­mite de memoria disponible.',
+            heapUsedMB: err?.heapUsedMB ?? null,
+            rssMB: err?.rssMB ?? null,
+            ...meta,
+            visibility,
+          });
+        }
+        throw err;
+      }
 
       if (!publishResult?.ok) {
         const requestIds = Array.isArray(publishResult?.requestIds) ? publishResult.requestIds : [];


### PR DESCRIPTION
## Summary
- tighten publish product memory thresholds via a reusable `withMemoryBudget` guard and expose heap/rss snapshots in `publish_product_memory_budget` logs
- reuse staged previews when `PUBLISH_LIGHT_MODE` is enabled, enforce configurable pixel ceilings, and add staged-upload abort timeouts to avoid holding large buffers
- narrow Shopify product queries to only the default variant and wrap inventory/media/publication steps in the new budget guard to prevent OOM spikes

## Testing
- not run (manual validation recommended)

## Notes
- file(s): lib/handlers/publishProduct.js – memory budget decorator, light-mode preview reuse, streaming safeguards, Shopify query reductions
- sample log: `publish_product_memory_budget` (before/after) includes `heapUsedMB`, `rssMB`, `label`, and `requestId`
- previous peak came from refetching up to 5 variants plus media after `inventory_item_update`; the mutation now limits to a single default variant and avoids unnecessary payloads
- QA: run publish-product flow in private/cart/public modes with `PUBLISH_LIGHT_MODE` toggled, monitor logs for `publish_product_memory_budget`, and ensure heap stays <350 MB / rss <700 MB; use preview deployment to confirm staged uploads respect timeouts

------
https://chatgpt.com/codex/tasks/task_e_68ddf0ab5bf48327ac113e7cf8e8bcc5