### PR TITLE
Harden public checkout flow

### DIFF
--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -763,6 +763,28 @@ export async function createJobAndProduct(
           body: JSON.stringify(checkoutPayload),
         });
         const ck = await ckResp.json().catch(() => null);
+        (result as Record<string, unknown>).publicCheckoutResponse = ck && typeof ck === 'object' ? ck : null;
+        (result as Record<string, unknown>).publicCheckoutStatus = typeof ckResp.status === 'number' ? ckResp.status : null;
+        if (SHOULD_LOG_COMMERCE) {
+          try {
+            logger.debug('[commerce]', {
+              tag: 'public-checkout-response',
+              status: typeof ckResp.status === 'number' ? ckResp.status : null,
+              keys: ck && typeof ck === 'object' ? Object.keys(ck) : [],
+              checkoutUrl:
+                (typeof ck?.checkoutUrl === 'string' && ck.checkoutUrl.trim())
+                  ? ck.checkoutUrl.trim()
+                  : typeof ck?.url === 'string' && ck.url.trim()
+                    ? ck.url.trim()
+                    : null,
+              diagId: typeof ck?.diagId === 'string' && ck.diagId ? ck.diagId : null,
+              mode: typeof ck?.mode === 'string' ? ck.mode : null,
+              error: typeof ck?.error === 'string' ? ck.error : null,
+            });
+          } catch (logErr) {
+            logger.warn('[createJobAndProduct] public_checkout_log_failed', logErr);
+          }
+        }
         const checkoutUrlFromResponse =
           typeof ck?.checkoutUrl === 'string' && ck.checkoutUrl.trim()
             ? ck.checkoutUrl.trim()


### PR DESCRIPTION
## Summary
- improve /api/create-checkout by resolving variant ids from multiple payload sources, adding cart/product fallbacks, and returning consistent ok/error payloads with diag information
- capture and log the create-checkout response in the front-end flow for easier diagnostics
- adjust the public checkout handler to prefer checkout URLs, gracefully handle popup blockers, and reuse handles for product fallbacks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0156c53f88327b3fa80ff510bf99e