### PR TITLE
Fix preview handler path validation

### DIFF
--- a/lib/api/handlers/printsPreview.js
+++ b/lib/api/handlers/printsPreview.js
@@ -60,7 +60,7 @@ export default async function printsPreviewHandler(req, res) {
     res.status(400).json({ ok: false, reason: 'missing_path', message: 'Falta el parámetro "path".' });
     return;
   }
-  if (!isValidPdfPath(rawPath)) {
+  if (!isValidPreviewPath(rawPath)) {
     res.status(400).json({ ok: false, reason: 'invalid_path', message: 'Formato de path inválido.' });
     return;
   }


### PR DESCRIPTION
## Summary
- correct the prints preview handler to use the existing preview path validation logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dec521270083279475a203a24fe05d