### PR TITLE
Add Shopify variant ID parser util and update permalinks

### DIFF
--- a/lib/handlers/cartAdd.js
+++ b/lib/handlers/cartAdd.js
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { parseJsonBody } from '../_lib/http.js';
-import { buildOnlineStorePermalinkFromGid, idVariantGidToNumeric } from '../shopify/permalinks.js';
+import { buildOnlineStorePermalinkFromGid } from '../shopify/permalinks.js';
+import { idVariantGidToNumeric } from '../utils/shopifyIds.js';
 import { getPublicStorefrontBase } from '../publicStorefront.js';
 
 const BodySchema = z
@@ -86,7 +87,23 @@ export default async function cartAdd(req, res) {
   const cartPlain = normalizedBase ? `${normalizedBase}/cart` : undefined;
   const checkoutPlain = normalizedBase ? `${normalizedBase}/checkout` : undefined;
 
-  const variantNumericId = idVariantGidToNumeric(variantGid);
+  let variantNumericId;
+  try {
+    variantNumericId = idVariantGidToNumeric(variantGid);
+  } catch (err) {
+    return respond(res, 400, {
+      ok: false,
+      error: 'invalid_variant_id',
+      code: 'INVALID_VARIANT_ID',
+      message: err?.message || 'Invalid variant ID format',
+    });
+  }
+
+  console.info('permalink_build', {
+    variantGid,
+    numericId: variantNumericId,
+    qty: normalizedQuantity,
+  });
   console.info('[cart_add_permalink]', {
     cartId,
     variantId: variantNumericId || null,

--- a/lib/handlers/cartLink.js
+++ b/lib/handlers/cartLink.js
@@ -99,9 +99,16 @@ function buildFallbackResponse({ variantNumericId, quantity, requestId, reason, 
   };
 }
 
-function buildPermalinkSuccess({ variantNumericId, quantity, requestId }) {
+function buildPermalinkSuccess({ variantNumericId, variantGid, quantity, requestId }) {
   const permalink = buildCartPermalink(variantNumericId, quantity);
   if (!permalink) return null;
+  try {
+    console.info('permalink_build', {
+      variantGid: variantGid || null,
+      numericId: variantNumericId || null,
+      qty: quantity,
+    });
+  } catch {}
   return {
     url: permalink,
     webUrl: permalink,
@@ -211,6 +218,7 @@ export default async function cartLink(req, res) {
 
     const successPayload = buildPermalinkSuccess({
       variantNumericId,
+      variantGid: resolvedVariantGid,
       quantity: qty,
       requestId: poll.requestId || null,
     });

--- a/lib/handlers/createCheckout.js
+++ b/lib/handlers/createCheckout.js
@@ -2,15 +2,7 @@ import { z } from 'zod';
 import { getPublicStorefrontBase } from '../publicStorefront.js';
 import { parseJsonBody } from '../_lib/http.js';
 import { buildOnlineStorePermalink } from '../shopify/permalinks.js';
-
-function normalizeVariantId(value) {
-  if (value == null) return '';
-  const raw = String(value).trim();
-  if (!raw) return '';
-  if (/^\d+$/.test(raw)) return raw;
-  const match = raw.match(/(\d+)(?:[^\d]*)$/);
-  return match ? match[1] : '';
-}
+import { idVariantGidToNumeric } from '../utils/shopifyIds.js';
 
 const BodySchema = z
   .object({
@@ -62,8 +54,20 @@ export default async function createCheckout(req, res) {
       return res.status(400).json({ ok: false, error: 'invalid_body', issues: parsed.error.flatten().fieldErrors });
     }
     const { variantId, variantGid, quantity, discount } = parsed.data;
-    const normalizedVariantId = normalizeVariantId(variantId ?? variantGid);
-    if (!normalizedVariantId) return res.status(400).json({ ok: false, error: 'missing_variant' });
+    let normalizedVariantId;
+    try {
+      normalizedVariantId = idVariantGidToNumeric(variantGid ?? variantId ?? '');
+    } catch (err) {
+      return res.status(400).json({
+        ok: false,
+        error: 'invalid_variant_id',
+        code: 'INVALID_VARIANT_ID',
+        message: err?.message || 'Invalid variant ID format',
+      });
+    }
+    if (!normalizedVariantId) {
+      return res.status(400).json({ ok: false, error: 'missing_variant' });
+    }
     const qtyRaw = Number(quantity);
     const qty = Number.isFinite(qtyRaw) && qtyRaw > 0 ? Math.min(Math.floor(qtyRaw), 99) : 1;
     const base = getPublicStorefrontBase();
@@ -78,6 +82,14 @@ export default async function createCheckout(req, res) {
     if (!permalink) {
       return res.status(500).json({ ok: false, error: 'permalink_build_failed' });
     }
+
+    try {
+      console.info('permalink_build', {
+        variantGid: typeof variantGid === 'string' ? variantGid : variantId ?? null,
+        numericId: normalizedVariantId,
+        qty,
+      });
+    } catch {}
 
     return res.status(200).json({ ok: true, url: permalink });
   } catch (e) {

--- a/lib/handlers/privateCheckout.js
+++ b/lib/handlers/privateCheckout.js
@@ -387,6 +387,12 @@ export default async function privateCheckout(req, res) {
       });
     }
 
+    safeInfo('permalink_build', {
+      variantGid: primaryLine.variantGid || null,
+      numericId: primaryLine.variantNumericId || null,
+      qty: primaryLine.quantity,
+    });
+
     const base = getPublicStorefrontBase();
     const normalizedBase = base ? base.replace(/\/+$/, '') : '';
     const cartPlain = normalizedBase ? `${normalizedBase}/cart` : undefined;

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -10,6 +10,7 @@ import { PassThrough, Readable, Transform } from 'node:stream';
 import { pipeline as streamPipeline } from 'node:stream/promises';
 import { shopifyAdmin, shopifyAdminGraphQL } from '../shopify.js';
 import { buildProductUrl, getPublicStorefrontBase } from '../publicStorefront.js';
+import { idVariantGidToNumeric } from '../utils/shopifyIds.js';
 
 import {
   ensureProductGid,
@@ -3869,7 +3870,41 @@ export async function publishProduct(req, res) {
     const normalizedQuantity = clampCheckoutQuantity(quantityInput);
     const discountCode = typeof body?.discountCode === 'string' ? body.discountCode.trim() : '';
     const variantReference = meta?.variantAdminId || meta?.variantId || variantId;
-    const variantNumericId = idVariantGidToNumeric(variantReference) || extractLegacyId(variantReference, 'ProductVariant');
+    let variantNumericId;
+    try {
+      variantNumericId = idVariantGidToNumeric(variantReference);
+    } catch (err) {
+      const publishRequestIds = Array.isArray(publishResult?.requestIds)
+        ? publishResult.requestIds.filter(Boolean)
+        : [];
+      const latestPublishRequestId = publishRequestIds.length
+        ? publishRequestIds[publishRequestIds.length - 1]
+        : null;
+      const requestIdForError = latestPublishRequestId || statusRequestId || null;
+      const message = err?.message || 'Invalid variant ID format';
+      try {
+        console.error('permalink_build_failed', {
+          variantGid: variantReference ?? null,
+          message,
+        });
+      } catch {}
+      return res.status(400).json({
+        ok: false,
+        reason: 'invalid_variant_id',
+        code: 'INVALID_VARIANT_ID',
+        message,
+        requestId: requestIdForError || undefined,
+        ...meta,
+        visibility,
+      });
+    }
+    try {
+      console.info('permalink_build', {
+        variantGid: variantReference ?? null,
+        numericId: variantNumericId,
+        qty: normalizedQuantity,
+      });
+    } catch {}
     const permalinkUrl = buildOnlineStoreCartPermalink({
       variantNumericId,
       quantity: normalizedQuantity,

--- a/lib/shopify/cartHelpers.js
+++ b/lib/shopify/cartHelpers.js
@@ -1,14 +1,15 @@
 import { getPublicStorefrontBase } from '../publicStorefront.js';
 import { shopifyStorefrontGraphQL } from '../shopify.js';
-import { buildOnlineStorePermalink, idVariantGidToNumeric } from './permalinks.js';
+import { idVariantGidToNumeric } from '../utils/shopifyIds.js';
+import { buildOnlineStorePermalink } from './permalinks.js';
 
 export function normalizeVariantNumericId(value) {
   if (value == null) return '';
-  const raw = String(value).trim();
-  if (!raw) return '';
-  if (/^\d+$/.test(raw)) return raw;
-  const match = raw.match(/(\d+)(?:[^\d]*)$/);
-  return match ? match[1] : '';
+  try {
+    return idVariantGidToNumeric(value);
+  } catch {
+    return '';
+  }
 }
 
 export function ensureVariantGid(preferred, fallback, numericId) {
@@ -35,7 +36,10 @@ export function resolveVariantIds({ variantId, variantGid }) {
 }
 
 export function buildCartPermalink(variantNumericId, quantity, { discountCode } = {}) {
-  const numericId = variantNumericId || idVariantGidToNumeric(variantNumericId);
+  let numericId = '';
+  try {
+    numericId = idVariantGidToNumeric(variantNumericId);
+  } catch {}
   return buildOnlineStorePermalink({ variantNumericId: numericId, quantity, discountCode });
 }
 

--- a/lib/shopify/permalinks.js
+++ b/lib/shopify/permalinks.js
@@ -1,4 +1,5 @@
 import { getPublicStorefrontBase } from '../publicStorefront.js';
+import { idVariantGidToNumeric } from '../utils/shopifyIds.js';
 
 function clampQuantity(value) {
   const raw = Number(value);
@@ -6,22 +7,19 @@ function clampQuantity(value) {
   return Math.max(1, Math.min(99, Math.floor(raw)));
 }
 
-export function idVariantGidToNumeric(value) {
-  if (value == null) return '';
-  const raw = String(value).trim();
-  if (!raw) return '';
-  const segments = raw.split('/');
-  const last = segments[segments.length - 1];
-  if (last && /^\d+$/.test(last)) return last;
-  const match = raw.match(/(\d+)(?:[^\d]*)$/);
-  return match ? match[1] : '';
-}
-
 export function buildOnlineStorePermalink({ variantNumericId, quantity = 1, discountCode } = {}) {
-  const numericId = typeof variantNumericId === 'string' && variantNumericId.trim()
-    ? variantNumericId.trim()
-    : idVariantGidToNumeric(variantNumericId);
-  if (!numericId) return '';
+  let numericId;
+  try {
+    numericId = idVariantGidToNumeric(variantNumericId);
+  } catch (err) {
+    try {
+      console.warn('build_online_store_permalink_invalid_id', {
+        message: err?.message || String(err),
+        variantNumericId: variantNumericId ?? null,
+      });
+    } catch {}
+    return '';
+  }
 
   const base = getPublicStorefrontBase();
   if (!base) return '';
@@ -46,7 +44,18 @@ export function buildOnlineStorePermalink({ variantNumericId, quantity = 1, disc
 }
 
 export function buildOnlineStorePermalinkFromGid({ variantGid, quantity = 1, discountCode } = {}) {
-  const numericId = idVariantGidToNumeric(variantGid);
+  let numericId;
+  try {
+    numericId = idVariantGidToNumeric(variantGid);
+  } catch (err) {
+    try {
+      console.warn('build_online_store_permalink_invalid_gid', {
+        message: err?.message || String(err),
+        variantGid: variantGid ?? null,
+      });
+    } catch {}
+    return '';
+  }
   return buildOnlineStorePermalink({ variantNumericId: numericId, quantity, discountCode });
 }
 

--- a/lib/utils/shopifyIds.js
+++ b/lib/utils/shopifyIds.js
@@ -1,0 +1,67 @@
+import { Buffer } from 'node:buffer';
+
+const SHOPIFY_GID_PREFIX = 'gid://';
+const SHOPIFY_VARIANT_BASE64_PREFIX = 'Z2lkOi8v';
+const BASE64_CHARS_REGEX = /^[A-Za-z0-9+/=]+$/;
+
+function ensureString(value) {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || !Number.isInteger(value)) {
+      throw new Error('Invalid variant ID format');
+    }
+    return String(value);
+  }
+  if (typeof value === 'bigint') {
+    if (value < 0n) {
+      throw new Error('Invalid variant ID format');
+    }
+    return value.toString();
+  }
+  return String(value ?? '').trim();
+}
+
+function extractNumericSegmentFromGid(gid) {
+  const cleaned = gid.split('?')[0];
+  const segments = cleaned.split('/');
+  const last = segments[segments.length - 1] || '';
+  if (/^\d+$/.test(last)) {
+    return last;
+  }
+  throw new Error('Invalid variant ID format');
+}
+
+export function idVariantGidToNumeric(gidOrId) {
+  if (gidOrId == null) {
+    throw new Error('Invalid variant ID format');
+  }
+
+  const rawInput = ensureString(gidOrId).trim();
+  if (!rawInput) {
+    throw new Error('Invalid variant ID format');
+  }
+
+  if (/^\d+$/.test(rawInput)) {
+    return rawInput;
+  }
+
+  if (rawInput.startsWith(SHOPIFY_GID_PREFIX)) {
+    return extractNumericSegmentFromGid(rawInput);
+  }
+
+  if (BASE64_CHARS_REGEX.test(rawInput) && rawInput.startsWith(SHOPIFY_VARIANT_BASE64_PREFIX)) {
+    let decoded;
+    try {
+      decoded = Buffer.from(rawInput, 'base64').toString('utf8');
+    } catch (err) {
+      throw new Error('Invalid variant ID format');
+    }
+    return idVariantGidToNumeric(decoded);
+  }
+
+  throw new Error('Invalid variant ID format');
+}
+
+export default {
+  idVariantGidToNumeric,
+};

--- a/tests/shopify-ids.test.js
+++ b/tests/shopify-ids.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { idVariantGidToNumeric } from '../lib/utils/shopifyIds.js';
+
+const SAMPLE_GID = 'gid://shopify/ProductVariant/53473441907060';
+const SAMPLE_ID = '53473441907060';
+const SAMPLE_GID_WITH_QUERY = `${SAMPLE_GID}?foo=bar`;
+const SAMPLE_BASE64 = 'Z2lkOi8vc2hvcGlmeS9Qcm9kdWN0VmFyaWFudC81MzQ3MzQ0MTkwNzA2MA==';
+
+test('idVariantGidToNumeric extracts digits from Shopify GID', () => {
+  assert.equal(idVariantGidToNumeric(SAMPLE_GID), SAMPLE_ID);
+});
+
+test('idVariantGidToNumeric returns numeric string unchanged', () => {
+  assert.equal(idVariantGidToNumeric(SAMPLE_ID), SAMPLE_ID);
+});
+
+test('idVariantGidToNumeric tolerates query parameters', () => {
+  assert.equal(idVariantGidToNumeric(SAMPLE_GID_WITH_QUERY), SAMPLE_ID);
+});
+
+test('idVariantGidToNumeric decodes base64 GID payloads', () => {
+  assert.equal(idVariantGidToNumeric(SAMPLE_BASE64), SAMPLE_ID);
+});
+
+test('idVariantGidToNumeric throws on invalid values', () => {
+  assert.throws(() => idVariantGidToNumeric('not-a-valid-id'), /Invalid variant ID format/);
+});


### PR DESCRIPTION
## Summary
- add a reusable Shopify variant ID parser that decodes GIDs and base64 payloads
- switch all permalink builders to the new parser and log `permalink_build` events
- surface INVALID_VARIANT_ID errors when parsing fails and add coverage for the util

## Testing
- node --test tests/shopify-ids.test.js
- node --test tests/cart-link.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de97f99b5c83278c94f2642c46b26a