### PR TITLE
Rollback public checkout to permalink

### DIFF
--- a/lib/handlers/cartLink.js
+++ b/lib/handlers/cartLink.js
@@ -1,12 +1,10 @@
 import { z } from 'zod';
-import { parseJsonBody, getClientIp } from '../_lib/http.js';
+import { parseJsonBody } from '../_lib/http.js';
 import getSupabaseAdmin from '../_lib/supabaseAdmin.js';
 import {
   resolveVariantIds,
   buildCartPermalink,
   precheckVariantAvailability,
-  createStorefrontCart,
-  normalizeCartAttributes,
 } from '../shopify/cartHelpers.js';
 
 const BodySchema = z
@@ -101,6 +99,22 @@ function buildFallbackResponse({ variantNumericId, quantity, requestId, reason, 
   };
 }
 
+function buildPermalinkSuccess({ variantNumericId, quantity, requestId }) {
+  const permalink = buildCartPermalink(variantNumericId, quantity);
+  if (!permalink) return null;
+  return {
+    url: permalink,
+    webUrl: permalink,
+    checkoutUrl: permalink,
+    cartPlain: 'https://www.mgmgamers.store/cart',
+    checkoutPlain: 'https://www.mgmgamers.store/checkout',
+    cart_id: null,
+    cart_token: null,
+    strategy: 'permalink',
+    requestId: requestId || undefined,
+  };
+}
+
 export default async function cartLink(req, res) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
@@ -125,7 +139,7 @@ export default async function cartLink(req, res) {
       return respondError(res, 400, 'bad_request');
 
     }
-    const { variantId, variantGid, quantity, jobId: jobIdRaw, job_id, attributes, note } = parsed.data;
+    const { variantId, variantGid, quantity, jobId: jobIdRaw, job_id } = parsed.data;
     const jobId = normalizeJobId(jobIdRaw, job_id);
 
     let { variantNumericId, variantGid: resolvedVariantGid } = resolveVariantIds({ variantId, variantGid });
@@ -166,7 +180,6 @@ export default async function cartLink(req, res) {
     }
 
     const qty = normalizeQuantity(quantity);
-    const buyerIp = getClientIp(req);
 
     const poll = await precheckVariantAvailability(resolvedVariantGid, {
       maxAttempts: 10,
@@ -196,106 +209,21 @@ export default async function cartLink(req, res) {
       return respondSuccess(res, fallback);
     }
 
-    const normalizedAttributes = normalizeCartAttributes(attributes);
-
-    let storefrontAttempt;
-    try {
-      storefrontAttempt = await createStorefrontCart({
-        variantGid: resolvedVariantGid,
-        quantity: qty,
-        buyerIp,
-        attributes: normalizedAttributes,
-        note,
-      });
-    } catch (err) {
-      logEvent(
-        'cart_create',
-        {
-          variantGid: resolvedVariantGid,
-          variantNumericId,
-          requestId: null,
-          reason: err?.message || 'storefront_exception',
-          strategy: 'permalink',
-        },
-        'warn',
-      );
-      const fallback = buildFallbackResponse({
-        variantNumericId,
-        quantity: qty,
-        requestId: poll.requestId || null,
-        reason: 'storefront_exception',
-      });
-      if (!fallback) {
-        return respondError(res, 502, 'shopify_unreachable');
-      }
-      logEvent(
-        'fallback_permalink',
-        {
-          variantGid: resolvedVariantGid,
-          variantNumericId,
-          requestId: poll.requestId || null,
-          reason: 'storefront_exception',
-        },
-        'warn',
-      );
-      return respondSuccess(res, fallback);
-    }
-
-    if (storefrontAttempt.ok) {
-      logEvent('cart_create', {
-        variantGid: resolvedVariantGid,
-        variantNumericId,
-        requestId: storefrontAttempt.requestId || poll.requestId || null,
-        checkoutUrl: storefrontAttempt.checkoutUrl || null,
-        strategy: 'storefront',
-      });
-      return respondSuccess(res, {
-        url: storefrontAttempt.cartUrl,
-        webUrl: storefrontAttempt.cartUrl,
-        checkoutUrl: storefrontAttempt.checkoutUrl || null,
-        cartPlain: storefrontAttempt.cartPlain || null,
-        checkoutPlain: storefrontAttempt.checkoutPlain || null,
-        cart_id: storefrontAttempt.cartId || null,
-        cart_token: storefrontAttempt.cartToken || null,
-        strategy: 'storefront',
-        requestId: storefrontAttempt.requestId || poll.requestId || undefined,
-      });
-    }
-
-      logEvent(
-        'cart_create',
-        {
-          variantGid: resolvedVariantGid,
-          variantNumericId,
-          requestId: storefrontAttempt.requestId || poll.requestId || null,
-          reason: storefrontAttempt.reason || 'storefront_failed',
-          userErrors: storefrontAttempt.userErrors || null,
-          strategy: 'permalink',
-        },
-        'warn',
-      );
-    const fallback = buildFallbackResponse({
+    const successPayload = buildPermalinkSuccess({
       variantNumericId,
       quantity: qty,
-      requestId: storefrontAttempt.requestId || poll.requestId || null,
-      reason: storefrontAttempt.reason || 'storefront_failed',
-      userErrors: storefrontAttempt.userErrors,
+      requestId: poll.requestId || null,
     });
-    if (!fallback) {
-      return respondError(res, 400, 'missing_variant');
+    if (!successPayload) {
+      return respondError(res, 500, 'permalink_build_failed');
     }
-    logEvent(
-      'fallback_permalink',
-      {
-        variantGid: resolvedVariantGid,
-        variantNumericId,
-        requestId: storefrontAttempt.requestId || poll.requestId || null,
-        reason: storefrontAttempt.reason || 'storefront_failed',
-        userErrors: storefrontAttempt.userErrors || null,
-      },
-      'warn',
-    );
-    return respondSuccess(res, fallback);
+    logEvent('cart_permalink', {
+      variantGid: resolvedVariantGid,
+      variantNumericId,
+      requestId: poll.requestId || null,
+      strategy: 'permalink',
+    });
+    return respondSuccess(res, successPayload);
 
   } catch (err) {
     if (res.statusCode === 413) {

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -248,21 +248,6 @@ async function createStorefrontCart({ variantGid, quantity = 1, buyerIp }) {
   };
 }
 
-function resolvePostPublishMode(body, { isPrivate } = {}) {
-  if (isPrivate) return 'private';
-  const rawMode = typeof body?.postPublishMode === 'string'
-    ? body.postPublishMode
-    : typeof body?.mode === 'string'
-      ? body.mode
-      : typeof body?.flow === 'string'
-        ? body.flow
-        : '';
-  const normalized = String(rawMode || '').trim().toLowerCase();
-  if (normalized === 'cart') return 'cart';
-  if (normalized === 'public' || normalized === 'checkout') return 'public';
-  return 'public';
-}
-
 function estimateBase64Size(base64) {
   if (typeof base64 !== 'string' || !base64) return 0;
   const cleaned = base64.replace(/\s+/g, '');
@@ -363,16 +348,6 @@ function logMemoryCheckpoint(label, extra = {}) {
     console.info('publish_product_memory_checkpoint', payload);
   } catch {}
   return usage;
-}
-
-function logSafeModeStep(label, { requestId } = {}) {
-  try {
-    console.info('publish_product_safe_mode_checkpoint', {
-      label,
-      requestId: requestId || null,
-    });
-  } catch {}
-  return null;
 }
 
 function resolveRequestId(resolver, result, error) {
@@ -2819,7 +2794,6 @@ export async function publishProduct(req, res) {
       });
     }
 
-    logSafeModeStep('safe_mode_product_create_start', { requestId: null });
 
     const {
       resp: productResp,
@@ -2947,7 +2921,6 @@ export async function publishProduct(req, res) {
       console.info('product_create_success', { requestId: productRequestId || null, productId: meta.productAdminId || null });
     } catch {}
 
-    logSafeModeStep('safe_mode_product_created', { requestId: productRequestId || null });
 
     const productIdForVariants = typeof product?.id === 'string' && product.id
       ? product.id
@@ -3107,7 +3080,6 @@ export async function publishProduct(req, res) {
 
     const variantUpdateInput = { ...variantUpdateInputBase, id: defaultVariant.id };
 
-    logSafeModeStep('safe_mode_variant_update_start', { requestId: null });
 
     const {
       resp: variantResp,
@@ -3377,7 +3349,6 @@ export async function publishProduct(req, res) {
       console.info('product_variant_update_success', variantSuccessLog);
     } catch {}
 
-    logSafeModeStep('safe_mode_variant_updated', { requestId: variantRequestIdFinal || null });
 
     variantInventoryMode = 'not_tracked';
     variantAvailableForSale = typeof updatedVariant?.availableForSale === 'boolean'
@@ -3853,7 +3824,6 @@ export async function publishProduct(req, res) {
         throw err;
       }
 
-      logSafeModeStep('safe_mode_publish_start', { requestId: publicationInfo?.id || null });
 
       try {
         publishResult = await withMemoryBudget(
@@ -3928,93 +3898,28 @@ export async function publishProduct(req, res) {
       }
     }
 
-    if (!isPrivate) {
-      const publishCheckpointRequestId = Array.isArray(publishResult?.requestIds) && publishResult.requestIds.length
-        ? publishResult.requestIds[publishResult.requestIds.length - 1]
-        : null;
-      logSafeModeStep('safe_mode_publish_success', { requestId: publishCheckpointRequestId });
-    } else {
-      logSafeModeStep('safe_mode_private_ready', { requestId: null });
-    }
-
-    const checkoutMode = resolvePostPublishMode(body, { isPrivate });
     const quantityInput = body?.quantity ?? body?.postPublishQuantity ?? 1;
     const normalizedQuantity = clampCheckoutQuantity(quantityInput);
-    const buyerIp = getClientIp(req);
     const discountCode = typeof body?.discountCode === 'string' ? body.discountCode.trim() : '';
     const variantGidForCheckout = ensureVariantGid(meta?.variantAdminId || meta?.variantId || variantId);
     const variantNumericId = extractLegacyId(meta?.variantAdminId || meta?.variantId || variantId, 'ProductVariant');
-    const permalinkFallback = buildOnlineStoreCartPermalink({
+    const permalinkUrl = buildOnlineStoreCartPermalink({
       variantNumericId,
       quantity: normalizedQuantity,
       discountCode,
     });
-
-    let storefrontCheckout = null;
-    if (variantGidForCheckout) {
-      storefrontCheckout = await createStorefrontCart({
-        variantGid: variantGidForCheckout,
-        quantity: normalizedQuantity,
-        buyerIp,
-      });
-    } else if (!isPrivate) {
-      try {
-        console.warn('storefront_checkout_missing_variant_gid', {
-          mode: checkoutMode,
-          productId: meta?.productAdminId || null,
-          variantId: meta?.variantAdminId || null,
-        });
-      } catch {}
-    }
-
-    const storefrontRequestId = storefrontCheckout?.requestId || null;
-    const storefrontUserErrors = Array.isArray(storefrontCheckout?.userErrors)
-      ? storefrontCheckout.userErrors
-      : [];
-
-    if (storefrontCheckout?.reason === 'user_errors' && storefrontUserErrors.length) {
-      try {
-        console.warn('storefront_checkout_user_errors', {
-          mode: checkoutMode,
-          requestId: storefrontRequestId,
-          userErrors: storefrontUserErrors,
-        });
-      } catch {}
-    } else if (storefrontCheckout && storefrontCheckout.ok === false) {
-      try {
-        console.error('storefront_checkout_failed', {
-          mode: checkoutMode,
-          reason: storefrontCheckout.reason || 'unknown',
-          status: storefrontCheckout.status || null,
-          requestId: storefrontRequestId,
-        });
-      } catch {}
-    }
-
     if (!isPrivate) {
-      if (storefrontCheckout?.ok) {
-        checkoutUrl = typeof storefrontCheckout.checkoutUrl === 'string'
-          ? storefrontCheckout.checkoutUrl.trim()
-          : checkoutUrl;
-        cartId = typeof storefrontCheckout.cartId === 'string' ? storefrontCheckout.cartId : cartId;
-        cartUrl = typeof storefrontCheckout.cartUrl === 'string' ? storefrontCheckout.cartUrl : cartUrl;
-        cartPlain = typeof storefrontCheckout.cartPlain === 'string' ? storefrontCheckout.cartPlain : cartPlain;
-        checkoutPlain = typeof storefrontCheckout.checkoutPlain === 'string'
-          ? storefrontCheckout.checkoutPlain
-          : checkoutPlain;
-        cartToken = typeof storefrontCheckout.cartToken === 'string' ? storefrontCheckout.cartToken : cartToken;
-      } else if (permalinkFallback) {
-        checkoutUrl = permalinkFallback;
-        cartUrl = permalinkFallback;
-        try {
-          console.info('storefront_checkout_fallback_permalink', {
-            mode: checkoutMode,
-            requestId: storefrontRequestId,
-            reason: storefrontCheckout?.reason || 'fallback',
-            discountApplied: Boolean(discountCode),
-          });
-        } catch {}
+      if (!permalinkUrl) {
+        return res.status(500).json({
+          ok: false,
+          reason: 'permalink_build_failed',
+          message: 'No se pudo construir el permalink del carrito público.',
+          ...meta,
+          visibility,
+        });
       }
+      checkoutUrl = permalinkUrl;
+      cartUrl = permalinkUrl;
     } else {
       if (!variantGidForCheckout) {
         return res.status(500).json({
@@ -4025,6 +3930,34 @@ export async function publishProduct(req, res) {
           visibility,
         });
       }
+      const buyerIp = getClientIp(req);
+      const storefrontCheckout = await createStorefrontCart({
+        variantGid: variantGidForCheckout,
+        quantity: normalizedQuantity,
+        buyerIp,
+      });
+      const storefrontRequestId = storefrontCheckout?.requestId || null;
+      const storefrontUserErrors = Array.isArray(storefrontCheckout?.userErrors)
+        ? storefrontCheckout.userErrors
+        : [];
+
+      if (storefrontCheckout?.reason === 'user_errors' && storefrontUserErrors.length) {
+        try {
+          console.warn('storefront_checkout_user_errors', {
+            requestId: storefrontRequestId,
+            userErrors: storefrontUserErrors,
+          });
+        } catch {}
+      } else if (storefrontCheckout && storefrontCheckout.ok === false) {
+        try {
+          console.error('storefront_checkout_failed', {
+            reason: storefrontCheckout.reason || 'unknown',
+            status: storefrontCheckout.status || null,
+            requestId: storefrontRequestId,
+          });
+        } catch {}
+      }
+
       if (!storefrontCheckout?.ok) {
         if (storefrontCheckout?.reason === 'user_errors' && storefrontUserErrors.length) {
           return res.status(400).json({
@@ -4312,7 +4245,16 @@ export async function publishProduct(req, res) {
         published: publishedFlag,
         availableForSale: variantAvailableForSale == null
           ? null
-          : variantAvailableForSale === true,
+        : variantAvailableForSale === true,
+      });
+    } catch {}
+
+    try {
+      console.info('publish_product_checkout_ready', {
+        productId: meta?.productAdminId || meta?.productId || productId || null,
+        variantId: meta?.variantAdminId || meta?.variantId || variantId || null,
+        visibility,
+        checkoutUrl: typeof checkoutUrl === 'string' ? checkoutUrl : null,
       });
     } catch {}
 


### PR DESCRIPTION
## Summary
- lib/handlers/publishProduct.js — remover Storefront en flujos públicos/carrito y restaurar permalink clásico
- lib/handlers/cartLink.js — remover Storefront en público/carrito y devolver permalink clásico
- tests/cart-link.test.js — actualizar QA automatizado para el permalink público

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de88eaa7e48327aea56f90bce8d176