### PR TITLE
api: make CORS lenient and error-safe on upload-original & moderate-image

### DIFF
--- a/api/_lib/cors.ts
+++ b/api/_lib/cors.ts
@@ -1,0 +1,57 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+const ALLOW_HEADERS = 'Content-Type, Authorization, X-Debug-Fast';
+
+type CorsDecision = {
+  allowed: boolean;
+  strict: boolean;
+};
+
+function parseAllowlist(): string[] {
+  const raw = process.env.CORS_ALLOWLIST;
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function resolveOrigin(
+  requestOrigin: string | undefined,
+  allowlist: string[],
+): { headerOrigin: string; allowed: boolean } {
+  if (allowlist.length === 0) {
+    return { headerOrigin: requestOrigin || '*', allowed: true };
+  }
+
+  const trimmed = requestOrigin?.trim();
+  if (trimmed && allowlist.includes(trimmed)) {
+    return { headerOrigin: trimmed, allowed: true };
+  }
+
+  const fallback = allowlist[0] || '*';
+  return { headerOrigin: fallback, allowed: false };
+}
+
+export function applyCors(
+  req: VercelRequest,
+  res: VercelResponse,
+  allowMethods: string,
+): CorsDecision {
+  const allowlist = parseAllowlist();
+  const originHeader = typeof req.headers.origin === 'string' ? req.headers.origin : undefined;
+  const { headerOrigin, allowed } = resolveOrigin(originHeader, allowlist);
+
+  res.setHeader('Access-Control-Allow-Origin', headerOrigin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', allowMethods);
+  res.setHeader('Access-Control-Allow-Headers', ALLOW_HEADERS);
+
+  return { allowed, strict: allowlist.length > 0 };
+}
+
+export function ensureJsonContentType(res: VercelResponse) {
+  if (!res.getHeader('Content-Type')) {
+    res.setHeader('Content-Type', 'application/json');
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared CORS helper with lenient reflection and optional allowlist support
- update upload-original to send consistent CORS headers, including on errors and OPTIONS
- align moderate-image responses with the lenient CORS strategy and structured JSON errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df5bbfe8ac832795dabb186795ba24