### PR TITLE
Fix prints search PDF filter for case-insensitive file names

### DIFF
--- a/lib/api/handlers/printsSearch.js
+++ b/lib/api/handlers/printsSearch.js
@@ -180,7 +180,7 @@ async function searchDatabase({
       'id, job_key, bucket, file_path, file_name, slug, width_cm, height_cm, material, bg_color, job_id, file_size_bytes, created_at, preview_url',
       { count: 'exact' },
     )
-    .like('file_name', '%.pdf')
+    .or('file_name.ilike.%.pdf,file_path.ilike.%.pdf')
     .order('created_at', { ascending: false })
     .order('file_name', { ascending: true })
     .range(offset, offset + limit - 1);


### PR DESCRIPTION
## Summary
- update prints search database query to accept PDF files by name or path using a case-insensitive filter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e02dff3c848327b04c84a8e879f683