### PR TITLE
Add funnel analytics view to admin dashboard

### DIFF
--- a/mgm-front/src/pages/AdminAnalytics.jsx
+++ b/mgm-front/src/pages/AdminAnalytics.jsx
@@ -2,8 +2,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import styles from './AdminAnalytics.module.css';
 
 const REFRESH_INTERVAL_MS = 60000;
-const RANGE_DAYS = 30;
-const RANGE_MS = RANGE_DAYS * 24 * 60 * 60 * 1000;
+const DEFAULT_RANGE_DAYS = 30;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const RANGE_OPTIONS = [7, 14, 30];
 
 function formatNumber(value) {
   if (typeof value !== 'number' || Number.isNaN(value)) {
@@ -47,11 +48,23 @@ export default function AdminAnalyticsPage() {
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [lastUpdated, setLastUpdated] = useState(null);
+  const [rangeDays, setRangeDays] = useState(DEFAULT_RANGE_DAYS);
+  const [funnel, setFunnel] = useState(null);
+  const [funnelError, setFunnelError] = useState('');
+  const [isFunnelLoading, setIsFunnelLoading] = useState(false);
 
   const rawBase = typeof import.meta.env.VITE_API_URL === 'string' ? import.meta.env.VITE_API_URL : '';
   const sanitizedBase = rawBase.trim().replace(/\/+$/, '');
   const apiBase = sanitizedBase || '/api';
   const analyticsEndpoint = useMemo(() => `${apiBase}/analytics/flows`, [apiBase]);
+  const funnelEndpoint = useMemo(() => `${apiBase}/analytics/funnel`, [apiBase]);
+
+  const buildWindowRange = useCallback(() => {
+    const now = new Date();
+    const toIso = now.toISOString();
+    const fromIso = new Date(now.getTime() - rangeDays * DAY_MS).toISOString();
+    return { fromIso, toIso };
+  }, [rangeDays]);
 
   const handleLogout = useCallback((options = {}) => {
     if (typeof window !== 'undefined') {
@@ -64,16 +77,19 @@ export default function AdminAnalyticsPage() {
     setToken('');
     setMetrics(null);
     setLastUpdated(null);
+    setFunnel(null);
     if (!options.preserveError) {
       setError('');
+      setFunnelError('');
     }
     if (!options.preserveForm) {
       setFormToken('');
     }
     setIsLoading(false);
+    setIsFunnelLoading(false);
   }, []);
 
-  const fetchAnalytics = useCallback(async (currentToken) => {
+  const fetchAnalytics = useCallback(async (currentToken, windowRange) => {
     if (!currentToken) {
       return;
     }
@@ -82,9 +98,8 @@ export default function AdminAnalyticsPage() {
     setError('');
 
     try {
-      const now = new Date();
-      const toIso = now.toISOString();
-      const fromIso = new Date(now.getTime() - RANGE_MS).toISOString();
+      const fromIso = windowRange?.fromIso ?? '';
+      const toIso = windowRange?.toIso ?? '';
       const url = `${analyticsEndpoint}?from=${encodeURIComponent(fromIso)}&to=${encodeURIComponent(toIso)}`;
 
       const response = await fetch(url, {
@@ -124,10 +139,71 @@ export default function AdminAnalyticsPage() {
     }
   }, [analyticsEndpoint, handleLogout]);
 
+  const fetchFunnel = useCallback(async (currentToken, windowRange) => {
+    if (!currentToken) {
+      return;
+    }
+
+    setIsFunnelLoading(true);
+
+    try {
+      const fromIso = windowRange?.fromIso ?? '';
+      const toIso = windowRange?.toIso ?? '';
+      const url = `${funnelEndpoint}?from=${encodeURIComponent(fromIso)}&to=${encodeURIComponent(toIso)}`;
+
+      const response = await fetch(url, {
+        headers: {
+          Accept: 'application/json',
+          'X-Admin-Token': currentToken,
+        },
+      });
+
+      if (response.status === 401) {
+        setFunnelError('Token inválido');
+        handleLogout({ preserveError: true });
+        return;
+      }
+
+      const text = await response.text();
+      const json = text ? JSON.parse(text) : null;
+
+      if (!response.ok || !json) {
+        throw new Error('invalid_response');
+      }
+
+      setFunnel(json);
+      if (json.ok === false) {
+        setFunnelError('Sin datos / ventana vacía');
+      } else {
+        setFunnelError('');
+      }
+    } catch (err) {
+      console.error('[admin-analytics] fetch_funnel_failed', err);
+      setFunnel(null);
+      setFunnelError('No se pudo cargar el funnel. Intentá nuevamente.');
+    } finally {
+      setIsFunnelLoading(false);
+    }
+  }, [funnelEndpoint, handleLogout]);
+
+  const loadAll = useCallback(async () => {
+    if (!token) {
+      return;
+    }
+
+    const windowRange = buildWindowRange();
+    await Promise.all([
+      fetchAnalytics(token, windowRange),
+      fetchFunnel(token, windowRange),
+    ]);
+  }, [token, buildWindowRange, fetchAnalytics, fetchFunnel]);
+
   useEffect(() => {
     if (!token) {
       setMetrics(null);
       setLastUpdated(null);
+      setFunnel(null);
+      setFunnelError('');
       return undefined;
     }
 
@@ -140,7 +216,7 @@ export default function AdminAnalyticsPage() {
       }
       isFetching = true;
       try {
-        await fetchAnalytics(token);
+        await loadAll();
       } finally {
         isFetching = false;
       }
@@ -153,7 +229,7 @@ export default function AdminAnalyticsPage() {
       cancelled = true;
       window.clearInterval(intervalId);
     };
-  }, [token, fetchAnalytics]);
+  }, [token, loadAll]);
 
   const handleSubmit = (event) => {
     event.preventDefault();
@@ -176,9 +252,29 @@ export default function AdminAnalyticsPage() {
 
   const handleRefresh = useCallback(() => {
     if (token) {
-      fetchAnalytics(token);
+      loadAll();
     }
-  }, [token, fetchAnalytics]);
+  }, [token, loadAll]);
+
+  const handleRangeChange = (event) => {
+    const value = Number(event.target.value);
+    if (Number.isNaN(value) || value === rangeDays) {
+      return;
+    }
+    setRangeDays(value);
+    setFunnel(null);
+    setFunnelError('');
+  };
+
+  const handleRetryFunnel = useCallback(() => {
+    if (!token) {
+      return;
+    }
+    const windowRange = buildWindowRange();
+    setFunnelError('');
+    setFunnel(null);
+    fetchFunnel(token, windowRange);
+  }, [token, buildWindowRange, fetchFunnel]);
 
   const totals = metrics?.ok ? metrics.totals : null;
   const topDesigns = metrics?.ok && Array.isArray(metrics.topDesigns) ? metrics.topDesigns : [];
@@ -186,6 +282,9 @@ export default function AdminAnalyticsPage() {
   const windowTo = metrics?.ok ? formatWindowDate(metrics.window?.to) : '';
   const isAwaitingMetrics = token && metrics === null;
   const showLoadingState = (isLoading || isAwaitingMetrics) && !error;
+  const showFunnelSkeleton = funnel === null && !funnelError;
+  const funnelStages = funnel?.ok ? funnel.stages ?? {} : {};
+  const funnelCta = funnel?.ok ? funnel.cta ?? {} : {};
 
   if (!token) {
     return (
@@ -236,6 +335,24 @@ export default function AdminAnalyticsPage() {
         </div>
       </div>
 
+      <div className={styles.filtersRow}>
+        <label className={styles.rangeLabel} htmlFor="admin-analytics-range">
+          Rango de fechas
+          <select
+            id="admin-analytics-range"
+            className={styles.rangeSelect}
+            value={rangeDays}
+            onChange={handleRangeChange}
+          >
+            {RANGE_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                Últimos {option} días
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
       {error && <p className={styles.error}>{error}</p>}
       {showLoadingState && <p className={styles.status}>Cargando métricas…</p>}
 
@@ -263,6 +380,104 @@ export default function AdminAnalyticsPage() {
         {lastUpdated && <span>Última actualización: {lastUpdated.toLocaleString()}</span>}
         {windowFrom && windowTo && <span>Ventana: {windowFrom} → {windowTo}</span>}
       </div>
+
+      <section className={styles.funnelSection}>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>Funnel</h2>
+          <span className={styles.sectionSubtitle}>/mockup → opciones → clic → compra</span>
+        </div>
+
+        {showFunnelSkeleton && <p className={styles.status}>Cargando funnel…</p>}
+
+        {funnelError && (
+          <div className={styles.inlineError}>
+            <span>{funnelError}</span>
+            <button
+              type="button"
+              className={styles.secondaryButton}
+              onClick={handleRetryFunnel}
+              disabled={isFunnelLoading}
+            >
+              Reintentar
+            </button>
+          </div>
+        )}
+
+        {funnel?.ok && (
+          <>
+            <div className={styles.cards}>
+              {[{
+                key: 'view',
+                label: 'View',
+                value: formatNumber(funnelStages?.view?.rids ?? 0),
+                subtitle: null,
+              }, {
+                key: 'continue',
+                label: 'Continue',
+                value: formatNumber(funnelStages?.continue?.rids ?? 0),
+                subtitle: `Conversión desde View: ${formatPercentage(funnelStages?.continue?.rate_from_view ?? 0)}`,
+              }, {
+                key: 'options',
+                label: 'Options',
+                value: formatNumber(funnelStages?.options?.rids ?? 0),
+                subtitle: `Conversión desde Continue: ${formatPercentage(funnelStages?.options?.rate_from_continue ?? 0)}`,
+              }, {
+                key: 'clicks',
+                label: 'Clicks',
+                value: formatNumber(funnelStages?.clicks?.rids ?? 0),
+                subtitle: `Conversión desde Options: ${formatPercentage(funnelStages?.clicks?.rate_from_options ?? 0)}`,
+              }, {
+                key: 'purchase',
+                label: 'Purchase',
+                value: formatNumber(funnelStages?.purchase?.rids ?? 0),
+                subtitle: `Conversión desde Clicks: ${formatPercentage(funnelStages?.purchase?.rate_from_clicks ?? 0)}`,
+              }].map(({ key, label, value, subtitle }) => (
+                <article key={key} className={styles.card}>
+                  <span className={styles.cardTitle}>{label}</span>
+                  <p className={styles.cardMetric}>{value}</p>
+                  {subtitle && <span className={styles.cardSubmetric}>{subtitle}</span>}
+                </article>
+              ))}
+            </div>
+
+            <div className={styles.tableWrapper}>
+              <h3 className={styles.sectionTitle}>CTA</h3>
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th>Tipo</th>
+                    <th>Clicks</th>
+                    <th>Compradores</th>
+                    <th>Conversión</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[{
+                    key: 'public',
+                    label: 'Public',
+                    data: funnelCta.public,
+                  }, {
+                    key: 'private',
+                    label: 'Private',
+                    data: funnelCta.private,
+                  }, {
+                    key: 'cart',
+                    label: 'Cart',
+                    data: funnelCta.cart,
+                  }].map(({ key, label, data }) => (
+                    <tr key={key}>
+                      <td>{label}</td>
+                      <td>{formatNumber(data?.clicks ?? 0)}</td>
+                      <td>{formatNumber(data?.purchasers ?? 0)}</td>
+                      <td>{formatPercentage(data?.rate ?? 0)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </section>
 
       <section className={styles.tableWrapper}>
         <h2 className={styles.sectionTitle}>Top diseños (clicks)</h2>

--- a/mgm-front/src/pages/AdminAnalytics.module.css
+++ b/mgm-front/src/pages/AdminAnalytics.module.css
@@ -15,6 +15,13 @@
   gap: 1rem;
 }
 
+.filtersRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+}
+
 .title {
   font-size: 1.75rem;
   font-weight: 600;
@@ -43,6 +50,22 @@
 
 .secondaryButton:hover:not(:disabled) {
   background: #353535;
+}
+
+.rangeLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: #d1d5db;
+}
+
+.rangeSelect {
+  border-radius: 10px;
+  border: 1px solid #3a3a3a;
+  padding: 0.5rem 0.75rem;
+  background: #151515;
+  color: #f5f5f5;
 }
 
 .status {
@@ -94,6 +117,35 @@
   font-size: 1.25rem;
   font-weight: 600;
   margin: 0;
+}
+
+.sectionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.sectionSubtitle {
+  font-size: 0.95rem;
+  color: #9ca3af;
+}
+
+.funnelSection {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  background: #202020;
+  border: 1px solid #2c2c2c;
+  border-radius: 16px;
+  padding: 1.5rem;
+}
+
+.inlineError {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  color: #ffb4b4;
 }
 
 .tableWrapper {
@@ -203,6 +255,11 @@
 @media (max-width: 600px) {
   .container {
     padding: 1.5rem 1rem 2rem;
+  }
+
+  .filtersRow {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .card {


### PR DESCRIPTION
## Summary
- add a date range selector that refreshes both flow and funnel analytics using the admin token header
- fetch and render the new funnel endpoint with stage cards, CTA table, and retry handling without breaking existing flows
- extend the admin analytics styles for the new filters and funnel section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e18acf3c4c83278c4c491a6fd52f4c