### PR TITLE
Stop private checkout markup and return to editor after checkout

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -1944,7 +1944,7 @@ export async function publishProduct(req, res) {
 
 
     const basePrice = isFiniteNumber(priceTransfer) ? Math.max(priceTransfer, 0) : 0;
-    const computedPrice = isPrivate ? basePrice * 1.25 : basePrice;
+    const computedPrice = basePrice;
     const priceValue = formatMoney(computedPrice) || '0.00';
 
     const variantUpdateInputBase = {


### PR DESCRIPTION
## Summary
- stop applying the extra markup when publishing private products so they keep the transfer price
- update the mockup flow to reuse finalizeCartSuccess and return to the editor after opening checkout tabs
- preserve last product details after private checkout so follow-up actions can still reuse them

## Testing
- npm test *(fails: imageBufferToPdf generates high fidelity PDF from PNG, imageBufferToPdf respects EXIF orientation without recompressing JPEG, evaluateImage blocks nazi symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68dec3419db88327aad4f2a98cf657ec