### PR TITLE
Fix static asset rewrites for Vercel deployment

### DIFF
--- a/mgm-front/vercel.json
+++ b/mgm-front/vercel.json
@@ -1,6 +1,7 @@
 {
-  "rewrites": [
-    { "source": "/((?!api/).*)", "destination": "/index.html" }
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
   ]
 }
 

--- a/mgm-front/vite.config.js
+++ b/mgm-front/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
+  base: '/',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- configure Vercel to serve static assets directly before rewriting to the SPA
- set the Vite base path to `/` to ensure public assets resolve correctly

## Testing
- npm run build
- npm run preview -- --host 0.0.0.0 --port 4173
- curl -I http://127.0.0.1:4173/icons/ancho.png
- curl -I http://127.0.0.1:4173/icons/largo.png

------
https://chatgpt.com/codex/tasks/task_e_68dfce09ee8c8327a63cd0c27c9c2121