### PR TITLE
front: ensure Git LFS checkout before build and stop tracking /public/icons/*.png

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 *.gif filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text
 *.psd filter=lfs diff=lfs merge=lfs -text
+mgm-front/public/icons/*.png -filter -diff -merge

--- a/mgm-front/package.json
+++ b/mgm-front/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
+    "prebuild": "git lfs install && git lfs fetch --all && git lfs checkout || true",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"


### PR DESCRIPTION
## Summary
- ensure the front-end build runs git lfs install/fetch/checkout before executing vite build so Vercel receives real image bytes
- detected mgm-front/public/icons/testimonio1.png as a 131 B Git LFS pointer and documented the fix in the commit
- update .gitattributes to keep new icons under mgm-front/public/icons from being tracked via Git LFS

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dffeedb4748327a8ece50116550cb5