### PR TITLE
Update Vercel config for Node.js 20 functions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,22 +1,23 @@
 {
   "version": 2,
-
-  "buildCommand": "npm run build",
-
-  "outputDirectory": "mgm-front/dist",
   "functions": {
-    "api/**": {
+    "api/**/*.{js,ts,mjs,cjs}": {
       "runtime": "nodejs20.x"
     },
-    "api/publish-product.js": {
+    "api/publishProduct.*": {
       "runtime": "nodejs20.x",
-      "maxDuration": 60,
-      "memory": 1024
+      "memory": 1024,
+      "maxDuration": 60
     },
-    "api/private/checkout/**": {
+    "api/publish-product.*": {
       "runtime": "nodejs20.x",
-      "maxDuration": 60,
-      "memory": 1024
+      "memory": 1024,
+      "maxDuration": 60
+    },
+    "api/private/checkout.*": {
+      "runtime": "nodejs20.x",
+      "memory": 1024,
+      "maxDuration": 60
     }
   },
   "rewrites": [
@@ -26,27 +27,19 @@
   ],
   "headers": [
     {
-      "source": "/api/(.*)",
-      "headers": [
-        { "key": "Cache-Control", "value": "no-store" }
-      ]
-    },
-    {
       "source": "/assets/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]
+    },
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" }
+      ]
     }
   ],
-  "git": {
-    "ignore": [
-      "**/tests/**",
-      "**/__tests__/**",
-      "**/__mocks__/**",
-      "**/mocks/**",
-      "**/fixtures/**",
-      "docs/**",
-      "playground/**"
-    ]
-  }
+  "installCommand": "npm ci",
+  "buildCommand": "npm run build",
+  "outputDirectory": "mgm-front/dist"
 }


### PR DESCRIPTION
## Summary
- update `vercel.json` to use the modern `functions` syntax with the Node.js 20 runtime
- configure SPA rewrites, cache headers, install/build commands, and output directory in a minimal manifest
- allocate higher resources for heavy API routes

## Testing
- [x] `npm ci`
- [x] `npm run build`
- [ ] `vercel pull --yes --environment=preview` *(fails in container: ENETUNREACH)*
- [ ] `vercel build` *(fails in container: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68df00a7a72883279a2c2ac5bd62fabb