### PR TITLE
Add lightweight post-publish checkout flow

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -8,10 +8,10 @@ import { createReadStream, createWriteStream } from 'node:fs';
 import { promises as fsPromises } from 'node:fs';
 import { PassThrough, Readable, Transform } from 'node:stream';
 import { pipeline as streamPipeline } from 'node:stream/promises';
-import { shopifyAdmin, shopifyAdminGraphQL } from '../shopify.js';
-import { buildProductUrl } from '../publicStorefront.js';
-import { publishToOnlineStore, resolveOnlineStorePublicationId } from '../shopify/publication.js';
-import { parseJsonBody } from '../_lib/http.js';
+import { shopifyAdmin, shopifyAdminGraphQL, shopifyStorefrontGraphQL } from '../shopify.js';
+import { buildProductUrl, getPublicStorefrontBase } from '../publicStorefront.js';
+import { ensureVariantGid, publishToOnlineStore, resolveOnlineStorePublicationId } from '../shopify/publication.js';
+import { parseJsonBody, getClientIp } from '../_lib/http.js';
 import { slugifyName } from '../_lib/slug.js';
 import savePrintPdfToSupabase, { savePrintPreviewToSupabase } from '../_lib/savePrintPdfToSupabase.js';
 import getSupabaseAdmin from '../_lib/supabaseAdmin.js';
@@ -41,6 +41,21 @@ const BASE64_CHUNK_CHAR_SIZE = Math.max(4, Math.floor((256 * 1024) / 3) * 4);
 const ENABLE_GC_DEV = String(process.env.ENABLE_GC_DEV || '').toLowerCase() === 'true';
 const PUBLISH_LIGHT_MODE = String(process.env.PUBLISH_LIGHT_MODE || '').toLowerCase() === 'true';
 const STAGED_UPLOAD_TIMEOUT_MS = 45_000;
+const POST_PUBLISH_CART_MUTATION = `
+  mutation PostPublishCartCreate($lines: [CartLineInput!]!) {
+    cartCreate(input: { lines: $lines }) {
+      cart {
+        id
+        checkoutUrl
+      }
+      userErrors {
+        message
+        field
+        code
+      }
+    }
+  }
+`;
 
 sharp.cache({ files: 0, items: 0, memory: 0 });
 sharp.concurrency(1);
@@ -48,6 +63,218 @@ sharp.concurrency(1);
 function bytesToMb(bytes) {
   if (!Number.isFinite(bytes) || bytes <= 0) return 0;
   return Number((bytes / BYTES_PER_MB).toFixed(2));
+}
+
+function buildPostPublishMemoryError({ label, usage }) {
+  const err = new Error('POST_PUBLISH_MEMORY_GUARD');
+  err.code = 'POST_PUBLISH_MEMORY_GUARD';
+  err.status = 503;
+  err.label = label;
+  err.heapUsed = usage?.heapUsed ?? null;
+  err.heapUsedMB = bytesToMb(usage?.heapUsed ?? 0);
+  err.rss = usage?.rss ?? null;
+  err.rssMB = bytesToMb(usage?.rss ?? 0);
+  return err;
+}
+
+function logPostPublishCheckpoint(label, extra = {}) {
+  const usage = process.memoryUsage();
+  const payload = {
+    label,
+    heapUsedMB: bytesToMb(usage.heapUsed),
+    rssMB: bytesToMb(usage.rss),
+    ...extra,
+  };
+  try {
+    console.info('post_publish_checkpoint', payload);
+  } catch {}
+  if (usage.heapUsed > MEMORY_HEAP_LIMIT || usage.rss > MEMORY_RSS_LIMIT) {
+    throw buildPostPublishMemoryError({ label, usage });
+  }
+  return usage;
+}
+
+function readStorefrontRequestId(resp) {
+  if (!resp || typeof resp !== 'object' || typeof resp.headers?.get !== 'function') return '';
+  return (
+    resp.headers.get('x-request-id')
+    || resp.headers.get('x-requestid')
+    || resp.headers.get('X-Request-ID')
+    || resp.headers.get('X-RequestId')
+    || ''
+  );
+}
+
+function deriveStorefrontCartUrls({ cartId, checkoutUrl }) {
+  const token = typeof cartId === 'string' ? cartId.split('/').pop() : '';
+  const checkoutRaw = typeof checkoutUrl === 'string' ? checkoutUrl.trim() : '';
+  let origin = '';
+  if (checkoutRaw) {
+    try {
+      const parsed = new URL(checkoutRaw);
+      origin = `${parsed.protocol}//${parsed.host}`;
+    } catch {}
+  }
+  if (!origin) {
+    origin = getPublicStorefrontBase();
+  }
+  const normalizedOrigin = typeof origin === 'string' ? origin.replace(/\/+$/, '') : '';
+  const cartUrl = normalizedOrigin && token ? `${normalizedOrigin}/cart/c/${token}` : '';
+  return {
+    cartUrl,
+    checkoutUrl: checkoutRaw,
+    cartPlain: normalizedOrigin ? `${normalizedOrigin}/cart` : '',
+    checkoutPlain: normalizedOrigin ? `${normalizedOrigin}/checkout` : '',
+    cartToken: token || '',
+  };
+}
+
+async function createPostPublishCart({ variantGid, quantity = 1, buyerIp }) {
+  if (!variantGid) {
+    return { ok: false, reason: 'missing_variant_gid' };
+  }
+
+  const lines = [
+    {
+      merchandiseId: variantGid,
+      quantity: Number.isFinite(quantity) && quantity > 0 ? Math.min(Math.max(Math.floor(quantity), 1), 99) : 1,
+    },
+  ];
+
+  let response;
+  try {
+    response = await shopifyStorefrontGraphQL(
+      POST_PUBLISH_CART_MUTATION,
+      { lines },
+      buyerIp ? { buyerIp } : {},
+    );
+  } catch (err) {
+    if (err?.message === 'SHOPIFY_STOREFRONT_ENV_MISSING') {
+      return { ok: false, reason: 'storefront_env_missing', missing: err?.missing || [] };
+    }
+    return { ok: false, reason: 'storefront_request_failed', error: err };
+  }
+
+  const requestId = readStorefrontRequestId(response) || null;
+  let text = '';
+  try {
+    text = await response.text();
+  } catch {}
+
+  let json = null;
+  if (text) {
+    try {
+      json = JSON.parse(text);
+    } catch (err) {
+      return {
+        ok: false,
+        reason: 'invalid_response',
+        requestId,
+        parseError: err?.message || 'json_parse_failed',
+      };
+    }
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      reason: 'http_error',
+      status: response.status,
+      requestId,
+      body: text ? text.slice(0, 2000) : '',
+    };
+  }
+
+  if (!json || typeof json !== 'object') {
+    return { ok: false, reason: 'invalid_response', requestId };
+  }
+
+  const payload = json?.data?.cartCreate;
+  if (!payload || typeof payload !== 'object') {
+    return { ok: false, reason: 'invalid_response', requestId };
+  }
+
+  const userErrors = Array.isArray(payload.userErrors)
+    ? payload.userErrors
+      .map((entry) => {
+        if (!entry || typeof entry !== 'object') return null;
+        const message = typeof entry.message === 'string' ? entry.message.trim() : '';
+        const code = typeof entry.code === 'string' ? entry.code : '';
+        const field = Array.isArray(entry.field)
+          ? entry.field.map((value) => (value == null ? '' : String(value))).filter(Boolean)
+          : undefined;
+        if (!message && !code) return null;
+        return {
+          ...(message ? { message } : {}),
+          ...(code ? { code } : {}),
+          ...(field && field.length ? { field } : {}),
+        };
+      })
+      .filter(Boolean)
+    : [];
+
+  if (userErrors.length) {
+    return { ok: false, reason: 'user_errors', userErrors, requestId };
+  }
+
+  const cart = payload.cart && typeof payload.cart === 'object' ? payload.cart : null;
+  const cartId = typeof cart?.id === 'string' ? cart.id : '';
+  const checkoutUrl = typeof cart?.checkoutUrl === 'string' ? cart.checkoutUrl : '';
+  if (!cartId || !checkoutUrl) {
+    return { ok: false, reason: 'missing_checkout_url', requestId };
+  }
+
+  const urls = deriveStorefrontCartUrls({ cartId, checkoutUrl });
+
+  return {
+    ok: true,
+    requestId,
+    cartId,
+    checkoutUrl: urls.checkoutUrl || checkoutUrl,
+    cartUrl: urls.cartUrl || '',
+    cartPlain: urls.cartPlain || '',
+    checkoutPlain: urls.checkoutPlain || '',
+    cartToken: urls.cartToken || '',
+  };
+}
+
+function resolvePostPublishMode(body, { isPrivate } = {}) {
+  if (isPrivate) return 'private';
+  const rawMode = typeof body?.postPublishMode === 'string'
+    ? body.postPublishMode
+    : typeof body?.mode === 'string'
+      ? body.mode
+      : typeof body?.flow === 'string'
+        ? body.flow
+        : '';
+  const normalized = String(rawMode || '').trim().toLowerCase();
+  if (normalized === 'cart') return 'cart';
+  if (normalized === 'public' || normalized === 'checkout') return 'public';
+  return 'public';
+}
+
+async function runPostPublishFlow({ req, body, meta, isPrivate }) {
+  if (isPrivate) return null;
+  const variantGid = ensureVariantGid(meta?.variantAdminId || meta?.variantId);
+  if (!variantGid) return null;
+  const mode = resolvePostPublishMode(body, { isPrivate });
+  const quantityRaw = Number(body?.postPublishQuantity ?? body?.quantity ?? 1);
+  const quantity = Number.isFinite(quantityRaw) && quantityRaw > 0
+    ? Math.min(Math.max(Math.floor(quantityRaw), 1), 99)
+    : 1;
+  const buyerIp = getClientIp(req);
+
+  logPostPublishCheckpoint('post_publish_start', { mode, variantGid, quantity });
+  const cartResult = await createPostPublishCart({ variantGid, quantity, buyerIp });
+  logPostPublishCheckpoint('post_publish_complete', {
+    mode,
+    variantGid,
+    quantity,
+    requestId: cartResult?.requestId || null,
+    ok: cartResult?.ok === true,
+    reason: cartResult?.reason || null,
+  });
+  return { mode, cartResult };
 }
 
 function estimateBase64Size(base64) {
@@ -2139,6 +2366,10 @@ export async function publishProduct(req, res) {
     let variantId;
     let checkoutUrl;
     let cartId;
+    let cartUrl;
+    let cartPlain;
+    let checkoutPlain;
+    let cartToken;
     let isPrivate = false;
     try {
       body = await parseJsonBody(req, { limit: PUBLISH_PRODUCT_BODY_LIMIT });
@@ -3691,6 +3922,95 @@ export async function publishProduct(req, res) {
       }
     }
 
+    let postPublishResult = null;
+    if (!isPrivate) {
+      try {
+        postPublishResult = await runPostPublishFlow({ req, body, meta, isPrivate });
+      } catch (postErr) {
+        if (postErr?.code === 'POST_PUBLISH_MEMORY_GUARD') {
+          try {
+            console.error('post_publish_memory_guard', {
+              label: postErr?.label || null,
+              heapUsedMB: postErr?.heapUsedMB ?? null,
+              rssMB: postErr?.rssMB ?? null,
+              productId: meta?.productAdminId || null,
+              variantId: meta?.variantAdminId || null,
+            });
+          } catch {}
+          return res.status(503).json({
+            ok: false,
+            reason: 'post_publish_memory_guard',
+            message: 'Se alcanzó el límite de memoria disponible durante el post-proceso.',
+            heapUsedMB: postErr?.heapUsedMB ?? null,
+            rssMB: postErr?.rssMB ?? null,
+            ...meta,
+            visibility,
+          });
+        }
+        try {
+          console.error('post_publish_flow_exception', {
+            message: postErr?.message || String(postErr),
+            productId: meta?.productAdminId || null,
+            variantId: meta?.variantAdminId || null,
+          });
+        } catch {}
+        warnings.push({
+          code: 'post_publish_flow_exception',
+          message: 'No se pudo completar el post-proceso de Storefront.',
+          detail: postErr?.message || String(postErr),
+        });
+      }
+    }
+
+    if (postPublishResult?.cartResult?.ok) {
+      const cartData = postPublishResult.cartResult;
+      if (!checkoutUrl && typeof cartData.checkoutUrl === 'string') {
+        checkoutUrl = cartData.checkoutUrl;
+      }
+      if (!cartId && typeof cartData.cartId === 'string') {
+        cartId = cartData.cartId;
+      }
+      if (!cartUrl && typeof cartData.cartUrl === 'string') {
+        cartUrl = cartData.cartUrl;
+      }
+      if (!cartPlain && typeof cartData.cartPlain === 'string') {
+        cartPlain = cartData.cartPlain;
+      }
+      if (!checkoutPlain && typeof cartData.checkoutPlain === 'string') {
+        checkoutPlain = cartData.checkoutPlain;
+      }
+      if (!cartToken && typeof cartData.cartToken === 'string') {
+        cartToken = cartData.cartToken;
+      }
+      try {
+        console.info('post_publish_checkout_ready', {
+          mode: postPublishResult?.mode || 'public',
+          checkoutUrl: cartData.checkoutUrl || null,
+          cartId: cartData.cartId || null,
+          requestId: cartData.requestId || null,
+        });
+      } catch {}
+    } else if (postPublishResult?.cartResult && postPublishResult.cartResult.ok === false) {
+      const failure = postPublishResult.cartResult;
+      warnings.push({
+        code: 'post_publish_checkout_failed',
+        message: 'No se pudo generar el checkout automático luego de la publicación.',
+        detail: {
+          reason: failure.reason || 'unknown',
+          requestId: failure.requestId || null,
+          status: failure.status || null,
+          userErrors: failure.userErrors || null,
+        },
+      });
+      try {
+        console.warn('post_publish_checkout_failed', {
+          reason: failure.reason || 'unknown',
+          requestId: failure.requestId || null,
+          status: failure.status || null,
+        });
+      } catch {}
+    }
+
     let pdfAsset = null;
     try {
       const rawPrintDataUrl = typeof body.printDataUrl === 'string' ? body.printDataUrl.trim() : '';
@@ -3884,6 +4204,22 @@ export async function publishProduct(req, res) {
 
     if (typeof cartId === 'string' && cartId.trim()) {
       responsePayload.cartId = cartId.trim();
+    }
+
+    if (typeof cartUrl === 'string' && cartUrl.trim()) {
+      responsePayload.cartUrl = cartUrl.trim();
+    }
+
+    if (typeof cartPlain === 'string' && cartPlain.trim()) {
+      responsePayload.cartPlain = cartPlain.trim();
+    }
+
+    if (typeof checkoutPlain === 'string' && checkoutPlain.trim()) {
+      responsePayload.checkoutPlain = checkoutPlain.trim();
+    }
+
+    if (typeof cartToken === 'string' && cartToken.trim()) {
+      responsePayload.cartToken = cartToken.trim();
     }
 
     if (pdfAsset) {


### PR DESCRIPTION
## Summary
- add Storefront cart helpers and post-publish memory checkpoints to keep publishProduct within the memory budget after publishing
- run a minimal Storefront cart create flow post-publication to surface checkout/cart links while capturing controlled failure modes
- expose checkout/cart metadata in the publishProduct response for downstream flows that consume the checkout URL directly

## Testing
- npm test *(interrupted after several suites completed because the run appeared to hang)*

------
https://chatgpt.com/codex/tasks/task_e_68de6f2c2cc08327a83877a4b61d01b9