### PR TITLE
Constrain calculator dimensions per material

### DIFF
--- a/mgm-front/index.html
+++ b/mgm-front/index.html
@@ -5,7 +5,6 @@
     <link rel="icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="/icons/icon-192.png" />
     <link rel="manifest" href="/site.webmanifest" />
-    <link rel="stylesheet" href="/src/index.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tu Mousepad Personalizado — MGMGAMERS</title>
     <meta

--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -10,6 +10,7 @@ import Result from './pages/Result.jsx';
 import DevRenderPreview from './pages/DevRenderPreview.jsx';
 import DevCanvasPreview from './pages/DevCanvasPreview.jsx';
 import Mockup from './pages/Mockup.jsx';
+import CalculadoraPage from './pages/Calculadora.jsx';
 import MousepadsPersonalizados from './pages/MousepadsPersonalizados.jsx';
 import ComoFunciona from './pages/ComoFunciona.jsx';
 import PreguntasFrecuentes from './pages/PreguntasFrecuentes.jsx';
@@ -25,6 +26,15 @@ if (typeof globalThis !== 'undefined' && typeof globalThis.Buffer === 'undefined
   globalThis.Buffer = Buffer;
 }
 
+if (typeof window !== 'undefined' && typeof window.AdminAnalytics === 'undefined') {
+  window.AdminAnalytics = new Proxy(
+    {},
+    {
+      get: () => () => {},
+    },
+  );
+}
+
 const routes = [
   {
     element: <App />,
@@ -38,6 +48,7 @@ const routes = [
       { path: '/busqueda', element: <Busqueda /> },
       { path: '/confirm', element: <Confirm /> },
       { path: '/mockup', element: <Mockup /> },
+      { path: '/calculadora', element: <CalculadoraPage /> },
       { path: '/creating/:jobId', element: <Creating /> },
       { path: '/result/:jobId', element: <Result /> },
       { path: '*', element: <NotFound /> }

--- a/mgm-front/src/pages/Calculadora.jsx
+++ b/mgm-front/src/pages/Calculadora.jsx
@@ -1,0 +1,177 @@
+import { useEffect, useMemo, useState } from 'react';
+import Calculadora from '../components/Calculadora.jsx';
+import styles from './Calculadora.module.css';
+
+const priceFormatter = new Intl.NumberFormat('es-AR', {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
+const CalculadoraPage = () => {
+  const [width, setWidth] = useState('');
+  const [height, setHeight] = useState('');
+  const [material, setMaterial] = useState('Classic');
+  const [transferPrice, setTransferPrice] = useState(0);
+
+  const materialOptions = useMemo(
+    () => [
+      { label: 'Glasspad', value: 'Glasspad' },
+      { label: 'Pro', value: 'Pro' },
+      { label: 'Classic', value: 'Classic' },
+    ],
+    [],
+  );
+
+  const dimensionConstraints = useMemo(
+    () => ({
+      Classic: {
+        width: { min: 20, max: 140 },
+        height: { min: 20, max: 100 },
+      },
+      Pro: {
+        width: { min: 20, max: 120 },
+        height: { min: 20, max: 60 },
+      },
+      Glasspad: {
+        width: { min: 20, max: 49 },
+        height: { min: 20, max: 42 },
+      },
+    }),
+    [],
+  );
+
+  const sanitizeNumericInput = (value) => value.replace(/[^0-9]/g, '');
+
+  const clampValue = (value, { min, max }) => {
+    if (value === '') {
+      return '';
+    }
+
+    const numericValue = Number(value);
+
+    if (Number.isNaN(numericValue)) {
+      return '';
+    }
+
+    const clampedValue = Math.min(Math.max(numericValue, min), max);
+    return String(clampedValue);
+  };
+
+  const handleDimensionChange = (setter) => (event) => {
+    const numericString = sanitizeNumericInput(event.target.value);
+    setter(numericString);
+  };
+
+  const handleDimensionBlur = (setter, constraint) => (event) => {
+    const clampedValue = clampValue(event.target.value, constraint);
+    setter(clampedValue);
+  };
+
+  const handleDimensionKeyDown = (setter, constraint) => (event) => {
+    if (event.key !== 'Enter') {
+      return;
+    }
+
+    event.preventDefault();
+    const clampedValue = clampValue(event.currentTarget.value, constraint);
+    setter(clampedValue);
+    event.currentTarget.blur();
+  };
+
+  const { width: widthConstraint, height: heightConstraint } =
+    dimensionConstraints[material];
+
+  useEffect(() => {
+    setWidth((current) => {
+      const clamped = clampValue(current, widthConstraint);
+      return clamped === current ? current : clamped;
+    });
+
+    setHeight((current) => {
+      const clamped = clampValue(current, heightConstraint);
+      return clamped === current ? current : clamped;
+    });
+  }, [heightConstraint, widthConstraint]);
+
+  return (
+    <section className={styles.container}>
+      <div className={styles.content}>
+        <h1 className={styles.title}>Calculadora de precios</h1>
+        <p className={styles.subtitle}>
+          Ingresá las medidas en centímetros para obtener el precio con transferencia.
+        </p>
+
+        <form className={styles.form}>
+          <label className={styles.label}>
+            Largo (cm)
+            <input
+              type="number"
+              min={widthConstraint.min}
+              max={widthConstraint.max}
+              step={1}
+              inputMode="numeric"
+              value={width}
+              onChange={handleDimensionChange(setWidth)}
+              onBlur={handleDimensionBlur(setWidth, widthConstraint)}
+              onKeyDown={handleDimensionKeyDown(setWidth, widthConstraint)}
+              placeholder="Ej: 90"
+              className={styles.input}
+            />
+          </label>
+
+          <label className={styles.label}>
+            Ancho (cm)
+            <input
+              type="number"
+              min={heightConstraint.min}
+              max={heightConstraint.max}
+              step={1}
+              inputMode="numeric"
+              value={height}
+              onChange={handleDimensionChange(setHeight)}
+              onBlur={handleDimensionBlur(setHeight, heightConstraint)}
+              onKeyDown={handleDimensionKeyDown(setHeight, heightConstraint)}
+              placeholder="Ej: 45"
+              className={styles.input}
+            />
+          </label>
+
+          <label className={styles.label}>
+            Tipo de material
+            <select
+              className={styles.input}
+              value={material}
+              onChange={(event) => setMaterial(event.target.value)}
+            >
+              {materialOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </form>
+
+        <Calculadora
+          width={width}
+          height={height}
+          material={material}
+          setPrice={setTransferPrice}
+          render={() => null}
+        />
+
+        <div className={styles.result}>
+          <h2 className={styles.resultTitle}>Precio con transferencia</h2>
+          <p className={styles.resultValue}>
+            {transferPrice > 0 ? `$${priceFormatter.format(transferPrice)}` : 'Ingresá medidas válidas'}
+          </p>
+          <p className={styles.resultDetails}>
+            ({`${material || 'Classic'} / ${width || '--'}x${height || '--'}`})
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default CalculadoraPage;

--- a/mgm-front/src/pages/Calculadora.module.css
+++ b/mgm-front/src/pages/Calculadora.module.css
@@ -1,0 +1,91 @@
+.container {
+  display: flex;
+  justify-content: center;
+  padding: 3rem 1rem;
+  background: #181818;
+  color: #f4f4f4;
+}
+
+.content {
+  width: min(100%, 520px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  background: #181818;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  box-shadow: 0 20px 35px rgba(0, 0, 0, 0.35);
+}
+
+.title {
+  font-size: clamp(1.8rem, 2vw + 1.2rem, 2.4rem);
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.subtitle {
+  color: rgba(255, 255, 255, 0.7);
+  line-height: 1.5;
+}
+
+.form {
+  display: grid;
+  gap: 0.875rem;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.input {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  font-size: 1rem;
+  background: #101010;
+  color: #f4f4f4;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input::placeholder {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.input:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.6);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.result {
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: #101010;
+  color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.resultTitle {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.75;
+}
+
+.resultValue {
+  font-size: clamp(1.8rem, 2vw + 1.2rem, 2.4rem);
+  font-weight: 700;
+}
+
+.resultDetails {
+  font-size: 18px;
+  color: rgba(255, 255, 255, 0.7);
+}


### PR DESCRIPTION
## Summary
- widen the calculator card while tightening internal spacing for a more compact layout
- enforce integer-only dimension inputs with per-material min/max bounds while allowing free typing and clamping on blur or Enter

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e15402b6a48327b6a7cf36676feb8e