### PR TITLE
Use previewUrl thumbnails in prints search

### DIFF
--- a/mgm-front/src/pages/Busqueda.module.css
+++ b/mgm-front/src/pages/Busqueda.module.css
@@ -146,8 +146,8 @@
 }
 
 .previewImage {
-  width: 96px;
-  height: 96px;
+  width: 72px;
+  height: 72px;
   object-fit: cover;
   border-radius: 8px;
   border: 1px solid rgba(59, 130, 246, 0.25);
@@ -158,8 +158,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 96px;
-  height: 96px;
+  width: 72px;
+  height: 72px;
   border-radius: 8px;
   border: 1px dashed rgba(148, 163, 184, 0.4);
   color: #94a3b8;


### PR DESCRIPTION
## Summary
- render the preview image directly from previewUrl with placeholder fallback
- compute a descriptive alt text for previews and keep download links pointing to downloadUrl
- tweak preview sizing styles for both the image and placeholder

## Testing
- npm run lint *(fails: existing lint errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68e041b448fc8327bf90765bac79b036