### PR TITLE
Stop converting PDFs when preview images are missing

### DIFF
--- a/lib/api/handlers/printsPreview.js
+++ b/lib/api/handlers/printsPreview.js
@@ -1,9 +1,6 @@
-﻿import sharp from 'sharp';
 import getSupabaseAdmin from '../../_lib/supabaseAdmin.js';
 
 const OUTPUT_BUCKET = 'outputs';
-const DEFAULT_PREVIEW_WIDTH = 600;
-const DEFAULT_PREVIEW_DENSITY = 180;
 
 function normalizePath(input) {
   if (typeof input !== 'string') return '';
@@ -143,29 +140,6 @@ export default async function printsPreviewHandler(req, res) {
     console.warn('[prints-preview] preview_fetch_failed', { path: previewBasePath, message: err?.message || err });
   }
 
-  const { data, error } = await storage.download(storagePath);
-  if (error || !data) {
-    res.status(404).json({ ok: false, reason: 'pdf_not_found', message: 'No se encontró el PDF solicitado.' });
-    return;
-  }
-
-  const fileBuffer = await toBuffer(data);
-  if (!fileBuffer.length) {
-    res.status(500).json({ ok: false, reason: 'empty_file', message: 'El archivo descargado está vacío.' });
-    return;
-  }
-
-  try {
-    const image = await sharp(fileBuffer, { density: DEFAULT_PREVIEW_DENSITY })
-      .resize({ width: DEFAULT_PREVIEW_WIDTH, fit: 'inside', withoutEnlargement: true })
-      .png({ compressionLevel: 8, adaptiveFiltering: true })
-      .toBuffer();
-
-    res.setHeader('Content-Type', 'image/png');
-    res.setHeader('Cache-Control', 'public, max-age=300, immutable');
-    res.status(200).end(image);
-  } catch (err) {
-    console.error('[prints-preview] generate_failed', err);
-    res.status(500).json({ ok: false, reason: 'preview_generation_failed', message: 'No se pudo generar el preview.' });
-  }
+  res.setHeader('Cache-Control', 'no-store');
+  res.status(404).json({ ok: false, reason: 'preview_unavailable', message: 'No hay una vista previa disponible.' });
 }

--- a/mgm-front/src/pages/Busqueda.jsx
+++ b/mgm-front/src/pages/Busqueda.jsx
@@ -13,6 +13,29 @@ import styles from './Busqueda.module.css';
 
 const PAGE_LIMIT = 25;
 
+function PreviewImage({ src, alt }) {
+  const [failed, setFailed] = useState(false);
+
+  if (!src || failed) {
+    return (
+      <span className={styles.previewPlaceholder} aria-label="PDF">
+        PDF
+      </span>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={styles.previewImage}
+      loading="lazy"
+      decoding="async"
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
 function formatBytes(size) {
   const value = Number(size);
   if (!Number.isFinite(value) || value <= 0) return '-';
@@ -299,16 +322,8 @@ export default function Busqueda() {
                 results.map((item) => {
                   const key = item.id || item.path || item.fileName;
                   const measurement = formatMeasurement(item.widthCm, item.heightCm);
-                  const previewContent = item.previewUrl ? (
-                    <img
-                      src={item.previewUrl}
-                      alt={item.fileName || 'preview'}
-                      className={styles.previewImage}
-                      loading="lazy"
-                      decoding="async"
-                    />
-                  ) : (
-                    <span className={styles.previewPlaceholder} aria-label="PDF">PDF</span>
+                  const previewContent = (
+                    <PreviewImage src={item.previewUrl} alt={item.fileName || 'preview'} />
                   );
                   return (
                     <tr key={key}>


### PR DESCRIPTION
## Summary
- update the prints preview API handler to return 404 when no preview image exists instead of trying to rasterize the PDF
- add a reusable preview image component on the search page that swaps to the PDF placeholder when the preview request fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ded25c0c888327b116690f8d5834cf