### PR TITLE
Increase moderation fetch timeout and enable fast debug mode

### DIFF
--- a/mgm-front/src/lib/api.js
+++ b/mgm-front/src/lib/api.js
@@ -86,7 +86,7 @@ export function apiFetch(methodOrPath, maybePathOrInit, maybeBody, maybeInitOver
   return fetch(url, maybePathOrInit);
 }
 
-export async function postJSON(url, data, timeoutMs = 20000) {
+export async function postJSON(url, data, timeoutMs = 60000) {
   const ctrl = new AbortController();
   const id = setTimeout(() => ctrl.abort(), timeoutMs);
 
@@ -106,6 +106,11 @@ export async function postJSON(url, data, timeoutMs = 20000) {
       throw new Error(`HTTP ${res.status} ${res.statusText} | ${text}`);
     }
     return json ?? { ok: true };
+  } catch (err) {
+    if (err?.name === 'AbortError' || err?.name === 'DOMException') {
+      throw new Error('TIMEOUT: la solicitud tardó demasiado (>60s)');
+    }
+    throw err;
   } finally {
     clearTimeout(id);
   }

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -305,8 +305,9 @@ export default function Home() {
       let moderationResponse;
       try {
         moderationResponse = await postJSON(
-          getResolvedApiUrl('/api/moderate-image'),
+          getResolvedApiUrl('/api/moderate-image?debug=1'),
           moderationPayload,
+          60000,
         );
       } catch (moderationErr) {
         console.error('moderate-image failed', moderationErr);


### PR DESCRIPTION
## Summary
- raise the shared postJSON helper timeout to 60s and surface a clear timeout error message
- call the moderate-image endpoint with the fast debug flag while testing the longer timeout

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df54f078a48327b1bf2cdc31556c2d