### PR TITLE
Improve preview handler fallback for missing images

### DIFF
--- a/lib/api/handlers/printsPreview.js
+++ b/lib/api/handlers/printsPreview.js
@@ -78,29 +78,71 @@ export default async function printsPreviewHandler(req, res) {
   const storagePath = resolveStoragePath(rawPath);
 
   if (!isPdf) {
-    const { data, error } = await storage.download(storagePath);
-    if (error || !data) {
+    const EMPTY_BUFFER = Symbol('empty');
+
+    const sendImageBuffer = (buffer, pathForType) => {
+      const normalized = pathForType.toLowerCase();
+      const contentType = normalized.endsWith('.png')
+        ? 'image/png'
+        : normalized.endsWith('.webp')
+          ? 'image/webp'
+          : normalized.endsWith('.jpg') || normalized.endsWith('.jpeg')
+            ? 'image/jpeg'
+            : 'application/octet-stream';
+      res.setHeader('Content-Type', contentType);
+      res.setHeader('Cache-Control', 'public, max-age=300, immutable');
+      res.status(200).end(buffer);
+    };
+
+    const attemptDownload = async (path) => {
+      const { data, error } = await storage.download(path);
+      if (error || !data) {
+        if (error && error.message && error.statusCode !== 404) {
+          console.info('[prints-preview] preview_unavailable', { path, message: error.message });
+        }
+        return null;
+      }
+
+      const buffer = await toBuffer(data);
+      if (!buffer.length) {
+        return EMPTY_BUFFER;
+      }
+      return buffer;
+    };
+
+    let buffer = await attemptDownload(storagePath);
+
+    if (!buffer) {
+      const basePath = storagePath.replace(/\.[^./]+$/, '');
+      const originalExt = storagePath.slice(basePath.length);
+      const candidates = ['.webp', '.png', '.jpg', '.jpeg'];
+      for (const ext of candidates) {
+        if (ext === originalExt) continue;
+        buffer = await attemptDownload(`${basePath}${ext}`);
+        if (buffer && buffer !== EMPTY_BUFFER) {
+          sendImageBuffer(buffer, `${basePath}${ext}`);
+          return;
+        }
+        if (buffer === EMPTY_BUFFER) {
+          res.status(500).json({ ok: false, reason: 'empty_file', message: 'El archivo descargado está vacío.' });
+          return;
+        }
+      }
+    } else if (buffer === EMPTY_BUFFER) {
+      res.status(500).json({ ok: false, reason: 'empty_file', message: 'El archivo descargado está vacío.' });
+      return;
+    } else {
+      sendImageBuffer(buffer, storagePath);
+      return;
+    }
+
+    if (!buffer) {
       res.status(404).json({ ok: false, reason: 'preview_not_found', message: 'No se encontró el archivo solicitado.' });
       return;
     }
 
-    const fileBuffer = await toBuffer(data);
-    if (!fileBuffer.length) {
-      res.status(500).json({ ok: false, reason: 'empty_file', message: 'El archivo descargado está vacío.' });
-      return;
-    }
-
-    const contentType = lowerPath.endsWith('.png')
-      ? 'image/png'
-      : lowerPath.endsWith('.webp')
-        ? 'image/webp'
-        : lowerPath.endsWith('.jpg') || lowerPath.endsWith('.jpeg')
-          ? 'image/jpeg'
-          : 'application/octet-stream';
-
-    res.setHeader('Content-Type', contentType);
-    res.setHeader('Cache-Control', 'public, max-age=300, immutable');
-    res.status(200).end(fileBuffer);
+    // If we got here, "buffer" equals the EMPTY_BUFFER sentinel.
+    res.status(500).json({ ok: false, reason: 'empty_file', message: 'El archivo descargado está vacío.' });
     return;
   }
 


### PR DESCRIPTION
## Summary
- add an image-preview fallback that retries alternate extensions when the stored preview file is missing
- return clearer errors for empty preview files while keeping cache headers for successful responses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ded6c455988327a91a7d517ebed1a2