### PR TITLE
Handle direct image previews in prints preview handler

### DIFF
--- a/lib/api/handlers/printsPreview.js
+++ b/lib/api/handlers/printsPreview.js
@@ -60,7 +60,7 @@ export default async function printsPreviewHandler(req, res) {
     res.status(400).json({ ok: false, reason: 'missing_path', message: 'Falta el parámetro "path".' });
     return;
   }
-  if (!isValidPdfPath(rawPath)) {
+  if (!isValidPreviewPath(rawPath)) {
     res.status(400).json({ ok: false, reason: 'invalid_path', message: 'Formato de path inválido.' });
     return;
   }
@@ -81,14 +81,32 @@ export default async function printsPreviewHandler(req, res) {
     return;
   }
 
-  const pdfBuffer = await toBuffer(data);
-  if (!pdfBuffer.length) {
-    res.status(500).json({ ok: false, reason: 'empty_pdf', message: 'El PDF descargado está vacío.' });
+  const fileBuffer = await toBuffer(data);
+  if (!fileBuffer.length) {
+    res.status(500).json({ ok: false, reason: 'empty_file', message: 'El archivo descargado está vacío.' });
     return;
   }
 
+  const lowerPath = rawPath.toLowerCase();
+  const isPdf = lowerPath.endsWith('.pdf');
+
   try {
-    const image = await sharp(pdfBuffer, { density: DEFAULT_PREVIEW_DENSITY })
+    if (!isPdf) {
+      const contentType = lowerPath.endsWith('.png')
+        ? 'image/png'
+        : lowerPath.endsWith('.webp')
+          ? 'image/webp'
+          : lowerPath.endsWith('.jpg') || lowerPath.endsWith('.jpeg')
+            ? 'image/jpeg'
+            : 'application/octet-stream';
+
+      res.setHeader('Content-Type', contentType);
+      res.setHeader('Cache-Control', 'public, max-age=300, immutable');
+      res.status(200).end(fileBuffer);
+      return;
+    }
+
+    const image = await sharp(fileBuffer, { density: DEFAULT_PREVIEW_DENSITY })
       .resize({ width: DEFAULT_PREVIEW_WIDTH, fit: 'inside', withoutEnlargement: true })
       .png({ compressionLevel: 8, adaptiveFiltering: true })
       .toBuffer();

--- a/lib/api/handlers/printsPreview.js
+++ b/lib/api/handlers/printsPreview.js
@@ -74,8 +74,76 @@ export default async function printsPreviewHandler(req, res) {
     return;
   }
 
+  const lowerPath = rawPath.toLowerCase();
+  const isPdf = lowerPath.endsWith('.pdf');
+
+  const storage = supabase.storage.from(OUTPUT_BUCKET);
   const storagePath = resolveStoragePath(rawPath);
-  const { data, error } = await supabase.storage.from(OUTPUT_BUCKET).download(storagePath);
+
+  if (!isPdf) {
+    const { data, error } = await storage.download(storagePath);
+    if (error || !data) {
+      res.status(404).json({ ok: false, reason: 'preview_not_found', message: 'No se encontró el archivo solicitado.' });
+      return;
+    }
+
+    const fileBuffer = await toBuffer(data);
+    if (!fileBuffer.length) {
+      res.status(500).json({ ok: false, reason: 'empty_file', message: 'El archivo descargado está vacío.' });
+      return;
+    }
+
+    const contentType = lowerPath.endsWith('.png')
+      ? 'image/png'
+      : lowerPath.endsWith('.webp')
+        ? 'image/webp'
+        : lowerPath.endsWith('.jpg') || lowerPath.endsWith('.jpeg')
+          ? 'image/jpeg'
+          : 'application/octet-stream';
+
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', 'public, max-age=300, immutable');
+    res.status(200).end(fileBuffer);
+    return;
+  }
+
+  const previewBasePath = (() => {
+    const withoutExt = storagePath.replace(/\.pdf$/i, '');
+    if (/^preview\//i.test(withoutExt)) return withoutExt;
+    if (/^pdf\//i.test(withoutExt)) return `preview/${withoutExt.slice(4)}`;
+    const parts = withoutExt.split('/');
+    if (parts.length <= 1) return `preview/${withoutExt}`;
+    return `preview/${parts.slice(1).join('/')}`;
+  })();
+
+  const previewCandidates = ['.jpg', '.jpeg', '.png', '.webp'].map((ext) => `${previewBasePath}${ext}`);
+
+  try {
+    for (const candidate of previewCandidates) {
+      const { data: previewData, error: previewError } = await storage.download(candidate);
+      if (!previewError && previewData) {
+        const previewBuffer = await toBuffer(previewData);
+        if (previewBuffer.length) {
+          const lower = candidate.toLowerCase();
+          const contentType = lower.endsWith('.png')
+            ? 'image/png'
+            : lower.endsWith('.webp')
+              ? 'image/webp'
+              : 'image/jpeg';
+          res.setHeader('Content-Type', contentType);
+          res.setHeader('Cache-Control', 'public, max-age=300, immutable');
+          res.status(200).end(previewBuffer);
+          return;
+        }
+      } else if (previewError && previewError.message && previewError.statusCode !== 404) {
+        console.info('[prints-preview] preview_unavailable', { path: candidate, message: previewError.message });
+      }
+    }
+  } catch (err) {
+    console.warn('[prints-preview] preview_fetch_failed', { path: previewBasePath, message: err?.message || err });
+  }
+
+  const { data, error } = await storage.download(storagePath);
   if (error || !data) {
     res.status(404).json({ ok: false, reason: 'pdf_not_found', message: 'No se encontró el PDF solicitado.' });
     return;
@@ -87,25 +155,7 @@ export default async function printsPreviewHandler(req, res) {
     return;
   }
 
-  const lowerPath = rawPath.toLowerCase();
-  const isPdf = lowerPath.endsWith('.pdf');
-
   try {
-    if (!isPdf) {
-      const contentType = lowerPath.endsWith('.png')
-        ? 'image/png'
-        : lowerPath.endsWith('.webp')
-          ? 'image/webp'
-          : lowerPath.endsWith('.jpg') || lowerPath.endsWith('.jpeg')
-            ? 'image/jpeg'
-            : 'application/octet-stream';
-
-      res.setHeader('Content-Type', contentType);
-      res.setHeader('Cache-Control', 'public, max-age=300, immutable');
-      res.status(200).end(fileBuffer);
-      return;
-    }
-
     const image = await sharp(fileBuffer, { density: DEFAULT_PREVIEW_DENSITY })
       .resize({ width: DEFAULT_PREVIEW_WIDTH, fit: 'inside', withoutEnlargement: true })
       .png({ compressionLevel: 8, adaptiveFiltering: true })


### PR DESCRIPTION
## Summary
- serve existing preview images without trying to re-render them with sharp
- keep PDF handling intact while setting proper cache and content headers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dec521270083279475a203a24fe05d