### PR TITLE
Add tracking for mockup view and purchase options

### DIFF
--- a/api/track.ts
+++ b/api/track.ts
@@ -3,6 +3,8 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { logApiError } from './_lib/diag.js';
 
 const ALLOWED_EVENTS = new Set<string>([
+  'mockup_view',
+  'view_purchase_options',
   'continue_design',
   'checkout_public_click',
   'checkout_private_click',


### PR DESCRIPTION
## Summary
- allow the tracking API to accept mockup_view and view_purchase_options events
- persist a rid on the mockup page and emit mockup_view and view_purchase_options once per session when the page and options load

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1869187c08327a78922f14db84e97