### PR TITLE
Add admin analytics dashboard gated by token

### DIFF
--- a/api/_lib/lenientCors.js
+++ b/api/_lib/lenientCors.js
@@ -1,4 +1,4 @@
-const DEFAULT_ALLOW_HEADERS = 'content-type, authorization';
+const DEFAULT_ALLOW_HEADERS = 'content-type, authorization, x-admin-token';
 const ALLOW_METHODS = 'GET, POST, OPTIONS';
 
 function resolveOrigin(req) {
@@ -29,12 +29,25 @@ function resolveRequestedHeaders(req) {
     return DEFAULT_ALLOW_HEADERS;
   }
 
-  const names = headerList
+  const requestedNames = headerList
     .split(',')
     .map((name) => name.split(':')[0].trim())
     .filter(Boolean);
 
-  return names.length ? names.join(', ') : DEFAULT_ALLOW_HEADERS;
+  const normalized = new Set(
+    DEFAULT_ALLOW_HEADERS.split(',')
+      .map((name) => name.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+  for (const name of requestedNames) {
+    normalized.add(name.toLowerCase());
+  }
+
+  normalized.add('x-admin-token');
+  normalized.add('content-type');
+
+  return normalized.size ? Array.from(normalized).join(', ') : DEFAULT_ALLOW_HEADERS;
 }
 
 export function applyLenientCors(req, res) {

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -10,6 +10,7 @@ import Result from './pages/Result.jsx';
 import DevRenderPreview from './pages/DevRenderPreview.jsx';
 import DevCanvasPreview from './pages/DevCanvasPreview.jsx';
 import Mockup from './pages/Mockup.jsx';
+import AdminAnalytics from './pages/AdminAnalytics.jsx';
 import MousepadsPersonalizados from './pages/MousepadsPersonalizados.jsx';
 import ComoFunciona from './pages/ComoFunciona.jsx';
 import PreguntasFrecuentes from './pages/PreguntasFrecuentes.jsx';
@@ -40,6 +41,7 @@ const routes = [
       { path: '/mockup', element: <Mockup /> },
       { path: '/creating/:jobId', element: <Creating /> },
       { path: '/result/:jobId', element: <Result /> },
+      { path: '/admin/analytics', element: <AdminAnalytics /> },
       { path: '*', element: <NotFound /> }
     ]
   }

--- a/mgm-front/src/pages/AdminAnalytics.jsx
+++ b/mgm-front/src/pages/AdminAnalytics.jsx
@@ -1,0 +1,290 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import styles from './AdminAnalytics.module.css';
+
+const REFRESH_INTERVAL_MS = 60000;
+const RANGE_DAYS = 30;
+const RANGE_MS = RANGE_DAYS * 24 * 60 * 60 * 1000;
+
+function formatNumber(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '0';
+  }
+  return value.toLocaleString('es-AR');
+}
+
+function formatPercentage(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return '0%';
+  }
+  return `${value.toFixed(2)}%`;
+}
+
+function formatWindowDate(value) {
+  if (!value) {
+    return '';
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.valueOf())) {
+    return '';
+  }
+  return parsed.toLocaleString();
+}
+
+export default function AdminAnalytics() {
+  const [token, setToken] = useState(() => {
+    if (typeof window === 'undefined') {
+      return '';
+    }
+    try {
+      return window.localStorage.getItem('adminToken') || '';
+    } catch (err) {
+      console.warn('[admin-analytics] localStorage_get_failed', err);
+      return '';
+    }
+  });
+  const [formToken, setFormToken] = useState('');
+  const [data, setData] = useState(null);
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState(null);
+
+  const rawBase = typeof import.meta.env.VITE_API_URL === 'string' ? import.meta.env.VITE_API_URL : '';
+  const sanitizedBase = rawBase.trim().replace(/\/+$/, '');
+  const apiBase = sanitizedBase || '/api';
+  const analyticsEndpoint = useMemo(() => `${apiBase}/analytics/flows`, [apiBase]);
+
+  const handleLogout = useCallback((options = {}) => {
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.removeItem('adminToken');
+      } catch (err) {
+        console.warn('[admin-analytics] localStorage_remove_failed', err);
+      }
+    }
+    setToken('');
+    setData(null);
+    setLastUpdated(null);
+    if (!options.preserveError) {
+      setError('');
+    }
+    if (!options.preserveForm) {
+      setFormToken('');
+    }
+    setIsLoading(false);
+  }, []);
+
+  const fetchAnalytics = useCallback(async (currentToken) => {
+    if (!currentToken) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const now = new Date();
+      const toIso = now.toISOString();
+      const fromIso = new Date(now.getTime() - RANGE_MS).toISOString();
+      const url = `${analyticsEndpoint}?from=${encodeURIComponent(fromIso)}&to=${encodeURIComponent(toIso)}`;
+
+      const response = await fetch(url, {
+        headers: {
+          Accept: 'application/json',
+          'X-Admin-Token': currentToken,
+        },
+      });
+
+      if (response.status === 401) {
+        setError('Token inválido');
+        handleLogout({ preserveError: true });
+        return;
+      }
+
+      const text = await response.text();
+      const json = text ? JSON.parse(text) : null;
+
+      if (!response.ok || !json?.ok) {
+        const message = typeof json?.error === 'string' && json.error
+          ? json.error
+          : 'No se pudieron cargar las métricas. Intentá nuevamente.';
+        setError(message);
+        if (!json?.ok) {
+          setData(null);
+        }
+        return;
+      }
+
+      setData(json);
+      setLastUpdated(new Date());
+    } catch (err) {
+      console.error('[admin-analytics] fetch_failed', err);
+      setError('No se pudieron cargar las métricas. Intentá nuevamente.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [analyticsEndpoint, handleLogout]);
+
+  useEffect(() => {
+    if (!token) {
+      setData(null);
+      setLastUpdated(null);
+      return undefined;
+    }
+
+    let cancelled = false;
+    let isFetching = false;
+
+    const load = async () => {
+      if (cancelled || isFetching) {
+        return;
+      }
+      isFetching = true;
+      try {
+        await fetchAnalytics(token);
+      } finally {
+        isFetching = false;
+      }
+    };
+
+    load();
+    const intervalId = window.setInterval(load, REFRESH_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [token, fetchAnalytics]);
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const value = formToken.trim();
+    if (!value) {
+      setError('Ingresá el token de administrador.');
+      return;
+    }
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem('adminToken', value);
+      } catch (err) {
+        console.warn('[admin-analytics] localStorage_set_failed', err);
+      }
+    }
+    setToken(value);
+    setFormToken('');
+    setError('');
+  };
+
+  const handleRefresh = useCallback(() => {
+    if (token) {
+      fetchAnalytics(token);
+    }
+  }, [token, fetchAnalytics]);
+
+  const totals = data?.ok ? data.totals : null;
+  const topDesigns = data?.ok && Array.isArray(data.topDesigns) ? data.topDesigns : [];
+  const windowFrom = data?.ok ? formatWindowDate(data.window?.from) : '';
+  const windowTo = data?.ok ? formatWindowDate(data.window?.to) : '';
+
+  if (!token) {
+    return (
+      <div className={styles.loginCard}>
+        <h1 className={styles.loginTitle}>Panel de Analytics</h1>
+        <form className={styles.loginForm} onSubmit={handleSubmit}>
+          <label className={styles.loginLabel}>
+            Token de administrador
+            <input
+              type="password"
+              className={styles.loginInput}
+              value={formToken}
+              onChange={(event) => setFormToken(event.target.value)}
+              placeholder="Ingresá tu token"
+              autoFocus
+            />
+          </label>
+          <button type="submit" className={styles.loginButton}>
+            Entrar
+          </button>
+        </form>
+        {error && <p className={styles.error}>{error}</p>}
+        <p className={styles.loginHint}>Ingresá el token de administrador para ver las métricas.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.headerRow}>
+        <h1 className={styles.title}>Analytics de flujos</h1>
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={`${styles.secondaryButton}`}
+            onClick={handleRefresh}
+            disabled={isLoading}
+          >
+            Actualizar
+          </button>
+          <button
+            type="button"
+            className={styles.primaryButton}
+            onClick={() => handleLogout()}
+          >
+            Salir
+          </button>
+        </div>
+      </div>
+
+      {error && <p className={styles.error}>{error}</p>}
+      {isLoading && <p className={styles.status}>Cargando métricas…</p>}
+
+      {totals && (
+        <section>
+          <div className={styles.cards}>
+            {[
+              { key: 'public', label: 'Public', data: totals.public },
+              { key: 'private', label: 'Private', data: totals.private },
+              { key: 'cart', label: 'Cart', data: totals.cart },
+            ].map(({ key, label, data: cardData }) => (
+              <article key={key} className={styles.card}>
+                <span className={styles.cardTitle}>{label}</span>
+                <p className={styles.cardMetric}>{formatNumber(cardData?.clicks ?? 0)}</p>
+                <span className={styles.cardSubmetric}>
+                  Compradores: {formatNumber(cardData?.purchasers ?? 0)} · Conversión: {formatPercentage(cardData?.rate ?? 0)}
+                </span>
+              </article>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <div className={styles.metaRow}>
+        {lastUpdated && <span>Última actualización: {lastUpdated.toLocaleString()}</span>}
+        {windowFrom && windowTo && <span>Ventana: {windowFrom} → {windowTo}</span>}
+      </div>
+
+      <section className={styles.tableWrapper}>
+        <h2 className={styles.sectionTitle}>Top diseños (clicks)</h2>
+        {topDesigns.length ? (
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Slug</th>
+                <th>Clicks</th>
+              </tr>
+            </thead>
+            <tbody>
+              {topDesigns.map((design) => (
+                <tr key={design.design_slug}>
+                  <td>{design.design_slug}</td>
+                  <td>{formatNumber(design.clicks ?? 0)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className={styles.emptyState}>Todavía no hay datos de diseños destacados.</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/mgm-front/src/pages/AdminAnalytics.module.css
+++ b/mgm-front/src/pages/AdminAnalytics.module.css
@@ -1,0 +1,216 @@
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.headerRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.title {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.primaryButton {
+  background: #ff0055;
+  border: none;
+  transition: background 0.2s ease-in-out;
+}
+
+.primaryButton:hover:not(:disabled) {
+  background: #ff2b72;
+}
+
+.secondaryButton {
+  background: #2a2a2a;
+  border: 1px solid #3a3a3a;
+}
+
+.secondaryButton:hover:not(:disabled) {
+  background: #353535;
+}
+
+.status {
+  margin: 0;
+  color: #d1d5db;
+  font-size: 0.95rem;
+}
+
+.error {
+  margin: 0;
+  color: #ff6b6b;
+  font-weight: 500;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: #202020;
+  border: 1px solid #2c2c2c;
+  border-radius: 16px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.cardTitle {
+  font-size: 1rem;
+  font-weight: 500;
+  color: #d1d5db;
+}
+
+.cardMetric {
+  font-size: 2rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.cardSubmetric {
+  font-size: 0.95rem;
+  color: #9ca3af;
+}
+
+.sectionTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.tableWrapper {
+  background: #202020;
+  border: 1px solid #2c2c2c;
+  border-radius: 16px;
+  padding: 1.5rem;
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: 0.75rem;
+  border-bottom: 1px solid #2f2f2f;
+}
+
+.table th {
+  font-weight: 600;
+  color: #d1d5db;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.emptyState {
+  margin: 0;
+  color: #9ca3af;
+  font-size: 0.95rem;
+}
+
+.loginCard {
+  max-width: 420px;
+  margin: 3rem auto 0;
+  background: #202020;
+  border: 1px solid #2c2c2c;
+  border-radius: 16px;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.loginTitle {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+.loginForm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.loginLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.loginInput {
+  border-radius: 10px;
+  border: 1px solid #3a3a3a;
+  padding: 0.75rem 0.9rem;
+  background: #151515;
+  color: #f5f5f5;
+  font-size: 1rem;
+}
+
+.loginButton {
+  margin-top: 0.5rem;
+  border: none;
+  background: #ff0055;
+  transition: background 0.2s ease-in-out;
+}
+
+.loginButton:hover:not(:disabled) {
+  background: #ff2b72;
+}
+
+.loginHint {
+  margin: 0;
+  color: #9ca3af;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  color: #9ca3af;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 1.5rem 1rem 2rem;
+  }
+
+  .card {
+    border-radius: 14px;
+  }
+
+  .loginCard {
+    margin-top: 2rem;
+    border-radius: 14px;
+  }
+}


### PR DESCRIPTION
## Summary
- require the X-Admin-Token header on /api/analytics/flows and expose it via CORS preflight handling
- add an admin analytics route in the front-end with a token form and metrics dashboard using the protected endpoint

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e155344a0c8327a5566e0413cdfcb2