### PR TITLE
Add calculadora route with dimension inputs

### DIFF
--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -10,6 +10,7 @@ import Result from './pages/Result.jsx';
 import DevRenderPreview from './pages/DevRenderPreview.jsx';
 import DevCanvasPreview from './pages/DevCanvasPreview.jsx';
 import Mockup from './pages/Mockup.jsx';
+import CalculadoraPage from './pages/Calculadora.jsx';
 import MousepadsPersonalizados from './pages/MousepadsPersonalizados.jsx';
 import ComoFunciona from './pages/ComoFunciona.jsx';
 import PreguntasFrecuentes from './pages/PreguntasFrecuentes.jsx';
@@ -38,6 +39,7 @@ const routes = [
       { path: '/busqueda', element: <Busqueda /> },
       { path: '/confirm', element: <Confirm /> },
       { path: '/mockup', element: <Mockup /> },
+      { path: '/calculadora', element: <CalculadoraPage /> },
       { path: '/creating/:jobId', element: <Creating /> },
       { path: '/result/:jobId', element: <Result /> },
       { path: '*', element: <NotFound /> }

--- a/mgm-front/src/pages/Calculadora.jsx
+++ b/mgm-front/src/pages/Calculadora.jsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import Calculadora from '../components/Calculadora.jsx';
+import styles from './Calculadora.module.css';
+
+const CalculadoraPage = () => {
+  const [width, setWidth] = useState('');
+  const [height, setHeight] = useState('');
+
+  return (
+    <section className={styles.container}>
+      <div className={styles.content}>
+        <h1 className={styles.title}>Calculadora de precios</h1>
+        <p className={styles.subtitle}>
+          Ingresá las medidas en centímetros para obtener el precio con transferencia.
+        </p>
+
+        <form className={styles.form}>
+          <label className={styles.label}>
+            Largo (cm)
+            <input
+              type="number"
+              min="0"
+              step="0.1"
+              value={width}
+              onChange={(event) => setWidth(event.target.value)}
+              placeholder="Ej: 90"
+              className={styles.input}
+            />
+          </label>
+
+          <label className={styles.label}>
+            Ancho (cm)
+            <input
+              type="number"
+              min="0"
+              step="0.1"
+              value={height}
+              onChange={(event) => setHeight(event.target.value)}
+              placeholder="Ej: 45"
+              className={styles.input}
+            />
+          </label>
+        </form>
+
+        <Calculadora
+          width={width}
+          height={height}
+          material="Pro"
+          render={({ valid, transfer, format }) => (
+            <div className={styles.result}>
+              <h2 className={styles.resultTitle}>Precio con transferencia</h2>
+              <p className={styles.resultValue}>
+                {valid && transfer > 0 ? `$${format(transfer)}` : 'Ingresá medidas válidas'}
+              </p>
+            </div>
+          )}
+        />
+      </div>
+    </section>
+  );
+};
+
+export default CalculadoraPage;

--- a/mgm-front/src/pages/Calculadora.module.css
+++ b/mgm-front/src/pages/Calculadora.module.css
@@ -1,0 +1,73 @@
+.container {
+  display: flex;
+  justify-content: center;
+  padding: 4rem 1.5rem;
+}
+
+.content {
+  width: min(100%, 420px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.title {
+  font-size: clamp(1.8rem, 2vw + 1.2rem, 2.4rem);
+  font-weight: 700;
+  color: var(--color-heading, #111);
+}
+
+.subtitle {
+  color: var(--color-text-muted, #555);
+  line-height: 1.5;
+}
+
+.form {
+  display: grid;
+  gap: 1rem;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--color-heading, #111);
+}
+
+.input {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  font-size: 1rem;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.input:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.result {
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: linear-gradient(145deg, #111, #1f2937);
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.resultTitle {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.8;
+}
+
+.resultValue {
+  font-size: clamp(1.8rem, 2vw + 1.2rem, 2.4rem);
+  font-weight: 700;
+}


### PR DESCRIPTION
## Summary
- add a dedicated /calculadora route that renders the pricing calculator
- allow users to ingresar largo y ancho in centímetros and see el precio con transferencia en vivo
- style the calculator page with a focused layout for the new inputs y resultado

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e15402b6a48327b6a7cf36676feb8e