### PR TITLE
Add missing PNG assets for favicons and OG image

### DIFF
--- a/mgm-front/public/icons/icon-192.png
+++ b/mgm-front/public/icons/icon-192.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64f070026fcbd8f591bae619b32ed09548cbeb4d969eeaa8fbf7049050efb8fe
+size 2239

--- a/mgm-front/public/icons/icon-512.png
+++ b/mgm-front/public/icons/icon-512.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac5c7faf9075e63f5c5fc24b5ff93181412bdd65e3b751521801f79455177dec
+size 6722

--- a/mgm-front/public/og/og-default.png
+++ b/mgm-front/public/og/og-default.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d1d7776fea8eaff4078e6ad0b8138a4d33ab482c6080fae66b8e6318e880b45
+size 21266


### PR DESCRIPTION
## Summary
- add 192x192 and 512x512 PNG icons so manifest and touch icon references resolve
- add default social sharing image at /og/og-default.png to prevent missing PNG errors

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68dfd3f8a7fc8327b7309138aa66ac4b