### PR TITLE
Update stub API endpoints to return SPA mockup URLs

### DIFF
--- a/api/cart/add.js
+++ b/api/cart/add.js
@@ -3,6 +3,12 @@ const FRONT_ORIGIN = (process.env.FRONT_ORIGIN || 'https://mgm-app.vercel.app').
 
 export const config = { memory: 256, maxDuration: 10 };
 
+function createRid() {
+  const base = Date.now().toString(36);
+  const random = Math.random().toString(36).slice(2, 8);
+  return `${base}${random}`;
+}
+
 function applyCors(req, res) {
   const origin = typeof req?.headers?.origin === 'string' && req.headers.origin ? req.headers.origin : '*';
   res.setHeader('Access-Control-Allow-Origin', origin);
@@ -49,19 +55,14 @@ function clampQuantity(value) {
 }
 
 function buildMockCartResponse(payload) {
-  const now = Date.now();
-  const random = Math.floor(Math.random() * 1_000_000);
-  const suffix = `${now}${random}`.slice(-12);
-  const cartId = typeof payload?.cartId === 'string' && payload.cartId.trim()
-    ? payload.cartId.trim()
-    : `mock-cart-${suffix}`;
+  const rid = createRid();
+  const cartId = `mock_${rid}`;
   const variantGid = typeof payload?.variantGid === 'string' && payload.variantGid.trim()
     ? payload.variantGid.trim()
-    : `gid://shopify/ProductVariant/${suffix}`;
+    : `gid://shopify/ProductVariant/${Math.floor(Math.random() * 9_000_000) + 1_000_000}`;
   const quantity = clampQuantity(payload?.quantity);
-  const sku = variantGid.split('/').pop() || `mock-sku-${suffix}`;
-  const rid = cartId;
-  const checkoutUrl = `${FRONT_ORIGIN}/mockup?rid=${encodeURIComponent(rid)}&step=checkout`;
+  const sku = variantGid.split('/').pop() || `mock-sku-${rid}`;
+  const checkoutUrl = `${FRONT_ORIGIN}/mockup?rid=${encodeURIComponent(rid)}&step=checkout&from=cart`;
   return {
     ok: true,
     stub: true,
@@ -74,10 +75,11 @@ function buildMockCartResponse(payload) {
     cartWebUrl: checkoutUrl,
     cartPlain: checkoutUrl,
     checkoutUrl,
+    checkout: checkoutUrl,
     checkoutPlain: checkoutUrl,
-    cartToken: `mock-token-${suffix}`,
+    cartToken: `mock-token-${rid}`,
     usedFallback: false,
-    requestId: `mock-request-${suffix}`,
+    requestId: `mock-request-${rid}`,
   };
 }
 

--- a/api/publish-product.js
+++ b/api/publish-product.js
@@ -3,6 +3,12 @@ const FRONT_ORIGIN = (process.env.FRONT_ORIGIN || 'https://mgm-app.vercel.app').
 
 export const config = { memory: 256, maxDuration: 10 };
 
+function createRid() {
+  const base = Date.now().toString(36);
+  const random = Math.random().toString(36).slice(2, 8);
+  return `${base}${random}`;
+}
+
 function applyCors(req, res) {
   const origin = typeof req?.headers?.origin === 'string' && req.headers.origin ? req.headers.origin : '*';
   res.setHeader('Access-Control-Allow-Origin', origin);
@@ -58,13 +64,11 @@ function buildMockProduct(payload) {
   const handleBase = design || title || 'mock-product';
   const handle = slugify(handleBase).slice(0, 64) || 'mock-product';
   const now = Date.now();
-  const random = Math.floor(Math.random() * 1_000_000);
-  const numericId = `${now}${random}`.slice(-12);
-  const productId = `mock-product-${numericId}`;
-  const variantNumeric = `${Number(numericId) % 9_000_000 + 1_000_000}`;
+  const rid = createRid();
+  const productId = `mock_${rid}`;
+  const variantNumeric = `${Math.floor(Math.random() * 9_000_000) + 1_000_000}`;
   const variantGid = `gid://shopify/ProductVariant/${variantNumeric}`;
-  const rid = productId;
-  const productUrl = `${FRONT_ORIGIN}/mockup?rid=${encodeURIComponent(rid)}`;
+  const productUrl = `${FRONT_ORIGIN}/mockup?rid=${encodeURIComponent(rid)}&from=publish`;
 
   return {
     ok: true,
@@ -74,6 +78,7 @@ function buildMockProduct(payload) {
     productHandle: handle,
     handle,
     productUrl,
+    url: productUrl,
     publicUrl: productUrl,
     variantId: variantGid,
     variantGid,


### PR DESCRIPTION
## Summary
- ensure the publish-product stub always returns mock product URLs pointing to the SPA mockup endpoint
- adjust the add-to-cart stub to surface checkout URLs pointing to the SPA mockup endpoint and add compatibility aliases
- generate a short request id for stub responses while keeping the Shopify fallback disabled

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfcee4a1608327a3a0d07423ebbf44