### PR TITLE
Fix pickCommerceTarget export for Mockup build

### DIFF
--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -1543,3 +1543,11 @@ export async function waitForVariantAvailability(
     quantityAvailable: null,
   };
 }
+// Preferir URLs que devuelve la API; si no hay, caer a Shopify
+export function pickCommerceTarget(json: any, shopifyDomain?: string): string | null {
+  const apiUrl = (json?.productUrl ?? json?.checkoutUrl ?? json?.url) ?? null;
+  if (apiUrl) return String(apiUrl);
+  const handle = json?.productHandle ?? json?.handle;
+  if (handle && shopifyDomain) return `https://${shopifyDomain}/products/${handle}`;
+  return null;
+}

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -11,8 +11,8 @@ import {
   createJobAndProduct,
   ONLINE_STORE_DISABLED_MESSAGE,
   ONLINE_STORE_MISSING_MESSAGE,
+  pickCommerceTarget,
 } from '@/lib/shopify.ts';
-import { pickCommerceTarget } from '../lib/shopify';
 import logger from '../lib/logger';
 
 /** NUEVO: imagen de la sección (reemplazá el path por el tuyo) */


### PR DESCRIPTION
## Summary
- export `pickCommerceTarget` from the Shopify helper module so the build can resolve it
- update the Mockup page to import `pickCommerceTarget` from the shared Shopify utilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dffce0de348327a18b396317095091