### PR TITLE
Refine moderation pipeline and align tests

### DIFF
--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -6,6 +6,14 @@ const SKIP_OCR = process.env.MODERATION_SKIP_OCR === '1';
 
 const clamp = (value, min = 0, max = 1) => Math.max(min, Math.min(max, value));
 
+const NAZI_BLOCK_THRESHOLD = 0.6;
+const PERSON_SCORE_THRESHOLD = 0.3;
+const REAL_PERSON_THRESHOLD = 0.6;
+const GENITALS_THRESHOLD = 0.6;
+const AREOLA_THRESHOLD = 0.65;
+const SEX_ACT_THRESHOLD = 0.55;
+const REVIEW_MARGIN = 0.1;
+
 function toBufferFromDataUrl(dataUrl) {
   const m = /^data:(.+?);base64,(.+)$/.exec(dataUrl || '');
   if (!m) return null;
@@ -243,18 +251,26 @@ function swastikaSVG({ size = 64, stroke = 10, invert = false, rotate = 0, flag 
 let TEMPLATES = null;
 async function getTemplates() {
   if (TEMPLATES) return TEMPLATES;
-  const svgs = [];
+  const templates = [];
   const rotations = [0, 45, 90, 135];
   const strokes = [8, 10, 12];
-  for (const r of rotations) for (const st of strokes) svgs.push(swastikaSVG({ rotate: r, stroke: st, invert: false, flag: false }));
-  // flags variants
-  for (const r of [0]) for (const st of [10]) svgs.push(swastikaSVG({ rotate: r, stroke: st, invert: false, flag: true }));
+  for (const r of rotations) {
+    for (const st of strokes) {
+      templates.push({ rotation: r, svg: swastikaSVG({ rotate: r, stroke: st, invert: false, flag: false }) });
+    }
+  }
+  // flags variants (retain rotation metadata for palette heuristics)
+  for (const r of [0]) {
+    for (const st of [10]) {
+      templates.push({ rotation: r, svg: swastikaSVG({ rotate: r, stroke: st, invert: false, flag: true }) });
+    }
+  }
   const hashes = [];
-  for (const svg of svgs) {
-    const buf = Buffer.from(svg);
+  for (const tpl of templates) {
+    const buf = Buffer.from(tpl.svg);
     const { data, info } = await sharp(buf).resize(64, 64).grayscale().raw().toBuffer({ resolveWithObject: true });
     const hash = pHashFromGray(data, info.width, info.height);
-    hashes.push(hash);
+    hashes.push({ hash, rotation: tpl.rotation });
   }
   TEMPLATES = hashes;
   return TEMPLATES;
@@ -266,37 +282,53 @@ async function detectNazi(buffer) {
   const hash = pHashFromGray(data, info.width, info.height);
   const tmpls = await getTemplates();
   let minDist = Infinity;
-  for (const th of tmpls) {
-    const d = hamming(hash, th);
-    if (d < minDist) minDist = d;
-    if (d <= 12) return { nazi: true, reason: 'phash', score: d };
+  let bestRotation = 0;
+  for (const tpl of tmpls) {
+    const d = hamming(hash, tpl.hash);
+    if (d < minDist) {
+      minDist = d;
+      bestRotation = tpl.rotation;
+    }
   }
-  const { data: d2, info: i2 } = await sharp(buffer).removeAlpha().resize({ width: 128 }).raw().toBuffer({ resolveWithObject: true });
-  const w = i2.width, h = i2.height, total = w * h;
-  let redDom = 0, whiteInCircle = 0, blackStroke = 0, inCircleCount = 0, inRingCount = 0;
-  const redMask = new Uint8Array(total);
-  const whiteMask = new Uint8Array(total);
-  const blackMask = new Uint8Array(total);
-  const cx = Math.floor(w / 2), cy = Math.floor(h / 2);
+
+  const normalized = clamp(1 - Math.max(0, minDist - 6) / 26);
+  const rotationFactor = bestRotation % 90 === 45 ? 1 : 0.45;
+  const shapeSignal = clamp(normalized * rotationFactor);
+
+  const { data: d2, info: i2 } = await sharp(buffer)
+    .removeAlpha()
+    .resize({ width: 128 })
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  const w = i2.width;
+  const h = i2.height;
+  const total = w * h;
+  let redDom = 0;
+  let whiteInCircle = 0;
+  let blackStroke = 0;
+  let inCircleCount = 0;
+  let inRingCount = 0;
+  const cx = Math.floor(w / 2);
+  const cy = Math.floor(h / 2);
   const r = Math.floor(Math.min(w, h) * 0.3);
   for (let p = 0, idx = 0; p < total; p++, idx += i2.channels) {
-    const R = d2[idx], G = d2[idx + 1], B = d2[idx + 2];
+    const R = d2[idx];
+    const G = d2[idx + 1];
+    const B = d2[idx + 2];
     const isRed = R > 200 && G < 90 && B < 90;
     const isWhite = R > 220 && G > 220 && B > 220;
     const isBlack = R < 55 && G < 55 && B < 55;
     if (isRed) {
       redDom++;
-      redMask[p] = 1;
     }
     if (isWhite) {
       whiteInCircle++;
-      whiteMask[p] = 1;
     }
     if (isBlack) {
       blackStroke++;
-      blackMask[p] = 1;
     }
-    const x = p % w, y = Math.floor(p / w);
+    const x = p % w;
+    const y = Math.floor(p / w);
     const dist = Math.hypot(x - cx, y - cy);
     if (dist <= r) inCircleCount++;
     if (dist > r * 0.85 && dist < r * 1.1) inRingCount++;
@@ -304,25 +336,22 @@ async function detectNazi(buffer) {
   const redRatio = redDom / total;
   const whiteCircleRatio = inCircleCount ? whiteInCircle / inCircleCount : 0;
   const blackStrokeRatio = inRingCount ? blackStroke / inRingCount : 0;
-  const COLOR_MATCH_THRESHOLDS = {
-    red: 0.5,
-    white: 0.75,
-    black: 0.18,
-    minDist: 24,
+
+  const redScore = clamp((redRatio - 0.45) / 0.25);
+  const whiteScore = clamp((whiteCircleRatio - 0.65) / 0.25);
+  const blackScore = clamp((blackStrokeRatio - 0.15) / 0.25);
+  const paletteSignal = clamp(redScore * 0.4 + whiteScore * 0.35 + blackScore * 0.25);
+
+  const likelyManji = rotationFactor < 0.7 && paletteSignal < 0.45;
+
+  return {
+    shapeSignal,
+    paletteSignal,
+    minDist,
+    rotation: bestRotation,
+    palette: { redRatio, whiteCircleRatio, blackStrokeRatio },
+    likelyManji,
   };
-  if (
-    minDist <= COLOR_MATCH_THRESHOLDS.minDist &&
-    redRatio >= COLOR_MATCH_THRESHOLDS.red &&
-    whiteCircleRatio >= COLOR_MATCH_THRESHOLDS.white &&
-    blackStrokeRatio >= COLOR_MATCH_THRESHOLDS.black
-  ) {
-    return {
-      nazi: true,
-      reason: 'flag_heuristic',
-      score: { redRatio, whiteCircleRatio, blackStrokeRatio, minDist },
-    };
-  }
-  return { nazi: false, reason: 'none', score: minDist };
 }
 
 // Ensure the moderation heuristics evaluate at least a medium sized canvas.
@@ -450,18 +479,17 @@ export async function evaluateImage(buffer, filename, designName = '', options =
   }
 
   const blockReasons = new Set();
-  let blockConfidence = 0;
-
-  const markBlocked = (reason, confidence = 0.6) => {
-    if (!reason) return;
-    blockReasons.add(reason);
-    blockConfidence = Math.max(blockConfidence, clamp(confidence));
-  };
+  const reviewReasons = new Set();
+  let decisionConfidence = 0.5;
 
   const metaGate = hateTextCheck({ filename, designName, textHints: '' });
+  const textSignals = [];
   if (metaGate.blocked) {
-    markBlocked('extremism_nazi_text', 0.85);
+    textSignals.push({ source: 'metadata', value: 0.75, reason: 'extremism_nazi_text', term: metaGate.term });
   }
+
+  const nazi = await detectNazi(workingBuffer);
+  debug.nazi = nazi;
 
   const illustration = await detectIllustration(workingBuffer);
   debug.illustration = illustration;
@@ -469,86 +497,148 @@ export async function evaluateImage(buffer, filename, designName = '', options =
   const skin = await detectSkin(workingBuffer);
   debug.skin = skin;
 
-  const nudityConfidence = computeNudityConfidence(skin);
-  debug.scores.realNudity = nudityConfidence;
-
-  const skinPercent = skin?.skinPercent ?? 0;
-  const centerSkinPercent = skin?.centerSkinPercent ?? 0;
-  const largestBlob = skin?.largestBlob ?? 0;
-  const largestBlobBoxCoverage = skin?.largestBlobBoxCoverage ?? 0;
-  const largestBlobCenterRatio = skin?.largestBlobCenterRatio ?? 0;
-  const toneVariance = skin?.toneVariance ?? 0;
-  const paletteRatio = illustration?.paletteRatio ?? 0;
-  const edgeRatio = illustration?.edgeRatio ?? 0;
-  const cartoonConfidence = illustration?.cartoonConfidence ?? 0;
-
-  debug.scores.skinPercent = skinPercent;
-  debug.scores.centerSkinPercent = centerSkinPercent;
-  debug.scores.largestBlob = largestBlob;
-  debug.scores.paletteRatio = paletteRatio;
-  debug.scores.edgeRatio = edgeRatio;
-  debug.scores.cartoonConfidence = cartoonConfidence;
-
-  const meetsCoverage = (
-    skinPercent >= 0.35 &&
-    centerSkinPercent >= 0.28 &&
-    largestBlob >= 0.24
-  );
-
-  const strongCenter = centerSkinPercent >= 0.55;
-  const strongBlob = largestBlob >= 0.42 || largestBlobBoxCoverage >= 0.38;
-  const highSkinCoverage = skinPercent >= 0.5;
-  const notCartoon =
-    cartoonConfidence < 0.65 ||
-    paletteRatio >= 0.015 ||
-    edgeRatio <= 0.03 ||
-    toneVariance <= 0.18;
-
-  debug.scores.notCartoon = notCartoon ? 1 : 0;
-
-  const shouldBlockStrong = strongCenter && strongBlob && highSkinCoverage && notCartoon;
-  const shouldBlockByConfidence =
-    !shouldBlockStrong &&
-    nudityConfidence >= 0.72 &&
-    meetsCoverage &&
-    notCartoon &&
-    centerSkinPercent >= 0.4 &&
-    largestBlob >= 0.35;
-
-  if (shouldBlockStrong || shouldBlockByConfidence) {
-    const baseConfidence = shouldBlockStrong ? 0.78 : 0.7;
-    const confidence = clamp(baseConfidence + (nudityConfidence - 0.7) * 0.5);
-    markBlocked('real_nudity', confidence);
+  let textHints = '';
+  if (!SKIP_OCR) {
+    textHints = await extractTextHints(workingBuffer);
   }
-
-  const nazi = await detectNazi(workingBuffer);
-  debug.nazi = nazi;
-  if (nazi?.nazi) {
-    if (nazi.reason === 'phash') {
-      const score = typeof nazi.score === 'number' ? nazi.score : 0;
-      const conf = clamp(0.95 - score * 0.03, 0.6, 0.95);
-      markBlocked('extremism_nazi', conf);
-    } else {
-      markBlocked('extremism_nazi', 0.85);
+  debug.textHints = textHints.length;
+  if (textHints) {
+    const ocrGate = hateTextCheck({ filename, designName, textHints });
+    if (ocrGate.blocked) {
+      textSignals.push({ source: 'ocr', value: 0.8, reason: 'extremism_nazi_text', term: ocrGate.term });
     }
   }
 
-  if (!blockReasons.size && !metaGate.blocked) {
-    const textHints = await extractTextHints(workingBuffer);
-    debug.textHints = textHints.length;
-    if (textHints) {
-      const ocrGate = hateTextCheck({ filename, designName, textHints });
-      if (ocrGate.blocked) {
-        markBlocked('extremism_nazi_text', 0.82);
+  const textSignal = textSignals.reduce((max, s) => Math.max(max, s.value), 0);
+  debug.scores.nazi_text_signal = textSignal;
+
+  const shapeSignal = nazi?.shapeSignal ?? 0;
+  const paletteSignal = nazi?.paletteSignal ?? 0;
+  debug.scores.nazi_shape = shapeSignal;
+  debug.scores.nazi_palette = paletteSignal;
+
+  const positiveSignals = [];
+  if (shapeSignal >= NAZI_BLOCK_THRESHOLD) positiveSignals.push(shapeSignal);
+  if (paletteSignal >= NAZI_BLOCK_THRESHOLD) positiveSignals.push(paletteSignal);
+  if (textSignal >= NAZI_BLOCK_THRESHOLD) positiveSignals.push(textSignal);
+
+  let naziScore = 0;
+  if (positiveSignals.length >= 2 && !(nazi?.likelyManji && paletteSignal < NAZI_BLOCK_THRESHOLD)) {
+    positiveSignals.sort((a, b) => b - a);
+    naziScore = (positiveSignals[0] + positiveSignals[1]) / 2;
+  }
+  debug.scores.nazi_score = naziScore;
+
+  if (naziScore >= NAZI_BLOCK_THRESHOLD) {
+    blockReasons.add('extremism_nazi');
+    if (textSignal >= NAZI_BLOCK_THRESHOLD) {
+      blockReasons.add('extremism_nazi_text');
+    }
+    decisionConfidence = Math.max(decisionConfidence, clamp(0.72 + naziScore * 0.25));
+  } else if (textSignal >= NAZI_BLOCK_THRESHOLD) {
+    reviewReasons.add('extremism_nazi_text');
+  }
+
+  const cartoonConfidence = illustration?.cartoonConfidence ?? 0;
+  const realProbability = clamp(1 - cartoonConfidence * 0.7 + 0.1);
+  const skinPercent = skin?.skinPercent ?? 0;
+  const centerSkinPercent = skin?.centerSkinPercent ?? 0;
+  const largestBlob = skin?.largestBlob ?? 0;
+  const largestBlobCenterRatio = skin?.largestBlobCenterRatio ?? 0;
+  const largestBlobBoxCoverage = skin?.largestBlobBoxCoverage ?? 0;
+
+  const personScore = clamp(
+    Math.max(
+      largestBlob * 0.6 + centerSkinPercent * 0.4,
+      largestBlobCenterRatio,
+      skinPercent * 0.5
+    )
+  );
+
+  debug.scores.person_score = personScore;
+  debug.scores.is_real_prob = realProbability;
+  debug.scores.skinPercent = skinPercent;
+  debug.scores.centerSkinPercent = centerSkinPercent;
+  debug.scores.largestBlob = largestBlob;
+  debug.scores.largestBlobCenterRatio = largestBlobCenterRatio;
+  debug.scores.cartoonConfidence = cartoonConfidence;
+
+  let allowByPersonGate = false;
+  if (personScore < PERSON_SCORE_THRESHOLD || realProbability < REAL_PERSON_THRESHOLD) {
+    allowByPersonGate = true;
+  }
+
+  const nudityConfidence = computeNudityConfidence(skin);
+  const visibleAreaRatio = clamp(largestBlobBoxCoverage || largestBlob || 0);
+  const isFemaleProb = clamp(personScore * 0.9);
+
+  const genitalsScore = clamp((nudityConfidence - 0.5) / 0.3);
+  const areolaScore = clamp((centerSkinPercent - 0.55) / 0.25);
+  const sexActScore = clamp((nudityConfidence - 0.6) / 0.25);
+
+  debug.scores.realNudity = nudityConfidence;
+  debug.scores.visible_area_ratio = visibleAreaRatio;
+  debug.scores.genitals_score = genitalsScore;
+  debug.scores.areola_score = areolaScore;
+  debug.scores.sex_act_score = sexActScore;
+
+  if (!allowByPersonGate && !blockReasons.has('extremism_nazi')) {
+    if (genitalsScore >= GENITALS_THRESHOLD && visibleAreaRatio >= 0.02) {
+      blockReasons.add('real_nudity');
+      decisionConfidence = Math.max(decisionConfidence, clamp(0.7 + (genitalsScore - GENITALS_THRESHOLD) * 0.25));
+    } else if (areolaScore >= AREOLA_THRESHOLD && isFemaleProb >= 0.5) {
+      blockReasons.add('real_nudity');
+      decisionConfidence = Math.max(decisionConfidence, clamp(0.68 + (areolaScore - AREOLA_THRESHOLD) * 0.25));
+    } else if (sexActScore >= SEX_ACT_THRESHOLD) {
+      blockReasons.add('real_nudity');
+      decisionConfidence = Math.max(decisionConfidence, clamp(0.7 + (sexActScore - SEX_ACT_THRESHOLD) * 0.3));
+    } else {
+      if (
+        genitalsScore >= GENITALS_THRESHOLD - REVIEW_MARGIN &&
+        genitalsScore < GENITALS_THRESHOLD &&
+        visibleAreaRatio >= 0.02
+      ) {
+        reviewReasons.add('real_nudity_review');
+      }
+      if (
+        areolaScore >= AREOLA_THRESHOLD - REVIEW_MARGIN &&
+        areolaScore < AREOLA_THRESHOLD &&
+        isFemaleProb >= 0.5
+      ) {
+        reviewReasons.add('real_nudity_review');
+      }
+      if (
+        sexActScore >= SEX_ACT_THRESHOLD - REVIEW_MARGIN &&
+        sexActScore < SEX_ACT_THRESHOLD
+      ) {
+        reviewReasons.add('real_nudity_review');
       }
     }
   }
 
-  if (blockReasons.size) {
+  if (blockReasons.has('extremism_nazi')) {
     return {
       label: 'BLOCK',
       reasons: Array.from(blockReasons),
-      confidence: blockConfidence || 0.65,
+      confidence: decisionConfidence,
+      details: debug,
+    };
+  }
+
+  if (blockReasons.has('real_nudity')) {
+    return {
+      label: 'BLOCK',
+      reasons: Array.from(blockReasons),
+      confidence: decisionConfidence,
+      details: debug,
+    };
+  }
+
+  if (reviewReasons.size) {
+    return {
+      label: 'REVIEW',
+      reasons: Array.from(reviewReasons),
+      confidence: clamp(0.45 + (Math.max(genitalsScore, areolaScore, sexActScore) || 0) * 0.1),
       details: debug,
     };
   }
@@ -556,7 +646,7 @@ export async function evaluateImage(buffer, filename, designName = '', options =
   return {
     label: 'ALLOW',
     reasons: ['no_violation_detected'],
-    confidence: clamp(0.78 + Math.max(0, 0.5 - cartoonConfidence) * 0.08),
+    confidence: clamp(0.78 + Math.max(0, realProbability - 0.5) * 0.1),
     details: debug,
   };
 }

--- a/tests/moderation.test.js
+++ b/tests/moderation.test.js
@@ -142,7 +142,7 @@ async function createStylizedCharacterBuffer() {
   return sharp(data, { raw: { width, height, channels } }).png().toBuffer();
 }
 
-function swastikaSVG({ size = 256, stroke = 26, flag = true } = {}) {
+function swastikaSVG({ size = 256, stroke = 26, flag = true, rotate = 45 } = {}) {
   const s = size;
   const m = s / 2;
   const bg = flag ? '#c00' : '#fff';
@@ -152,7 +152,7 @@ function swastikaSVG({ size = 256, stroke = 26, flag = true } = {}) {
         s * 0.04,
       )}"/>`
     : '';
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<svg xmlns="http://www.w3.org/2000/svg" width="${s}" height="${s}" viewBox="0 0 ${s} ${s}">\n  <rect width="100%" height="100%" fill="${bg}"/>\n  ${circle}\n  <g transform="rotate(0, ${m}, ${m})" fill="#000">\n    <rect x="${m - stroke / 2}" y="${m - s * 0.36}" width="${stroke}" height="${s * 0.72}"/>\n    <rect x="${m - s * 0.36}" y="${m - stroke / 2}" width="${s * 0.72}" height="${stroke}"/>\n    <rect x="${m + stroke * 0.45}" y="${m - s * 0.36}" width="${s * 0.2}" height="${stroke}"/>\n    <rect x="${m - stroke / 2}" y="${m + stroke * 0.45}" width="${stroke}" height="${s * 0.2}"/>\n    <rect x="${m - s * 0.36}" y="${m - stroke * 0.45 - s * 0.2}" width="${s * 0.2}" height="${stroke}"/>\n    <rect x="${m - stroke * 0.45 - s * 0.2}" y="${m - stroke / 2}" width="${stroke}" height="${s * 0.2}"/>\n  </g>\n</svg>`;
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<svg xmlns="http://www.w3.org/2000/svg" width="${s}" height="${s}" viewBox="0 0 ${s} ${s}">\n  <rect width="100%" height="100%" fill="${bg}"/>\n  ${circle}\n  <g transform="rotate(${rotate}, ${m}, ${m})" fill="#000">\n    <rect x="${m - stroke / 2}" y="${m - s * 0.36}" width="${stroke}" height="${s * 0.72}"/>\n    <rect x="${m - s * 0.36}" y="${m - stroke / 2}" width="${s * 0.72}" height="${stroke}"/>\n    <rect x="${m + stroke * 0.45}" y="${m - s * 0.36}" width="${s * 0.2}" height="${stroke}"/>\n    <rect x="${m - stroke / 2}" y="${m + stroke * 0.45}" width="${stroke}" height="${s * 0.2}"/>\n    <rect x="${m - s * 0.36}" y="${m - stroke * 0.45 - s * 0.2}" width="${s * 0.2}" height="${stroke}"/>\n    <rect x="${m - stroke * 0.45 - s * 0.2}" y="${m - stroke / 2}" width="${stroke}" height="${s * 0.2}"/>\n  </g>\n</svg>`;
 }
 
 async function createSwastikaBuffer() {
@@ -198,10 +198,10 @@ test('evaluateImage blocks nazi symbols', async () => {
   assert(result.reasons.includes('extremism_nazi'));
 });
 
-test('evaluateImage blocks nazi text metadata', async () => {
+test('evaluateImage flags nazi text metadata for review', async () => {
   const buf = await createNeutralBuffer();
   const result = await evaluateImage(buf, 'safe.png', 'Heil Hitler banner');
-  assert.equal(result.label, 'BLOCK');
+  assert.equal(result.label, 'REVIEW');
   assert(result.reasons.includes('extremism_nazi_text'));
 });
 


### PR DESCRIPTION
## Summary
- tighten the moderation flow so nazi symbols require two signals, real-person gating precedes nudity checks, and review outcomes are surfaced
- expose the key nudity and nazi scores in the debug payload while adjusting thresholds to the relaxed policy
- refresh moderation and image-to-pdf tests to reflect the updated decision rules and existing PDF output metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ded3d2825c8327b9b9da82e6aa7c97