### PR TITLE
Handle Shopify purchase webhooks

### DIFF
--- a/api-routes/shopify-webhook.js
+++ b/api-routes/shopify-webhook.js
@@ -6,6 +6,10 @@ export default createApiHandler({
   methods: 'POST',
   rateLimitKey: 'shopify-webhook',
   context: 'shopify-webhook',
-  requiredEnv: resolveEnvRequirements('SHOPIFY_ADMIN', 'SHOPIFY_WEBHOOK_SECRET'),
+  requiredEnv: resolveEnvRequirements(
+    'SHOPIFY_ADMIN',
+    'SUPABASE_SERVICE',
+    'SHOPIFY_WEBHOOK_SECRET',
+  ),
   handler: shopifyWebhook,
 });

--- a/lib/handlers/shopifyWebhook.js
+++ b/lib/handlers/shopifyWebhook.js
@@ -1,8 +1,94 @@
 import crypto from 'node:crypto';
 import { readRequestBody } from '../_lib/http.js';
 import logger from '../_lib/logger.js';
+import { getSupabaseAdmin } from '../_lib/supabaseAdmin.js';
 
+const ALLOWED_TOPICS = new Set(['orders/create', 'orders/paid']);
 const HMAC_HEADER = 'x-shopify-hmac-sha256';
+
+function getHeaderValue(req, name) {
+  const header = req.headers?.[name] ?? req.headers?.[name.toLowerCase()];
+  if (Array.isArray(header)) return header[0];
+  return header;
+}
+
+function toTrimmedString(value) {
+  if (value == null) return null;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
+}
+
+function toNumber(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const num = Number(value);
+    if (Number.isFinite(num)) {
+      return num;
+    }
+  }
+  return null;
+}
+
+function findAttribute(collection, key) {
+  if (!Array.isArray(collection)) return null;
+  const target = String(key || '').toLowerCase();
+  for (const entry of collection) {
+    if (!entry || typeof entry !== 'object') continue;
+    const name = typeof entry.name === 'string' ? entry.name.toLowerCase() : '';
+    if (name === target) {
+      const value = 'value' in entry ? entry.value : undefined;
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed) return trimmed;
+      }
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return String(value);
+      }
+    }
+  }
+  return null;
+}
+
+function findInLineItemProperties(lineItems, key) {
+  if (!Array.isArray(lineItems)) return null;
+  for (const item of lineItems) {
+    if (!item || typeof item !== 'object') continue;
+    const match = findAttribute(item.properties, key);
+    if (match) return match;
+  }
+  return null;
+}
+
+function extractRid(order) {
+  const fromLineItem = findInLineItemProperties(order?.line_items, 'rid');
+  if (fromLineItem) return fromLineItem;
+
+  const fromNotes = findAttribute(order?.note_attributes, 'rid');
+  if (fromNotes) return fromNotes;
+
+  const note = typeof order?.note === 'string' ? order.note : '';
+  if (note) {
+    const match = note.match(/rid=([A-Za-z0-9\-_]+)/i);
+    if (match) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+function extractDesignSlug(order) {
+  const fromLineItem = findInLineItemProperties(order?.line_items, 'design_slug');
+  if (fromLineItem) return fromLineItem;
+  return findAttribute(order?.note_attributes, 'design_slug');
+}
 
 function safeCompare(expected, received) {
   const expectedBuf = Buffer.from(expected || '', 'utf8');
@@ -30,22 +116,27 @@ export default async function shopifyWebhook(req, res) {
     rawBody = await readRequestBody(req, { limit: 512 * 1024 });
   } catch (err) {
     if (err?.code === 'payload_too_large') {
-      return res.status(413).json({ ok: false, diag_id: diagId, error: 'payload_too_large' });
+      logger.error('shopify-webhook payload_too_large', { diagId });
+    } else {
+      logger.error('shopify-webhook read_error', { diagId, err });
     }
-    logger.error('shopify-webhook read_error', err);
-    return res.status(400).json({ ok: false, diag_id: diagId, error: 'invalid_body' });
+    res.status(200).json({ ok: true });
+    return;
   }
 
-  const signatureHeader = req.headers?.[HMAC_HEADER] || req.headers?.[HMAC_HEADER.toUpperCase()];
-  const provided = Array.isArray(signatureHeader) ? signatureHeader[0] : signatureHeader;
+  const signatureHeader = getHeaderValue(req, HMAC_HEADER);
+  const provided = signatureHeader ? String(signatureHeader) : '';
   if (!provided) {
-    return res.status(401).json({ ok: false, diag_id: diagId, error: 'missing_signature' });
+    logger.error('shopify-webhook missing_signature', { diagId });
+    res.status(401).end();
+    return;
   }
 
   const digest = crypto.createHmac('sha256', secret).update(rawBody, 'utf8').digest('base64');
   if (!safeCompare(digest, provided)) {
     logger.error('shopify-webhook invalid_signature', { diagId });
-    return res.status(401).json({ ok: false, diag_id: diagId, error: 'invalid_signature' });
+    res.status(401).end();
+    return;
   }
 
   let payload;
@@ -53,12 +144,99 @@ export default async function shopifyWebhook(req, res) {
     payload = rawBody ? JSON.parse(rawBody) : {};
   } catch (err) {
     logger.error('shopify-webhook json_error', { diagId, err: err?.message || err });
-    return res.status(400).json({ ok: false, diag_id: diagId, error: 'invalid_json' });
+    res.status(200).json({ ok: true });
+    return;
   }
 
-  const topicHeader = req.headers?.['x-shopify-topic'] || req.headers?.['X-Shopify-Topic'];
-  const topic = Array.isArray(topicHeader) ? topicHeader[0] : topicHeader;
+  const topic = getHeaderValue(req, 'x-shopify-topic') || null;
+  const normalizedTopic = String(topic || '').toLowerCase();
+  const orderId = payload?.id;
+  const orderIdString = orderId == null ? null : String(orderId);
+  const rid = extractRid(payload);
+  const designSlug = extractDesignSlug(payload);
 
-  return res.status(200).json({ ok: true, diag_id: diagId, received: true, topic: topic || null, ts: Date.now() });
+  logger.info('shopify-webhook received', {
+    diagId,
+    topic,
+    orderId: orderIdString,
+    ridFound: Boolean(rid),
+  });
+
+  if (!ALLOWED_TOPICS.has(normalizedTopic)) {
+    res.status(200).json({ ok: true });
+    return;
+  }
+
+  const shopDomain = getHeaderValue(req, 'x-shopify-shop-domain') || null;
+
+  if (!orderIdString) {
+    logger.warn('shopify-webhook missing_order_id', { diagId, topic });
+    res.status(200).json({ ok: true });
+    return;
+  }
+  const amount = toNumber(payload?.total_price);
+  const currency = toTrimmedString(payload?.currency);
+  const lineItemsCount = Array.isArray(payload?.line_items) ? payload.line_items.length : 0;
+  const details = {
+    topic,
+    line_items_count: lineItemsCount,
+    email: toTrimmedString(payload?.email),
+    financial_status: toTrimmedString(payload?.financial_status),
+  };
+
+  try {
+    const client = getSupabaseAdmin();
+    const { data: existing, error: selectError } = await client
+      .from('events')
+      .select('id')
+      .eq('event_name', 'purchase_completed')
+      .eq('order_id', orderIdString)
+      .limit(1);
+
+    if (selectError) {
+      throw selectError;
+    }
+
+    if (!Array.isArray(existing) || existing.length === 0) {
+      const userAgentHeader = getHeaderValue(req, 'user-agent');
+      const userAgent = userAgentHeader ? String(userAgentHeader) : 'shopify-webhook';
+      const insertPayload = {
+        event_name: 'purchase_completed',
+        rid,
+        design_slug: designSlug,
+        order_id: orderIdString,
+        amount,
+        currency,
+        origin: shopDomain ? String(shopDomain) : null,
+        user_agent: userAgent,
+        referer: '',
+        details,
+      };
+
+      const { error: insertError } = await client.from('events').insert(insertPayload);
+      if (insertError) {
+        throw insertError;
+      }
+    }
+  } catch (err) {
+    logger.error('shopify-webhook supabase_error', {
+      diagId,
+      topic,
+      orderId: orderIdString,
+      ridFound: Boolean(rid),
+      err,
+    });
+    res.status(200).json({ ok: true });
+    return;
+  }
+
+  logger.info('shopify-webhook processed', {
+    diagId,
+    topic,
+    orderId: orderIdString,
+    ridFound: Boolean(rid),
+  });
+
+  res.status(200).json({ ok: true });
 }
 


### PR DESCRIPTION
## Summary
- ensure the Shopify webhook route verifies Supabase service credentials
- validate Shopify order webhook signatures, extract RID/design metadata, and log diagnostics
- record idempotent `purchase_completed` events in Supabase using the service role client

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e140ec2ba88327826f212572c36957