### PR TITLE
Fix missing AdminAnalyticsPage import

### DIFF
--- a/mgm-front/src/main.jsx
+++ b/mgm-front/src/main.jsx
@@ -11,6 +11,7 @@ import DevRenderPreview from './pages/DevRenderPreview.jsx';
 import DevCanvasPreview from './pages/DevCanvasPreview.jsx';
 import Mockup from './pages/Mockup.jsx';
 import CalculadoraPage from './pages/Calculadora.jsx';
+import AdminAnalyticsPage from './pages/AdminAnalytics.jsx';
 import MousepadsPersonalizados from './pages/MousepadsPersonalizados.jsx';
 import ComoFunciona from './pages/ComoFunciona.jsx';
 import PreguntasFrecuentes from './pages/PreguntasFrecuentes.jsx';


### PR DESCRIPTION
## Summary
- import the AdminAnalyticsPage component so the /admin/analytics route renders correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e186be4b7883279bc461d95003dcec