### PR TITLE
Update stub responses for publish and cart endpoints

### DIFF
--- a/api/cart/add.js
+++ b/api/cart/add.js
@@ -1,4 +1,5 @@
 const SHOPIFY_ENABLED = process.env.SHOPIFY_ENABLED === '1';
+const FRONT_ORIGIN = (process.env.FRONT_ORIGIN || 'https://mgm-app.vercel.app').replace(/\/$/, '');
 
 export const config = { memory: 256, maxDuration: 10 };
 
@@ -59,9 +60,8 @@ function buildMockCartResponse(payload) {
     : `gid://shopify/ProductVariant/${suffix}`;
   const quantity = clampQuantity(payload?.quantity);
   const sku = variantGid.split('/').pop() || `mock-sku-${suffix}`;
-  const baseUrl = 'https://example.test';
-  const cartPath = `/cart/${encodeURIComponent(sku)}:${quantity}`;
-  const checkoutUrl = `${baseUrl}${cartPath}?stub=1`;
+  const rid = cartId;
+  const checkoutUrl = `${FRONT_ORIGIN}/mockup?rid=${encodeURIComponent(rid)}&step=checkout`;
   return {
     ok: true,
     stub: true,

--- a/api/publish-product.js
+++ b/api/publish-product.js
@@ -1,4 +1,5 @@
 const SHOPIFY_ENABLED = process.env.SHOPIFY_ENABLED === '1';
+const FRONT_ORIGIN = (process.env.FRONT_ORIGIN || 'https://mgm-app.vercel.app').replace(/\/$/, '');
 
 export const config = { memory: 256, maxDuration: 10 };
 
@@ -62,7 +63,8 @@ function buildMockProduct(payload) {
   const productId = `mock-product-${numericId}`;
   const variantNumeric = `${Number(numericId) % 9_000_000 + 1_000_000}`;
   const variantGid = `gid://shopify/ProductVariant/${variantNumeric}`;
-  const productUrl = `https://example.test/products/${handle}`;
+  const rid = productId;
+  const productUrl = `${FRONT_ORIGIN}/mockup?rid=${encodeURIComponent(rid)}`;
 
   return {
     ok: true,


### PR DESCRIPTION
## Summary
- ensure the publish-product stub builds mock product URLs that point to the configured FRONT_ORIGIN mockup page
- update the add-to-cart stub to return checkout URLs pointing at the FRONT_ORIGIN mockup checkout step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfcd08ea80832780c05dcb13e49488