### PR TITLE
Relax image moderation thresholds

### DIFF
--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -8,12 +8,17 @@ const SKIP_OCR = process.env.MODERATION_SKIP_OCR === '1';
 const clamp = (value, min = 0, max = 1) => Math.max(min, Math.min(max, value));
 
 const NAZI_BLOCK_THRESHOLD = 0.6;
-const PERSON_SCORE_THRESHOLD = 0.3;
-const REAL_PERSON_THRESHOLD = 0.6;
-const GENITALS_THRESHOLD = 0.6;
-const AREOLA_THRESHOLD = 0.65;
-const SEX_ACT_THRESHOLD = 0.55;
-const REVIEW_MARGIN = 0.1;
+const PERSON_SCORE_THRESHOLD = 0.4;
+const REAL_PERSON_THRESHOLD = 0.7;
+const GENITALS_THRESHOLD = 0.8;
+const AREOLA_THRESHOLD = 0.85;
+const SEX_ACT_THRESHOLD = 0.75;
+const BUTT_EXPOSED_THRESHOLD = 0.8;
+const VISIBLE_AREA_RATIO_MIN = 0.03;
+const MINOR_BLOCK_THRESHOLD = 0.5;
+const MINOR_REVIEW_THRESHOLD = 0.4;
+const IGNORE_DETECTION_CONFIDENCE_BELOW = 0.6;
+const REVIEW_MARGIN = 0.05;
 
 function toBufferFromDataUrl(dataUrl) {
   const m = /^data:(.+?);base64,(.+)$/.exec(dataUrl || '');
@@ -556,22 +561,39 @@ export async function evaluateImage(buffer, filename, designName = '', options =
     )
   );
 
+  const isRealPerson = personScore >= PERSON_SCORE_THRESHOLD && realProbability >= REAL_PERSON_THRESHOLD;
+
   debug.scores.person_score = personScore;
   debug.scores.is_real_prob = realProbability;
+  debug.scores.is_real_person = isRealPerson ? 1 : 0;
   debug.scores.skinPercent = skinPercent;
   debug.scores.centerSkinPercent = centerSkinPercent;
   debug.scores.largestBlob = largestBlob;
   debug.scores.largestBlobCenterRatio = largestBlobCenterRatio;
   debug.scores.cartoonConfidence = cartoonConfidence;
 
-  let allowByPersonGate = false;
-  if (personScore < PERSON_SCORE_THRESHOLD || realProbability < REAL_PERSON_THRESHOLD) {
-    allowByPersonGate = true;
+  const allowByPersonGate = !isRealPerson;
+
+  // Server-side pipeline currently lacks a minor classifier; default to zero risk until integrated.
+  let minorProbability = 0;
+  debug.scores.minor_prob = minorProbability;
+
+  if (!allowByPersonGate) {
+    if (minorProbability >= MINOR_BLOCK_THRESHOLD) {
+      blockReasons.add('minor');
+      decisionConfidence = Math.max(decisionConfidence, clamp(0.82 + (minorProbability - MINOR_BLOCK_THRESHOLD) * 0.3));
+    } else if (minorProbability >= MINOR_REVIEW_THRESHOLD) {
+      reviewReasons.add('minor_review');
+    }
   }
 
   const nudityConfidence = computeNudityConfidence(skin);
   const visibleAreaRatio = clamp(largestBlobBoxCoverage || largestBlob || 0);
-  const isFemaleProb = clamp(personScore * 0.9);
+  const isFemaleProb = clamp(personScore);
+  const faceOrTorsoPresent = clamp(personScore);
+  const buttExposedScore = 0; // Placeholder until dedicated detector is available server-side.
+  const detectionConfidence = clamp(personScore);
+  const detectionConfidenceOk = detectionConfidence >= IGNORE_DETECTION_CONFIDENCE_BELOW;
 
   const genitalsScore = clamp((nudityConfidence - 0.5) / 0.3);
   const areolaScore = clamp((centerSkinPercent - 0.55) / 0.25);
@@ -582,29 +604,35 @@ export async function evaluateImage(buffer, filename, designName = '', options =
   debug.scores.genitals_score = genitalsScore;
   debug.scores.areola_score = areolaScore;
   debug.scores.sex_act_score = sexActScore;
+  debug.scores.butt_exposed_score = buttExposedScore;
+  debug.scores.face_or_torso_present = faceOrTorsoPresent;
+  debug.scores.detection_confidence = detectionConfidence;
 
-  if (!allowByPersonGate && !blockReasons.has('extremism_nazi')) {
-    if (genitalsScore >= GENITALS_THRESHOLD && visibleAreaRatio >= 0.02) {
+  if (!allowByPersonGate && detectionConfidenceOk && !blockReasons.has('extremism_nazi')) {
+    if (genitalsScore >= GENITALS_THRESHOLD && visibleAreaRatio >= VISIBLE_AREA_RATIO_MIN) {
       blockReasons.add('real_nudity');
       decisionConfidence = Math.max(decisionConfidence, clamp(0.7 + (genitalsScore - GENITALS_THRESHOLD) * 0.25));
-    } else if (areolaScore >= AREOLA_THRESHOLD && isFemaleProb >= 0.5) {
+    } else if (areolaScore >= AREOLA_THRESHOLD && isFemaleProb >= 0.6) {
       blockReasons.add('real_nudity');
       decisionConfidence = Math.max(decisionConfidence, clamp(0.68 + (areolaScore - AREOLA_THRESHOLD) * 0.25));
     } else if (sexActScore >= SEX_ACT_THRESHOLD) {
       blockReasons.add('real_nudity');
       decisionConfidence = Math.max(decisionConfidence, clamp(0.7 + (sexActScore - SEX_ACT_THRESHOLD) * 0.3));
+    } else if (buttExposedScore >= BUTT_EXPOSED_THRESHOLD && faceOrTorsoPresent >= 0.5) {
+      blockReasons.add('real_nudity');
+      decisionConfidence = Math.max(decisionConfidence, clamp(0.7 + (buttExposedScore - BUTT_EXPOSED_THRESHOLD) * 0.25));
     } else {
       if (
         genitalsScore >= GENITALS_THRESHOLD - REVIEW_MARGIN &&
         genitalsScore < GENITALS_THRESHOLD &&
-        visibleAreaRatio >= 0.02
+        visibleAreaRatio >= VISIBLE_AREA_RATIO_MIN
       ) {
         reviewReasons.add('real_nudity_review');
       }
       if (
         areolaScore >= AREOLA_THRESHOLD - REVIEW_MARGIN &&
         areolaScore < AREOLA_THRESHOLD &&
-        isFemaleProb >= 0.5
+        isFemaleProb >= 0.6
       ) {
         reviewReasons.add('real_nudity_review');
       }
@@ -614,10 +642,30 @@ export async function evaluateImage(buffer, filename, designName = '', options =
       ) {
         reviewReasons.add('real_nudity_review');
       }
+      if (
+        buttExposedScore >= BUTT_EXPOSED_THRESHOLD - REVIEW_MARGIN &&
+        buttExposedScore < BUTT_EXPOSED_THRESHOLD &&
+        faceOrTorsoPresent >= 0.5
+      ) {
+        reviewReasons.add('real_nudity_review');
+      }
     }
+  } else if (!allowByPersonGate && !detectionConfidenceOk) {
+    debug.scores.explicit_skipped_low_confidence = 1;
   }
 
   if (blockReasons.has('extremism_nazi')) {
+    debug.decision = 'BLOCK';
+    return {
+      label: 'BLOCK',
+      reasons: Array.from(blockReasons),
+      confidence: decisionConfidence,
+      details: debug,
+    };
+  }
+
+  if (blockReasons.has('minor')) {
+    debug.decision = 'BLOCK';
     return {
       label: 'BLOCK',
       reasons: Array.from(blockReasons),
@@ -627,6 +675,7 @@ export async function evaluateImage(buffer, filename, designName = '', options =
   }
 
   if (blockReasons.has('real_nudity')) {
+    debug.decision = 'BLOCK';
     return {
       label: 'BLOCK',
       reasons: Array.from(blockReasons),
@@ -636,14 +685,16 @@ export async function evaluateImage(buffer, filename, designName = '', options =
   }
 
   if (reviewReasons.size) {
+    debug.decision = 'REVIEW';
     return {
       label: 'REVIEW',
       reasons: Array.from(reviewReasons),
-      confidence: clamp(0.45 + (Math.max(genitalsScore, areolaScore, sexActScore) || 0) * 0.1),
+      confidence: clamp(0.45 + (Math.max(genitalsScore, areolaScore, sexActScore, buttExposedScore) || 0) * 0.1),
       details: debug,
     };
   }
 
+  debug.decision = 'ALLOW';
   return {
     label: 'ALLOW',
     reasons: ['no_violation_detected'],


### PR DESCRIPTION
## Summary
- update image moderation thresholds to require higher person confidence and log decision metadata for auditing
- enforce the new explicit content gates with higher nudity thresholds, minimum visible area checks, and detection confidence skips
- add placeholders for minor and buttocks detection so policy logging stays consistent with the relaxed rules

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dee42e6fc08327b72f2bc125cc7e06