### PR TITLE
Add lenient CORS checkout endpoints with Shopify stubs

### DIFF
--- a/api/_lib/lenientCors.js
+++ b/api/_lib/lenientCors.js
@@ -1,0 +1,71 @@
+const ALLOW_METHODS = 'POST, OPTIONS';
+const ALLOW_HEADERS = 'Content-Type, Authorization';
+
+function resolveOrigin(req) {
+  if (req && req.headers && typeof req.headers.origin === 'string') {
+    const value = req.headers.origin.trim();
+    if (value) {
+      return value;
+    }
+  }
+  return '*';
+}
+
+export function applyLenientCors(req, res) {
+  const origin = resolveOrigin(req);
+  if (typeof res.setHeader === 'function') {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    res.setHeader('Access-Control-Allow-Methods', ALLOW_METHODS);
+    res.setHeader('Access-Control-Allow-Headers', ALLOW_HEADERS);
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  }
+  return origin;
+}
+
+export function sendCorsOptions(req, res) {
+  applyLenientCors(req, res);
+  if (typeof res.status === 'function') {
+    res.status(200);
+  } else {
+    res.statusCode = 200;
+  }
+  res.end('');
+}
+
+export function sendJsonWithCors(req, res, status, payload) {
+  applyLenientCors(req, res);
+  if (typeof res.status === 'function') {
+    res.status(status);
+  } else {
+    res.statusCode = status;
+  }
+  const body = payload == null ? {} : payload;
+  const json = JSON.stringify(body);
+  if (typeof res.json === 'function' && res.json !== sendJsonWithCors) {
+    res.json(body);
+    return;
+  }
+  res.end(json);
+}
+
+export async function runWithLenientCors(req, res, handler) {
+  const originalEnd = typeof res.end === 'function' ? res.end : null;
+
+  if (originalEnd) {
+    res.end = function patchedEnd(...args) {
+      applyLenientCors(req, res);
+      return originalEnd.apply(this, args);
+    };
+  }
+
+  try {
+    applyLenientCors(req, res);
+    const result = await handler();
+    return result;
+  } finally {
+    if (originalEnd) {
+      res.end = originalEnd;
+    }
+  }
+}

--- a/api/create-checkout.js
+++ b/api/create-checkout.js
@@ -1,0 +1,61 @@
+import { buildStubRequestId, resolveFrontOrigin } from '../lib/_lib/stubHelpers.js';
+import { runWithLenientCors, sendCorsOptions, sendJsonWithCors } from './_lib/lenientCors.js';
+
+const SHOPIFY_ENABLED = process.env.SHOPIFY_ENABLED === '1';
+
+function buildStubCheckoutPayload() {
+  const rid = buildStubRequestId();
+  const origin = resolveFrontOrigin();
+  const checkoutUrl = `${origin}/mockup?rid=${encodeURIComponent(rid)}&step=checkout&from=create-checkout`;
+
+  return {
+    ok: true,
+    stub: true,
+    url: checkoutUrl,
+    checkoutUrl,
+    message: null,
+    missing: [],
+  };
+}
+
+async function proxyRealHandler(req, res) {
+  await runWithLenientCors(req, res, async () => {
+    const mod = await import('../api-routes/create-checkout.js');
+    const handler = mod?.default || mod;
+    if (typeof handler !== 'function') {
+      throw new Error('handler_not_found');
+    }
+    return handler(req, res);
+  });
+}
+
+export default async function handler(req, res) {
+  if (req.method === 'OPTIONS') {
+    sendCorsOptions(req, res);
+    return;
+  }
+
+  if ((req.method || '').toUpperCase() !== 'POST') {
+    if (typeof res.setHeader === 'function') {
+      res.setHeader('Allow', 'POST, OPTIONS');
+    }
+    sendJsonWithCors(req, res, 405, { ok: false, error: 'method_not_allowed' });
+    return;
+  }
+
+  if (!SHOPIFY_ENABLED) {
+    const payload = buildStubCheckoutPayload();
+    sendJsonWithCors(req, res, 200, payload);
+    return;
+  }
+
+  try {
+    await proxyRealHandler(req, res);
+  } catch (err) {
+    if (!res.headersSent) {
+      sendJsonWithCors(req, res, 500, { ok: false, error: 'internal_error' });
+    }
+  }
+}
+
+export const config = { memory: 256 };

--- a/api/private/checkout.js
+++ b/api/private/checkout.js
@@ -1,0 +1,62 @@
+import { buildStubRequestId, resolveFrontOrigin } from '../../lib/_lib/stubHelpers.js';
+import { runWithLenientCors, sendCorsOptions, sendJsonWithCors } from '../_lib/lenientCors.js';
+
+const SHOPIFY_ENABLED = process.env.SHOPIFY_ENABLED === '1';
+
+function buildStubPrivatePayload() {
+  const rid = buildStubRequestId();
+  const origin = resolveFrontOrigin();
+  const checkoutUrl = `${origin}/mockup?rid=${encodeURIComponent(rid)}&step=private&from=private-checkout`;
+
+  return {
+    ok: true,
+    stub: true,
+    url: checkoutUrl,
+    checkoutUrl,
+    invoiceUrl: checkoutUrl,
+    draftOrderId: `mock_draft_${rid}`,
+    requestIds: [],
+  };
+}
+
+async function proxyRealHandler(req, res) {
+  await runWithLenientCors(req, res, async () => {
+    const mod = await import('../../api-routes/private/checkout/index.js');
+    const handler = mod?.default || mod;
+    if (typeof handler !== 'function') {
+      throw new Error('handler_not_found');
+    }
+    return handler(req, res);
+  });
+}
+
+export default async function handler(req, res) {
+  if (req.method === 'OPTIONS') {
+    sendCorsOptions(req, res);
+    return;
+  }
+
+  if ((req.method || '').toUpperCase() !== 'POST') {
+    if (typeof res.setHeader === 'function') {
+      res.setHeader('Allow', 'POST, OPTIONS');
+    }
+    sendJsonWithCors(req, res, 405, { ok: false, error: 'method_not_allowed' });
+    return;
+  }
+
+  if (!SHOPIFY_ENABLED) {
+    const payload = buildStubPrivatePayload();
+    sendJsonWithCors(req, res, 200, payload);
+    return;
+  }
+
+  try {
+    await proxyRealHandler(req, res);
+  } catch (err) {
+    if (!res.headersSent) {
+      sendJsonWithCors(req, res, 500, { ok: false, error: 'internal_error' });
+    }
+  }
+}
+
+export const config = { memory: 256 };


### PR DESCRIPTION
## Summary
- add lenient CORS helper and expose the create-checkout and private/checkout API routes
- provide Shopify-disabled stubs that return front-origin URLs while preserving real logic when enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfffb241c08327801d0dd3b273f9dc