### PR TITLE
Propagate rid/design_slug to Shopify line items

### DIFF
--- a/lib/handlers/createCheckout.js
+++ b/lib/handlers/createCheckout.js
@@ -31,6 +31,9 @@ const BodySchema = z
       )
       .optional(),
     discount: z.string().optional(),
+    rid: z.string().optional(),
+    design_slug: z.string().optional(),
+    designSlug: z.string().optional(),
   })
   .passthrough();
 
@@ -82,6 +85,39 @@ function collectAttributes({ noteAttributes, email }) {
   return normalized;
 }
 
+function normalizeAttributeValue(value) {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  return trimmed.slice(0, 255);
+}
+
+function pickHeaderValue(headers, name) {
+  if (!headers || typeof name !== 'string') return '';
+  const lower = name.toLowerCase();
+  const upper = name.toUpperCase();
+  const raw = headers[name] ?? headers[lower] ?? headers[upper];
+  if (Array.isArray(raw)) {
+    return typeof raw[0] === 'string' ? raw[0] : '';
+  }
+  return typeof raw === 'string' ? raw : '';
+}
+
+function extractTrackingFields({ body, headers }) {
+  const ridValue =
+    (typeof body?.rid === 'string' && body.rid) ||
+    (typeof body?.rid === 'number' ? String(body.rid) : '') ||
+    pickHeaderValue(headers, 'x-rid');
+  const designSlugValue =
+    (typeof body?.design_slug === 'string' && body.design_slug) ||
+    (typeof body?.designSlug === 'string' && body.designSlug) ||
+    pickHeaderValue(headers, 'x-design-slug');
+
+  const rid = normalizeAttributeValue(ridValue);
+  const designSlug = normalizeAttributeValue(designSlugValue);
+  return { rid, designSlug };
+}
+
 const CART_CREATE_MUTATION = `
   mutation CartCreate($input: CartInput!) {
     cartCreate(input: $input) {
@@ -97,19 +133,35 @@ const CART_CREATE_MUTATION = `
   }
 `;
 
-async function createStorefrontCheckout({ variantId, quantity, email, note, noteAttributes, buyerIp, discount }) {
+async function createStorefrontCheckout({
+  variantId,
+  quantity,
+  email,
+  note,
+  noteAttributes,
+  buyerIp,
+  discount,
+  rid,
+  designSlug,
+}) {
   const variantGid = buildVariantGid(variantId);
   if (!variantGid) {
     return { ok: false, reason: 'invalid_variant' };
   }
 
+  const lineItem = {
+    merchandiseId: variantGid,
+    quantity,
+  };
+  const customAttributes = [];
+  if (rid) customAttributes.push({ key: 'rid', value: rid });
+  if (designSlug) customAttributes.push({ key: 'design_slug', value: designSlug });
+  if (customAttributes.length) {
+    lineItem.attributes = customAttributes;
+  }
+
   const input = {
-    lines: [
-      {
-        merchandiseId: variantGid,
-        quantity,
-      },
-    ],
+    lines: [lineItem],
   };
 
   const attributes = collectAttributes({ noteAttributes, email });
@@ -230,6 +282,16 @@ export default async function createCheckout(req, res) {
       return res.status(400).json({ ok: false, error: 'invalid_body', issues: parsed.error.flatten().fieldErrors });
     }
     const { variantId, variantGid, quantity, email, mode, note, noteAttributes, discount } = parsed.data;
+    const { rid, designSlug } = extractTrackingFields({ body, headers: req.headers || {} });
+    const diagId = req?.mgmDiagId || null;
+    try {
+      logger.info?.('create_checkout_attach_rid', {
+        diagId,
+        step: 'attach_rid',
+        rid: rid || null,
+        design_slug: designSlug || null,
+      });
+    } catch {}
     const normalizedVariantId = normalizeVariantId(variantId ?? variantGid);
     if (!normalizedVariantId) return res.status(400).json({ ok: false, error: 'missing_variant' });
     const qtyRaw = Number(quantity);
@@ -253,6 +315,8 @@ export default async function createCheckout(req, res) {
         noteAttributes,
         buyerIp,
         discount: normalizedDiscount,
+        rid,
+        designSlug,
       });
       if (!storefrontCheckout?.ok || !storefrontCheckout?.url) {
         if (storefrontCheckout?.missing) {


### PR DESCRIPTION
## Summary
- accept rid and design_slug from the checkout payload or headers
- forward the tracking metadata to Shopify checkout line items as custom attributes and log the attach step
- ensure the reusable checkout handler emits the attributes when creating carts for the private flow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1431b3d748327a08518fb4756a5d8