### PR TITLE
Harden publish-product and checkout API handlers

### DIFF
--- a/api/_lib/diag.js
+++ b/api/_lib/diag.js
@@ -1,0 +1,19 @@
+export function createDiagId() {
+  const base = Date.now().toString(36);
+  const random = Math.random().toString(36).slice(2, 8);
+  return `${base}${random}`;
+}
+
+export function logApiError(label, payload = {}) {
+  const { diagId, step, error } = payload || {};
+  const normalizedError = typeof error === 'string' ? error : error?.message || error;
+  try {
+    console.error(`[${label}]`, {
+      ...(diagId ? { diagId } : {}),
+      ...(step ? { step } : {}),
+      error: normalizedError,
+    });
+  } catch {}
+}
+
+export default { createDiagId, logApiError };

--- a/api/_lib/lenientCors.js
+++ b/api/_lib/lenientCors.js
@@ -1,5 +1,5 @@
 const ALLOW_METHODS = 'POST, OPTIONS';
-const ALLOW_HEADERS = 'Content-Type, Authorization';
+const ALLOW_HEADERS = 'Content-Type, Authorization, Content-Type: application/json';
 
 function resolveOrigin(req) {
   if (req && req.headers && typeof req.headers.origin === 'string') {

--- a/api/create-checkout.js
+++ b/api/create-checkout.js
@@ -1,7 +1,11 @@
 import { buildStubRequestId, resolveFrontOrigin } from '../lib/_lib/stubHelpers.js';
 import { runWithLenientCors, sendCorsOptions, sendJsonWithCors } from './_lib/lenientCors.js';
+import { resolveEnvRequirements, collectMissingEnv } from './_lib/envChecks.js';
+import { createDiagId, logApiError } from './_lib/diag.js';
 
 const SHOPIFY_ENABLED = process.env.SHOPIFY_ENABLED === '1';
+const REQUIRED_ENV = resolveEnvRequirements('SHOPIFY_STOREFRONT');
+const SHOPIFY_TIMEOUT_STATUS = 504;
 
 function buildStubCheckoutPayload() {
   const rid = buildStubRequestId();
@@ -29,7 +33,37 @@ async function proxyRealHandler(req, res) {
   });
 }
 
+function resolveShopDomain() {
+  const candidates = [process.env.SHOPIFY_STORE_DOMAIN, process.env.SHOPIFY_SHOP];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed) return trimmed;
+    }
+  }
+  return '';
+}
+
+function validateRealConfig(req, res, diagId) {
+  const missing = collectMissingEnv(REQUIRED_ENV);
+  if (missing.length) {
+    logApiError('create-checkout', { diagId, step: 'missing_env', error: `missing_env:${missing.join(',')}` });
+    sendJsonWithCors(req, res, 400, { ok: false, error: 'missing_env', missing, diagId });
+    return false;
+  }
+
+  const domain = resolveShopDomain();
+  if (!domain || !/\.myshopify\.com$/i.test(domain)) {
+    logApiError('create-checkout', { diagId, step: 'invalid_shop_domain', error: domain || 'missing_domain' });
+    sendJsonWithCors(req, res, 400, { ok: false, error: 'invalid_shop_domain', diagId });
+    return false;
+  }
+
+  return true;
+}
+
 export default async function handler(req, res) {
+  const diagId = createDiagId();
   if (req.method === 'OPTIONS') {
     sendCorsOptions(req, res);
     return;
@@ -39,23 +73,39 @@ export default async function handler(req, res) {
     if (typeof res.setHeader === 'function') {
       res.setHeader('Allow', 'POST, OPTIONS');
     }
-    sendJsonWithCors(req, res, 405, { ok: false, error: 'method_not_allowed' });
+    sendJsonWithCors(req, res, 405, { ok: false, error: 'method_not_allowed', diagId });
     return;
   }
 
   if (!SHOPIFY_ENABLED) {
     const payload = buildStubCheckoutPayload();
-    sendJsonWithCors(req, res, 200, payload);
+    sendJsonWithCors(req, res, 200, { ...payload, diagId });
+    return;
+  }
+
+  if (!validateRealConfig(req, res, diagId)) {
     return;
   }
 
   try {
+    req.mgmDiagId = diagId;
     await proxyRealHandler(req, res);
   } catch (err) {
+    const step = err?.code === 'SHOPIFY_TIMEOUT' ? err?.step || 'shopify_request' : 'proxy_handler';
+    logApiError('create-checkout', { diagId, step, error: err });
     if (!res.headersSent) {
-      sendJsonWithCors(req, res, 500, { ok: false, error: 'internal_error' });
+      if (err?.code === 'SHOPIFY_TIMEOUT') {
+        sendJsonWithCors(req, res, SHOPIFY_TIMEOUT_STATUS, {
+          ok: false,
+          error: 'shopify_timeout',
+          diagId,
+          step,
+        });
+        return;
+      }
+      sendJsonWithCors(req, res, 502, { ok: false, error: 'checkout_failed', diagId });
     }
   }
 }
 
-export const config = { memory: 256 };
+export const config = { memory: 256, maxDuration: 60 };

--- a/api/private/checkout.js
+++ b/api/private/checkout.js
@@ -1,7 +1,9 @@
 import { buildStubRequestId, resolveFrontOrigin } from '../../lib/_lib/stubHelpers.js';
 import { runWithLenientCors, sendCorsOptions, sendJsonWithCors } from '../_lib/lenientCors.js';
+import { createDiagId, logApiError } from '../_lib/diag.js';
 
 const SHOPIFY_ENABLED = process.env.SHOPIFY_ENABLED === '1';
+const SHOPIFY_TIMEOUT_STATUS = 504;
 
 function buildStubPrivatePayload() {
   const rid = buildStubRequestId();
@@ -31,6 +33,7 @@ async function proxyRealHandler(req, res) {
 }
 
 export default async function handler(req, res) {
+  const diagId = createDiagId();
   if (req.method === 'OPTIONS') {
     sendCorsOptions(req, res);
     return;
@@ -40,23 +43,35 @@ export default async function handler(req, res) {
     if (typeof res.setHeader === 'function') {
       res.setHeader('Allow', 'POST, OPTIONS');
     }
-    sendJsonWithCors(req, res, 405, { ok: false, error: 'method_not_allowed' });
+    sendJsonWithCors(req, res, 405, { ok: false, error: 'method_not_allowed', diagId });
     return;
   }
 
   if (!SHOPIFY_ENABLED) {
     const payload = buildStubPrivatePayload();
-    sendJsonWithCors(req, res, 200, payload);
+    sendJsonWithCors(req, res, 200, { ...payload, diagId });
     return;
   }
 
   try {
+    req.mgmDiagId = diagId;
     await proxyRealHandler(req, res);
   } catch (err) {
+    const step = err?.code === 'SHOPIFY_TIMEOUT' ? err?.step || 'shopify_request' : 'proxy_handler';
+    logApiError('private-checkout', { diagId, step, error: err });
     if (!res.headersSent) {
-      sendJsonWithCors(req, res, 500, { ok: false, error: 'internal_error' });
+      if (err?.code === 'SHOPIFY_TIMEOUT') {
+        sendJsonWithCors(req, res, SHOPIFY_TIMEOUT_STATUS, {
+          ok: false,
+          error: 'shopify_timeout',
+          diagId,
+          step,
+        });
+        return;
+      }
+      sendJsonWithCors(req, res, 502, { ok: false, error: 'checkout_failed', diagId });
     }
   }
 }
 
-export const config = { memory: 256 };
+export const config = { memory: 256, maxDuration: 60 };

--- a/api/publish-product.js
+++ b/api/publish-product.js
@@ -1,7 +1,12 @@
+import { resolveEnvRequirements, collectMissingEnv } from './_lib/envChecks.js';
+import { createDiagId, logApiError } from './_lib/diag.js';
+
 const SHOPIFY_ENABLED = process.env.SHOPIFY_ENABLED === '1';
 const FRONT_ORIGIN = (process.env.FRONT_ORIGIN || 'https://mgm-app.vercel.app').replace(/\/$/, '');
+const REQUIRED_ENV = resolveEnvRequirements('SHOPIFY_ADMIN', 'SUPABASE_SERVICE');
+const SHOPIFY_TIMEOUT_STATUS = 504;
 
-export const config = { memory: 256, maxDuration: 10 };
+export const config = { memory: 256, maxDuration: 60 };
 
 function createRid() {
   const base = Date.now().toString(36);
@@ -14,7 +19,7 @@ function applyCors(req, res) {
   res.setHeader('Access-Control-Allow-Origin', origin);
   res.setHeader('Vary', 'Origin');
   res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, Content-Type: application/json');
   res.setHeader('Content-Type', 'application/json; charset=utf-8');
 }
 
@@ -22,6 +27,35 @@ function sendJson(req, res, status, payload) {
   applyCors(req, res);
   res.statusCode = status;
   res.end(JSON.stringify(payload ?? {}));
+}
+
+function resolveShopDomain() {
+  const candidates = [process.env.SHOPIFY_STORE_DOMAIN, process.env.SHOPIFY_SHOP];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed) return trimmed;
+    }
+  }
+  return '';
+}
+
+function validateRealConfig(req, res, diagId) {
+  const missing = collectMissingEnv(REQUIRED_ENV);
+  if (missing.length) {
+    logApiError('publish-product', { diagId, step: 'missing_env', error: `missing_env:${missing.join(',')}` });
+    sendJson(req, res, 400, { ok: false, error: 'missing_env', missing, diagId });
+    return null;
+  }
+
+  const domain = resolveShopDomain();
+  if (!domain || !/\.myshopify\.com$/i.test(domain)) {
+    logApiError('publish-product', { diagId, step: 'invalid_shop_domain', error: domain || 'missing_domain' });
+    sendJson(req, res, 400, { ok: false, error: 'invalid_shop_domain', diagId });
+    return null;
+  }
+
+  return { domain };
 }
 
 function slugify(value) {
@@ -90,6 +124,7 @@ function buildMockProduct(payload) {
 }
 
 export default async function handler(req, res) {
+  const diagId = createDiagId();
   applyCors(req, res);
   if (req.method === 'OPTIONS') {
     res.statusCode = 200;
@@ -98,7 +133,7 @@ export default async function handler(req, res) {
   }
   if ((req.method || '').toUpperCase() !== 'POST') {
     res.setHeader('Allow', 'POST, OPTIONS');
-    sendJson(req, res, 405, { ok: false, error: 'method_not_allowed' });
+    sendJson(req, res, 405, { ok: false, error: 'method_not_allowed', diagId });
     return;
   }
 
@@ -109,8 +144,13 @@ export default async function handler(req, res) {
     } catch (err) {
       body = null;
     }
-    const payload = buildMockProduct(body || {});
+    const payload = { ...buildMockProduct(body || {}), diagId };
     sendJson(req, res, 200, payload);
+    return;
+  }
+
+  const configOk = validateRealConfig(req, res, diagId);
+  if (!configOk) {
     return;
   }
 
@@ -118,13 +158,30 @@ export default async function handler(req, res) {
     const mod = await import('../api-routes/publish-product.js');
     const realHandler = mod?.default || mod;
     if (typeof realHandler !== 'function') {
-      sendJson(req, res, 200, { ok: true, stub: true, message: 'not_implemented' });
+      logApiError('publish-product', { diagId, step: 'handler_missing', error: 'handler_not_found' });
+      sendJson(req, res, 200, { ok: true, stub: true, message: 'not_implemented', diagId });
       return;
     }
+    req.mgmDiagId = diagId;
     await realHandler(req, res);
   } catch (err) {
+    const step = err?.code === 'SHOPIFY_TIMEOUT' ? err?.step || 'shopify_request' : 'real_handler';
+    logApiError('publish-product', { diagId, step, error: err });
     if (!res.headersSent) {
-      sendJson(req, res, 200, { ok: true, stub: true, message: 'not_implemented' });
+      if (err?.code === 'SHOPIFY_TIMEOUT') {
+        sendJson(req, res, SHOPIFY_TIMEOUT_STATUS, {
+          ok: false,
+          error: 'shopify_timeout',
+          diagId,
+          step,
+        });
+        return;
+      }
+      sendJson(req, res, 502, {
+        ok: false,
+        error: 'publish_failed',
+        diagId,
+      });
     }
   }
 }

--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -3,6 +3,80 @@
 import { randomUUID } from 'crypto';
 import { getShopifyConfig } from './config.js';
 
+const DEFAULT_TIMEOUT_MS = 20000;
+
+function extractGraphQlOperationName(query = '') {
+  if (typeof query !== 'string') return '';
+  const match = query.match(/\b(?:mutation|query)\s+(\w+)/i);
+  return match ? match[1] : '';
+}
+
+function combineAbortSignals(signals = []) {
+  const filtered = signals.filter((signal) => signal && typeof signal === 'object');
+  if (filtered.length === 0) return undefined;
+  if (filtered.length === 1) return filtered[0];
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.any === 'function') {
+    return AbortSignal.any(filtered);
+  }
+  const relay = new AbortController();
+  const abortRelay = (signal) => {
+    if (relay.signal.aborted) return;
+    const reason = typeof signal?.reason !== 'undefined' ? signal.reason : undefined;
+    relay.abort(reason);
+  };
+  for (const signal of filtered) {
+    if (signal.aborted) {
+      abortRelay(signal);
+      break;
+    }
+    signal.addEventListener('abort', () => abortRelay(signal), { once: true });
+  }
+  return relay.signal;
+}
+
+async function fetchWithTimeout(url, init = {}, { timeoutMs = DEFAULT_TIMEOUT_MS, stepName = 'shopify_request' } = {}) {
+  const externalSignal = init?.signal;
+  const timeoutInfo = {};
+  let signal = externalSignal;
+
+  if (typeof timeoutMs === 'number' && timeoutMs > 0 && typeof AbortController === 'function') {
+    const controller = new AbortController();
+    const reason = new Error('shopify_timeout');
+    reason.code = 'SHOPIFY_TIMEOUT';
+    reason.step = stepName;
+    reason.url = url;
+    const timeoutId = setTimeout(() => controller.abort(reason), timeoutMs);
+    timeoutInfo.controller = controller;
+    timeoutInfo.reason = reason;
+    timeoutInfo.timer = timeoutId;
+    signal = combineAbortSignals([externalSignal, controller.signal]) || controller.signal;
+  }
+
+  try {
+    const finalInit = signal ? { ...init, signal } : { ...init };
+    if (!finalInit.signal && externalSignal) {
+      finalInit.signal = externalSignal;
+    }
+    return await fetch(url, finalInit);
+  } catch (err) {
+    const abortedByTimeout = Boolean(
+      timeoutInfo?.controller?.signal?.aborted && timeoutInfo.controller.signal.reason === timeoutInfo.reason,
+    );
+    if (abortedByTimeout || err?.code === 'SHOPIFY_TIMEOUT') {
+      const timeoutError = new Error('shopify_timeout');
+      timeoutError.code = 'SHOPIFY_TIMEOUT';
+      timeoutError.step = stepName;
+      timeoutError.url = url;
+      throw timeoutError;
+    }
+    throw err;
+  } finally {
+    if (timeoutInfo?.timer) {
+      clearTimeout(timeoutInfo.timer);
+    }
+  }
+}
+
 export async function shopifyAdmin(path, init = {}, idemKey) {
   const { STORE_DOMAIN, ADMIN_TOKEN, API_VERSION } = getShopifyConfig();
   if (!STORE_DOMAIN || !ADMIN_TOKEN) {
@@ -20,7 +94,8 @@ export async function shopifyAdmin(path, init = {}, idemKey) {
     'X-Shopify-Idempotency-Key': idemKey || randomUUID(),
     ...(init.headers || {}),
   };
-  return fetch(url, { ...init, headers });
+  const stepName = `shopify_admin:${cleanPath || 'request'}`;
+  return fetchWithTimeout(url, { ...init, headers }, { stepName });
 }
 
 export async function shopifyAdminGraphQL(query, variables = {}, idemKey) {
@@ -41,7 +116,13 @@ export async function shopifyAdminGraphQL(query, variables = {}, idemKey) {
     'X-Shopify-Access-Token': ADMIN_TOKEN,
     'X-Shopify-Idempotency-Key': idemKey || randomUUID(),
   };
-  return fetch(url, { method: 'POST', headers, body: JSON.stringify({ query, variables }) });
+  const operation = extractGraphQlOperationName(query);
+  const stepName = operation ? `shopify_admin_graphql:${operation}` : 'shopify_admin_graphql';
+  return fetchWithTimeout(
+    url,
+    { method: 'POST', headers, body: JSON.stringify({ query, variables }) },
+    { stepName },
+  );
 }
 
 function buildStorefrontEndpoint(domain, apiVersion) {
@@ -81,11 +162,17 @@ export async function shopifyStorefrontGraphQL(query, variables = {}, options = 
   if (options?.buyerIp) {
     headers['Shopify-Storefront-Buyer-IP'] = options.buyerIp;
   }
-  return fetch(endpoint, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({ query, variables }),
-  });
+  const operation = extractGraphQlOperationName(query);
+  const stepName = operation ? `shopify_storefront_graphql:${operation}` : 'shopify_storefront_graphql';
+  return fetchWithTimeout(
+    endpoint,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ query, variables }),
+    },
+    { stepName },
+  );
 }
 
 function pickEnv(names) {


### PR DESCRIPTION
## Summary
- ensure /api/publish-product, /api/create-checkout, and /api/private/checkout always respond with the required CORS headers (including OPTIONS)
- add diagId logging, environment validation, and extend maxDuration to 60 seconds to improve resiliency and error reporting
- wrap Shopify client calls with AbortController-based timeouts to surface upstream delays as JSON errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00792c00c832784428268761d4a44