### PR TITLE
Restore publishProduct checkout flow with storefront fallback

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -20,25 +20,6 @@ import imageBufferToPdf from '../_lib/imageToPdf.js';
 const DEFAULT_VENDOR = 'MgMGamers';
 const OUTPUT_BUCKET = 'outputs';
 const PUBLISH_PRODUCT_BODY_LIMIT = 6 * 1024 * 1024; // 6 MiB
-
-function parseEnvFlag(value, defaultValue = false) {
-  if (value == null) return defaultValue;
-  const normalized = String(value).trim().toLowerCase();
-  if (!normalized) return defaultValue;
-  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
-}
-
-const PUBLISH_STRICT_SAFE_MODE = parseEnvFlag(process.env.PUBLISH_STRICT_SAFE_MODE);
-const POST_PUBLISH_REFRESH_ENABLED = parseEnvFlag(process.env.POST_PUBLISH_REFRESH, true);
-const POST_PUBLISH_SYNC_ENABLED = parseEnvFlag(process.env.POST_PUBLISH_SYNC, true);
-const DISABLE_HEAVY_REFETCH = parseEnvFlag(process.env.DISABLE_HEAVY_REFETCH);
-const DISABLE_MEDIA_POSTWORK = parseEnvFlag(process.env.DISABLE_MEDIA_POSTWORK);
-const DISABLE_PRIVATE_CHECKOUT_TEMP = parseEnvFlag(process.env.DISABLE_PRIVATE_CHECKOUT_TEMP);
-const SAFE_MODE_ENABLED = PUBLISH_STRICT_SAFE_MODE === true;
-const POST_PUBLISH_FEATURES_ENABLED = POST_PUBLISH_REFRESH_ENABLED
-  && POST_PUBLISH_SYNC_ENABLED
-  && !DISABLE_HEAVY_REFETCH
-  && !DISABLE_MEDIA_POSTWORK;
 const ONLINE_STORE_MISSING_MESSAGE = [
   'No pudimos encontrar el canal Online Store para publicar este producto.',
   'RevisÃ¡: 1) que el canal estÃ© instalado, 2) que la app tenga el scope write_publications.',
@@ -56,13 +37,7 @@ const MAX_IMAGE_PIXEL_AREA = Number.isFinite(RAW_MEDIA_MAX_PIXELS) && RAW_MEDIA_
   : DEFAULT_MAX_IMAGE_PIXEL_AREA;
 const MEMORY_HEAP_LIMIT = DEFAULT_MEMORY_HEAP_BUDGET_MB * BYTES_PER_MB;
 const MEMORY_RSS_LIMIT = DEFAULT_MEMORY_RSS_BUDGET_MB * BYTES_PER_MB;
-const SAFE_MODE_HEAP_LIMIT_MB = 350;
-const SAFE_MODE_HEAP_LIMIT_BYTES = SAFE_MODE_HEAP_LIMIT_MB * BYTES_PER_MB;
-const BASE64_CHUNK_CHAR_SIZE = Math.max(4, Math.floor((256 * 1024) / 3) * 4);
-const ENABLE_GC_DEV = String(process.env.ENABLE_GC_DEV || '').toLowerCase() === 'true';
-const PUBLISH_LIGHT_MODE = String(process.env.PUBLISH_LIGHT_MODE || '').toLowerCase() === 'true';
-const STAGED_UPLOAD_TIMEOUT_MS = 45_000;
-const POST_PUBLISH_CART_MUTATION = `
+const STOREFRONT_CART_CREATE_MUTATION = `
   mutation PostPublishCartCreate($lines: [CartLineInput!]!) {
     cartCreate(input: { lines: $lines }) {
       cart {
@@ -77,6 +52,10 @@ const POST_PUBLISH_CART_MUTATION = `
     }
   }
 `;
+const BASE64_CHUNK_CHAR_SIZE = Math.max(4, Math.floor((256 * 1024) / 3) * 4);
+const ENABLE_GC_DEV = String(process.env.ENABLE_GC_DEV || '').toLowerCase() === 'true';
+const PUBLISH_LIGHT_MODE = String(process.env.PUBLISH_LIGHT_MODE || '').toLowerCase() === 'true';
+const STAGED_UPLOAD_TIMEOUT_MS = 45_000;
 
 sharp.cache({ files: 0, items: 0, memory: 0 });
 sharp.concurrency(1);
@@ -84,35 +63,6 @@ sharp.concurrency(1);
 function bytesToMb(bytes) {
   if (!Number.isFinite(bytes) || bytes <= 0) return 0;
   return Number((bytes / BYTES_PER_MB).toFixed(2));
-}
-
-function buildPostPublishMemoryError({ label, usage }) {
-  const err = new Error('POST_PUBLISH_MEMORY_GUARD');
-  err.code = 'POST_PUBLISH_MEMORY_GUARD';
-  err.status = 503;
-  err.label = label;
-  err.heapUsed = usage?.heapUsed ?? null;
-  err.heapUsedMB = bytesToMb(usage?.heapUsed ?? 0);
-  err.rss = usage?.rss ?? null;
-  err.rssMB = bytesToMb(usage?.rss ?? 0);
-  return err;
-}
-
-function logPostPublishCheckpoint(label, extra = {}) {
-  const usage = process.memoryUsage();
-  const payload = {
-    label,
-    heapUsedMB: bytesToMb(usage.heapUsed),
-    rssMB: bytesToMb(usage.rss),
-    ...extra,
-  };
-  try {
-    console.info('post_publish_checkpoint', payload);
-  } catch {}
-  if (usage.heapUsed > MEMORY_HEAP_LIMIT || usage.rss > MEMORY_RSS_LIMIT) {
-    throw buildPostPublishMemoryError({ label, usage });
-  }
-  return usage;
 }
 
 function readStorefrontRequestId(resp) {
@@ -150,7 +100,42 @@ function deriveStorefrontCartUrls({ cartId, checkoutUrl }) {
   };
 }
 
-async function createPostPublishCart({ variantGid, quantity = 1, buyerIp }) {
+function clampCheckoutQuantity(value) {
+  const raw = Number(value);
+  if (!Number.isFinite(raw) || raw <= 0) return 1;
+  return Math.max(1, Math.min(99, Math.floor(raw)));
+}
+
+function buildOnlineStoreCartPermalink({ variantNumericId, quantity = 1, discountCode }) {
+  const numericId = typeof variantNumericId === 'string' && variantNumericId.trim()
+    ? variantNumericId.trim()
+    : typeof variantNumericId === 'number' && Number.isFinite(variantNumericId)
+      ? String(Math.trunc(variantNumericId))
+      : '';
+  if (!numericId) return '';
+  const qty = clampCheckoutQuantity(quantity);
+  const base = getPublicStorefrontBase();
+  try {
+    const url = new URL(`/cart/${numericId}:${qty}`, base);
+    const code = typeof discountCode === 'string' ? discountCode.trim() : '';
+    if (code) {
+      url.searchParams.set('discount', code);
+    }
+    return url.toString();
+  } catch (err) {
+    try {
+      console.error('online_store_permalink_build_failed', {
+        message: err?.message || String(err),
+        base,
+        variantNumericId: numericId,
+        quantity: qty,
+      });
+    } catch {}
+    return '';
+  }
+}
+
+async function createStorefrontCart({ variantGid, quantity = 1, buyerIp }) {
   if (!variantGid) {
     return { ok: false, reason: 'missing_variant_gid' };
   }
@@ -165,7 +150,7 @@ async function createPostPublishCart({ variantGid, quantity = 1, buyerIp }) {
   let response;
   try {
     response = await shopifyStorefrontGraphQL(
-      POST_PUBLISH_CART_MUTATION,
+      STOREFRONT_CART_CREATE_MUTATION,
       { lines },
       buyerIp ? { buyerIp } : {},
     );
@@ -224,11 +209,15 @@ async function createPostPublishCart({ variantGid, quantity = 1, buyerIp }) {
         const field = Array.isArray(entry.field)
           ? entry.field.map((value) => (value == null ? '' : String(value))).filter(Boolean)
           : undefined;
-        if (!message && !code) return null;
+        const extensions = entry && typeof entry.extensions === 'object' && entry.extensions
+          ? entry.extensions
+          : undefined;
+        if (!message && !code && !extensions) return null;
         return {
           ...(message ? { message } : {}),
           ...(code ? { code } : {}),
           ...(field && field.length ? { field } : {}),
+          ...(extensions ? { extensions } : {}),
         };
       })
       .filter(Boolean)
@@ -272,31 +261,6 @@ function resolvePostPublishMode(body, { isPrivate } = {}) {
   if (normalized === 'cart') return 'cart';
   if (normalized === 'public' || normalized === 'checkout') return 'public';
   return 'public';
-}
-
-async function runPostPublishFlow({ req, body, meta, isPrivate }) {
-  if (SAFE_MODE_ENABLED || !POST_PUBLISH_FEATURES_ENABLED) return null;
-  if (isPrivate) return null;
-  const variantGid = ensureVariantGid(meta?.variantAdminId || meta?.variantId);
-  if (!variantGid) return null;
-  const mode = resolvePostPublishMode(body, { isPrivate });
-  const quantityRaw = Number(body?.postPublishQuantity ?? body?.quantity ?? 1);
-  const quantity = Number.isFinite(quantityRaw) && quantityRaw > 0
-    ? Math.min(Math.max(Math.floor(quantityRaw), 1), 99)
-    : 1;
-  const buyerIp = getClientIp(req);
-
-  logPostPublishCheckpoint('post_publish_start', { mode, variantGid, quantity });
-  const cartResult = await createPostPublishCart({ variantGid, quantity, buyerIp });
-  logPostPublishCheckpoint('post_publish_complete', {
-    mode,
-    variantGid,
-    quantity,
-    requestId: cartResult?.requestId || null,
-    ok: cartResult?.ok === true,
-    reason: cartResult?.reason || null,
-  });
-  return { mode, cartResult };
 }
 
 function estimateBase64Size(base64) {
@@ -401,36 +365,14 @@ function logMemoryCheckpoint(label, extra = {}) {
   return usage;
 }
 
-function buildSafeModeOOMError({ label, requestId, usage }) {
-  const err = new Error('SAFE_MODE_MEMORY_GUARD');
-  err.code = 'OOM_GUARD';
-  err.status = 503;
-  err.label = label;
-  err.requestId = requestId || null;
-  err.heapUsed = usage?.heapUsed ?? null;
-  err.heapUsedMB = bytesToMb(usage?.heapUsed ?? 0);
-  err.rss = usage?.rss ?? null;
-  err.rssMB = bytesToMb(usage?.rss ?? 0);
-  err.limitMB = SAFE_MODE_HEAP_LIMIT_MB;
-  return err;
-}
-
 function logSafeModeStep(label, { requestId } = {}) {
-  if (!SAFE_MODE_ENABLED) return null;
-  const usage = process.memoryUsage();
-  const payload = {
-    label,
-    heapUsedMB: bytesToMb(usage.heapUsed),
-    rssMB: bytesToMb(usage.rss),
-    requestId: requestId || null,
-  };
   try {
-    console.info('publish_product_safe_mode_checkpoint', payload);
+    console.info('publish_product_safe_mode_checkpoint', {
+      label,
+      requestId: requestId || null,
+    });
   } catch {}
-  if (usage.heapUsed > SAFE_MODE_HEAP_LIMIT_BYTES) {
-    throw buildSafeModeOOMError({ label, requestId, usage });
-  }
-  return usage;
+  return null;
 }
 
 function resolveRequestId(resolver, result, error) {
@@ -3995,208 +3937,126 @@ export async function publishProduct(req, res) {
       logSafeModeStep('safe_mode_private_ready', { requestId: null });
     }
 
-    if (SAFE_MODE_ENABLED) {
-      if (isPrivate && DISABLE_PRIVATE_CHECKOUT_TEMP) {
-        logSafeModeStep('safe_mode_private_disabled', { requestId: null });
-        return res.status(503).json({
-          ok: false,
-          reason: 'private_checkout_temporarily_disabled',
-          message: 'El checkout privado está temporalmente deshabilitado.',
-          ...meta,
-          visibility,
-        });
-      }
+    const checkoutMode = resolvePostPublishMode(body, { isPrivate });
+    const quantityInput = body?.quantity ?? body?.postPublishQuantity ?? 1;
+    const normalizedQuantity = clampCheckoutQuantity(quantityInput);
+    const buyerIp = getClientIp(req);
+    const discountCode = typeof body?.discountCode === 'string' ? body.discountCode.trim() : '';
+    const variantGidForCheckout = ensureVariantGid(meta?.variantAdminId || meta?.variantId || variantId);
+    const variantNumericId = extractLegacyId(meta?.variantAdminId || meta?.variantId || variantId, 'ProductVariant');
+    const permalinkFallback = buildOnlineStoreCartPermalink({
+      variantNumericId,
+      quantity: normalizedQuantity,
+      discountCode,
+    });
 
-      const variantGidSafeMode = ensureVariantGid(meta?.variantAdminId || meta?.variantId || variantId);
-      if (!variantGidSafeMode) {
-        logSafeModeStep('safe_mode_missing_variant_gid', { requestId: null });
-        return res.status(500).json({
-          ok: false,
-          reason: 'safe_mode_missing_variant_gid',
-          message: 'No se pudo determinar la variante para generar el checkout.',
-          ...meta,
-          visibility,
-        });
-      }
-
-      const safeModeQuantityRaw = Number(body?.postPublishQuantity ?? body?.quantity ?? 1);
-      const safeModeQuantity = Number.isFinite(safeModeQuantityRaw) && safeModeQuantityRaw > 0
-        ? Math.min(Math.max(Math.floor(safeModeQuantityRaw), 1), 99)
-        : 1;
-      const safeModeBuyerIp = getClientIp(req);
-
-      logSafeModeStep('safe_mode_checkout_start', { requestId: null });
-      const safeModeCartResult = await createPostPublishCart({
-        variantGid: variantGidSafeMode,
-        quantity: safeModeQuantity,
-        buyerIp: safeModeBuyerIp,
+    let storefrontCheckout = null;
+    if (variantGidForCheckout) {
+      storefrontCheckout = await createStorefrontCart({
+        variantGid: variantGidForCheckout,
+        quantity: normalizedQuantity,
+        buyerIp,
       });
-      logSafeModeStep('safe_mode_checkout_complete', { requestId: safeModeCartResult?.requestId || null });
-
-      if (!safeModeCartResult?.ok) {
-        const safeModeReason = safeModeCartResult?.reason || 'safe_mode_checkout_failed';
-        return res.status(502).json({
-          ok: false,
-          reason: safeModeReason,
-          message: 'No se pudo generar el checkout automático en SAFE MODE.',
-          detail: {
-            reason: safeModeReason,
-            requestId: safeModeCartResult?.requestId || null,
-            status: safeModeCartResult?.status || null,
-          },
-          ...meta,
-          visibility,
+    } else if (!isPrivate) {
+      try {
+        console.warn('storefront_checkout_missing_variant_gid', {
+          mode: checkoutMode,
+          productId: meta?.productAdminId || null,
+          variantId: meta?.variantAdminId || null,
         });
-      }
-
-      const safeCheckoutUrl = typeof safeModeCartResult.checkoutUrl === 'string'
-        ? safeModeCartResult.checkoutUrl.trim()
-        : '';
-      const safeCartId = typeof safeModeCartResult.cartId === 'string'
-        ? safeModeCartResult.cartId.trim()
-        : '';
-      const safeCartUrl = typeof safeModeCartResult.cartUrl === 'string'
-        ? safeModeCartResult.cartUrl.trim()
-        : '';
-      const safeCartPlain = typeof safeModeCartResult.cartPlain === 'string'
-        ? safeModeCartResult.cartPlain.trim()
-        : '';
-      const safeCheckoutPlain = typeof safeModeCartResult.checkoutPlain === 'string'
-        ? safeModeCartResult.checkoutPlain.trim()
-        : '';
-      const safeCartToken = typeof safeModeCartResult.cartToken === 'string'
-        ? safeModeCartResult.cartToken.trim()
-        : '';
-
-      const warningMessages = warnings
-        .map((entry) => (entry && typeof entry.message === 'string' ? entry.message : typeof entry === 'string' ? entry : ''))
-        .filter((entry) => entry);
-      const warningCodes = warnings
-        .map((entry) => (entry && typeof entry.code === 'string' ? entry.code : ''))
-        .filter((entry) => entry);
-
-      const responsePayload = {
-        ok: true,
-        ...meta,
-        productId,
-        variantId,
-        status: product?.status,
-        visibility,
-        ...(safeCheckoutUrl ? { checkoutUrl: safeCheckoutUrl } : {}),
-        ...(safeCartId ? { cartId: safeCartId } : {}),
-        ...(safeCartUrl ? { cartUrl: safeCartUrl } : {}),
-        ...(safeCartPlain ? { cartPlain: safeCartPlain } : {}),
-        ...(safeCheckoutPlain ? { checkoutPlain: safeCheckoutPlain } : {}),
-        ...(safeCartToken ? { cartToken: safeCartToken } : {}),
-        ...(warnings.length ? { warnings } : {}),
-        ...(warningMessages.length ? { warningMessages } : {}),
-        ...(warningCodes.length ? { warningCodes } : {}),
-      };
-
-      if (!isPrivate) {
-        responsePayload.publicationId = publishResult?.publicationId || null;
-        responsePayload.publicationSource = publicationInfo?.source || null;
-        responsePayload.requestIds = publishResult?.requestIds || null;
-        if (typeof publishResult?.attempt === 'number') {
-          responsePayload.publishAttempts = publishResult.attempt;
-        }
-      } else {
-        responsePayload.publicationId = null;
-        responsePayload.publicationSource = null;
-        responsePayload.requestIds = null;
-      }
-
-      logSafeModeStep('safe_mode_complete', { requestId: safeModeCartResult?.requestId || null });
-      return res.status(200).json(responsePayload);
+      } catch {}
     }
 
-    let postPublishResult = null;
-    if (!isPrivate) {
+    const storefrontRequestId = storefrontCheckout?.requestId || null;
+    const storefrontUserErrors = Array.isArray(storefrontCheckout?.userErrors)
+      ? storefrontCheckout.userErrors
+      : [];
+
+    if (storefrontCheckout?.reason === 'user_errors' && storefrontUserErrors.length) {
       try {
-        postPublishResult = await runPostPublishFlow({ req, body, meta, isPrivate });
-      } catch (postErr) {
-        if (postErr?.code === 'POST_PUBLISH_MEMORY_GUARD') {
-          try {
-            console.error('post_publish_memory_guard', {
-              label: postErr?.label || null,
-              heapUsedMB: postErr?.heapUsedMB ?? null,
-              rssMB: postErr?.rssMB ?? null,
-              productId: meta?.productAdminId || null,
-              variantId: meta?.variantAdminId || null,
-            });
-          } catch {}
-          return res.status(503).json({
+        console.warn('storefront_checkout_user_errors', {
+          mode: checkoutMode,
+          requestId: storefrontRequestId,
+          userErrors: storefrontUserErrors,
+        });
+      } catch {}
+    } else if (storefrontCheckout && storefrontCheckout.ok === false) {
+      try {
+        console.error('storefront_checkout_failed', {
+          mode: checkoutMode,
+          reason: storefrontCheckout.reason || 'unknown',
+          status: storefrontCheckout.status || null,
+          requestId: storefrontRequestId,
+        });
+      } catch {}
+    }
+
+    if (!isPrivate) {
+      if (storefrontCheckout?.ok) {
+        checkoutUrl = typeof storefrontCheckout.checkoutUrl === 'string'
+          ? storefrontCheckout.checkoutUrl.trim()
+          : checkoutUrl;
+        cartId = typeof storefrontCheckout.cartId === 'string' ? storefrontCheckout.cartId : cartId;
+        cartUrl = typeof storefrontCheckout.cartUrl === 'string' ? storefrontCheckout.cartUrl : cartUrl;
+        cartPlain = typeof storefrontCheckout.cartPlain === 'string' ? storefrontCheckout.cartPlain : cartPlain;
+        checkoutPlain = typeof storefrontCheckout.checkoutPlain === 'string'
+          ? storefrontCheckout.checkoutPlain
+          : checkoutPlain;
+        cartToken = typeof storefrontCheckout.cartToken === 'string' ? storefrontCheckout.cartToken : cartToken;
+      } else if (permalinkFallback) {
+        checkoutUrl = permalinkFallback;
+        cartUrl = permalinkFallback;
+        try {
+          console.info('storefront_checkout_fallback_permalink', {
+            mode: checkoutMode,
+            requestId: storefrontRequestId,
+            reason: storefrontCheckout?.reason || 'fallback',
+            discountApplied: Boolean(discountCode),
+          });
+        } catch {}
+      }
+    } else {
+      if (!variantGidForCheckout) {
+        return res.status(500).json({
+          ok: false,
+          reason: 'missing_variant_gid',
+          message: 'No se pudo determinar la variante para generar el checkout privado.',
+          ...meta,
+          visibility,
+        });
+      }
+      if (!storefrontCheckout?.ok) {
+        if (storefrontCheckout?.reason === 'user_errors' && storefrontUserErrors.length) {
+          return res.status(400).json({
             ok: false,
-            reason: 'post_publish_memory_guard',
-            message: 'Se alcanzó el límite de memoria disponible durante el post-proceso.',
-            heapUsedMB: postErr?.heapUsedMB ?? null,
-            rssMB: postErr?.rssMB ?? null,
+            reason: 'user_errors',
+            message: 'Shopify rechazó la creación del checkout privado.',
+            requestId: storefrontRequestId,
+            userErrors: storefrontUserErrors,
             ...meta,
             visibility,
           });
         }
-        try {
-          console.error('post_publish_flow_exception', {
-            message: postErr?.message || String(postErr),
-            productId: meta?.productAdminId || null,
-            variantId: meta?.variantAdminId || null,
-          });
-        } catch {}
-        warnings.push({
-          code: 'post_publish_flow_exception',
-          message: 'No se pudo completar el post-proceso de Storefront.',
-          detail: postErr?.message || String(postErr),
+        return res.status(502).json({
+          ok: false,
+          reason: storefrontCheckout?.reason || 'checkout_failed',
+          message: 'No se pudo generar el checkout privado en Shopify.',
+          requestId: storefrontRequestId,
+          status: storefrontCheckout?.status || null,
+          ...meta,
+          visibility,
         });
       }
-    }
-
-    if (postPublishResult?.cartResult?.ok) {
-      const cartData = postPublishResult.cartResult;
-      if (!checkoutUrl && typeof cartData.checkoutUrl === 'string') {
-        checkoutUrl = cartData.checkoutUrl;
-      }
-      if (!cartId && typeof cartData.cartId === 'string') {
-        cartId = cartData.cartId;
-      }
-      if (!cartUrl && typeof cartData.cartUrl === 'string') {
-        cartUrl = cartData.cartUrl;
-      }
-      if (!cartPlain && typeof cartData.cartPlain === 'string') {
-        cartPlain = cartData.cartPlain;
-      }
-      if (!checkoutPlain && typeof cartData.checkoutPlain === 'string') {
-        checkoutPlain = cartData.checkoutPlain;
-      }
-      if (!cartToken && typeof cartData.cartToken === 'string') {
-        cartToken = cartData.cartToken;
-      }
-      try {
-        console.info('post_publish_checkout_ready', {
-          mode: postPublishResult?.mode || 'public',
-          checkoutUrl: cartData.checkoutUrl || null,
-          cartId: cartData.cartId || null,
-          requestId: cartData.requestId || null,
-        });
-      } catch {}
-    } else if (postPublishResult?.cartResult && postPublishResult.cartResult.ok === false) {
-      const failure = postPublishResult.cartResult;
-      warnings.push({
-        code: 'post_publish_checkout_failed',
-        message: 'No se pudo generar el checkout automático luego de la publicación.',
-        detail: {
-          reason: failure.reason || 'unknown',
-          requestId: failure.requestId || null,
-          status: failure.status || null,
-          userErrors: failure.userErrors || null,
-        },
-      });
-      try {
-        console.warn('post_publish_checkout_failed', {
-          reason: failure.reason || 'unknown',
-          requestId: failure.requestId || null,
-          status: failure.status || null,
-        });
-      } catch {}
+      checkoutUrl = typeof storefrontCheckout.checkoutUrl === 'string'
+        ? storefrontCheckout.checkoutUrl.trim()
+        : checkoutUrl;
+      cartId = typeof storefrontCheckout.cartId === 'string' ? storefrontCheckout.cartId : cartId;
+      cartUrl = typeof storefrontCheckout.cartUrl === 'string' ? storefrontCheckout.cartUrl : cartUrl;
+      cartPlain = typeof storefrontCheckout.cartPlain === 'string' ? storefrontCheckout.cartPlain : cartPlain;
+      checkoutPlain = typeof storefrontCheckout.checkoutPlain === 'string'
+        ? storefrontCheckout.checkoutPlain
+        : checkoutPlain;
+      cartToken = typeof storefrontCheckout.cartToken === 'string' ? storefrontCheckout.cartToken : cartToken;
     }
 
     let pdfAsset = null;
@@ -4473,12 +4333,12 @@ export async function publishProduct(req, res) {
       return res.status(e?.status || 503).json({
         ok: false,
         reason: 'oom_guard',
-        message: 'SAFE_MODE_MEMORY_GUARD: Se alcanzó el límite de memoria permitido.',
+        message: 'Se alcanzó el límite de memoria permitido durante la publicación.',
         label: e?.label || null,
         heapUsedMB: e?.heapUsedMB ?? null,
         rssMB: e?.rssMB ?? null,
         requestId: e?.requestId || null,
-        limitMB: e?.limitMB ?? SAFE_MODE_HEAP_LIMIT_MB,
+        limitMB: e?.limitMB ?? DEFAULT_MEMORY_HEAP_BUDGET_MB,
       });
     }
     console.error('publish_product_error', e);


### PR DESCRIPTION
## Summary
- lib/handlers/publishProduct.js – remover safe-mode/kill-switch, restaurar flujo base, agregar fallback permalink y log completo de userErrors.

## Logs
- Los nuevos mensajes `storefront_checkout_user_errors` y `storefront_checkout_fallback_permalink` muestran el intento Storefront con userErrors y el uso automático del fallback B.

## Confirmation
- Se verificó que no quedan llamadas post-publish adicionales.

## Testing
- `npm test` *(falla conocida: OOM en tests/image-to-pdf.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68de83289ce883279ae20a26134d211e