### PR TITLE
Allow MGM Gamers subdomains for CORS

### DIFF
--- a/lib/cors.js
+++ b/lib/cors.js
@@ -9,7 +9,7 @@ const STATIC_ALLOWED = [
   'https://mgm-api.vercel.app',
 ];
 
-const SUFFIX_ALLOWED = new Set(['.vercel.app']);
+const SUFFIX_ALLOWED = new Set(['.vercel.app', '.mgmgamers.store']);
 
 if (process.env?.ALLOWED_ORIGIN_SUFFIXES) {
   for (const entry of process.env.ALLOWED_ORIGIN_SUFFIXES.split(',')) {


### PR DESCRIPTION
## Summary
- allow any mgmgamers.store subdomain through the suffix-based CORS allowlist so newer storefront domains can call the API

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df6132d36083279c307e05b776ce8b