### PR TITLE
Fix production tracking pipeline

### DIFF
--- a/api/analytics/flows.ts
+++ b/api/analytics/flows.ts
@@ -7,9 +7,9 @@ import { applyLenientCors } from '../_lib/lenientCors.js';
 export const config = { maxDuration: 10 };
 
 const EVENT_NAMES = {
-  public: 'checkout_public_click',
-  private: 'checkout_private_click',
-  cart: 'add_to_cart_click',
+  public: 'cta_click_public',
+  private: 'cta_click_private',
+  cart: 'cta_click_cart',
   purchase: 'purchase_completed',
 } as const;
 
@@ -84,11 +84,11 @@ async function fetchRidSet(
   toIso: string,
 ): Promise<Set<string>> {
   const { data, error } = await supabase
-    .from('events')
+    .from('track_events')
     .select('rid')
     .eq('event_name', eventName)
-    .gte('ts', fromIso)
-    .lte('ts', toIso);
+    .gte('created_at', fromIso)
+    .lte('created_at', toIso);
 
   if (error) {
     throw error;
@@ -103,11 +103,11 @@ async function fetchTopDesigns(
   toIso: string,
 ): Promise<TopDesign[]> {
   const { data, error } = await supabase
-    .from('events')
+    .from('track_events')
     .select('design_slug')
     .in('event_name', CTA_EVENTS)
-    .gte('ts', fromIso)
-    .lte('ts', toIso)
+    .gte('created_at', fromIso)
+    .lte('created_at', toIso)
     .not('design_slug', 'is', null);
 
   if (error) {

--- a/api/analytics/funnel.ts
+++ b/api/analytics/funnel.ts
@@ -16,9 +16,9 @@ const EVENT_NAMES = {
   view: 'mockup_view',
   continue: 'continue_design',
   options: 'view_purchase_options',
-  publicClick: 'checkout_public_click',
-  privateClick: 'checkout_private_click',
-  cartClick: 'add_to_cart_click',
+  publicClick: 'cta_click_public',
+  privateClick: 'cta_click_private',
+  cartClick: 'cta_click_cart',
   purchase: 'purchase_completed',
 } as const;
 
@@ -89,11 +89,11 @@ async function fetchRidSet(
   toIso: string,
 ): Promise<Set<string>> {
   const { data, error } = await supabase
-    .from('events')
+    .from('track_events')
     .select('rid')
     .eq('event_name', eventName)
-    .gte('ts', fromIso)
-    .lte('ts', toIso);
+    .gte('created_at', fromIso)
+    .lte('created_at', toIso);
 
   if (error) {
     throw error;

--- a/api/analytics/last-events.ts
+++ b/api/analytics/last-events.ts
@@ -1,0 +1,89 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import getSupabaseAdmin from '../../lib/_lib/supabaseAdmin.js';
+import { createDiagId, logApiError } from '../_lib/diag.js';
+import { applyLenientCors } from '../_lib/lenientCors.js';
+
+export const config = { maxDuration: 10 };
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+type LastEventRow = {
+  rid: string | null;
+  event_name: string | null;
+  origin: string | null;
+  created_at: string | null;
+};
+
+function parseLimit(value: string | string[] | undefined): number {
+  if (Array.isArray(value)) {
+    return parseLimit(value[0]);
+  }
+  if (typeof value !== 'string') {
+    return DEFAULT_LIMIT;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(parsed, MAX_LIMIT);
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const diagId = createDiagId();
+  res.setHeader('X-Diag-Id', diagId);
+  applyLenientCors(req, res);
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.status(405).json({ ok: false, error: 'method_not_allowed', diagId });
+    return;
+  }
+
+  const expectedToken = process.env.ANALYTICS_ADMIN_TOKEN;
+  if (!expectedToken) {
+    res.status(200).json({ ok: false, error: 'missing_env', diagId });
+    return;
+  }
+
+  const rawToken = req.headers['x-admin-token'];
+  const providedToken = Array.isArray(rawToken) ? rawToken[0] : rawToken;
+  if (!providedToken || providedToken !== expectedToken) {
+    res.status(401).json({ ok: false, error: 'unauthorized', diagId });
+    return;
+  }
+
+  let supabase: SupabaseClient;
+  try {
+    supabase = getSupabaseAdmin();
+  } catch (error) {
+    logApiError('analytics-last-events', { diagId, step: 'init_supabase', error });
+    res.status(200).json({ ok: false, error: 'missing_env', diagId });
+    return;
+  }
+
+  const limit = parseLimit(req.query?.limit);
+
+  try {
+    const { data, error } = await supabase
+      .from('track_events')
+      .select('rid, event_name, origin, created_at')
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (error) {
+      throw error;
+    }
+
+    const events = Array.isArray(data) ? (data as LastEventRow[]) : [];
+    res.status(200).json({ ok: true, diagId, events });
+  } catch (error) {
+    logApiError('analytics-last-events', { diagId, step: 'fetch', error });
+    res.status(200).json({ ok: false, error: 'query_failed', diagId });
+  }
+}

--- a/lib/handlers/shopifyWebhook.js
+++ b/lib/handlers/shopifyWebhook.js
@@ -217,6 +217,28 @@ export default async function shopifyWebhook(req, res) {
       if (insertError) {
         throw insertError;
       }
+
+      try {
+        const trackInsert = {
+          event_name: 'purchase_completed',
+          rid,
+          design_slug: designSlug,
+          origin: shopDomain ? String(shopDomain) : null,
+          user_agent: userAgent,
+          referer: '',
+          diag_id: diagId,
+          created_at: new Date().toISOString(),
+        };
+        await client.from('track_events').insert(trackInsert);
+      } catch (trackErr) {
+        logger.warn('shopify-webhook track_events_insert_failed', {
+          diagId,
+          topic,
+          orderId: orderIdString,
+          ridFound: Boolean(rid),
+          err: trackErr,
+        });
+      }
     }
   } catch (err) {
     logger.error('shopify-webhook supabase_error', {

--- a/mgm-front/src/pages/Mockup.jsx
+++ b/mgm-front/src/pages/Mockup.jsx
@@ -236,6 +236,13 @@ export default function Mockup() {
     return generated;
   }
 
+  function debugTrackFire(eventName, ridValue) {
+    if (typeof window === 'undefined') return;
+    if ((window).__TRACK_DEBUG__ === true) {
+      console.debug('[track:fire]', { event: eventName, rid: ridValue });
+    }
+  }
+
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const resolvedRid = ensureRid();
@@ -253,6 +260,7 @@ export default function Mockup() {
       return;
     }
 
+    debugTrackFire('mockup_view', resolvedRid);
     trackEvent('mockup_view', {
       rid: resolvedRid,
       design_slug: designSlug,
@@ -289,6 +297,7 @@ export default function Mockup() {
       return;
     }
 
+    debugTrackFire('view_purchase_options', resolvedRid);
     trackEvent('view_purchase_options', {
       rid: resolvedRid,
       design_slug: designSlug,
@@ -1331,11 +1340,13 @@ export default function Mockup() {
               disabled={busy}
               className={`${styles.ctaButton} ${styles.ctaButtonPrimary}`}
               onClick={() => {
-                trackEvent('add_to_cart_click', {
+                debugTrackFire('cta_click_cart', rid);
+                trackEvent('cta_click_cart', {
                   rid,
                   design_slug: designSlug,
                   product_id: lastProductId,
                   variant_id: lastVariantId,
+                  cta: 'cart',
                 });
                 handle('cart');
               }}
@@ -1404,11 +1415,13 @@ export default function Mockup() {
           disabled={busy}
           className={styles.hiddenButton}
           onClick={() => {
-            trackEvent('checkout_private_click', {
+            debugTrackFire('cta_click_private', rid);
+            trackEvent('cta_click_private', {
               rid,
               design_slug: designSlug,
               product_id: lastProductId,
               variant_id: lastVariantId,
+              cta: 'private',
             });
             handle('private');
           }}
@@ -1507,11 +1520,13 @@ export default function Mockup() {
                 disabled={busy}
                 className={styles.modalPrimary}
                 onClick={() => {
-                  trackEvent('checkout_public_click', {
+                  debugTrackFire('cta_click_public', rid);
+                  trackEvent('cta_click_public', {
                     rid,
                     design_slug: designSlug,
                     product_id: lastProductId,
                     variant_id: lastVariantId,
+                    cta: 'public',
                   });
                   setBuyPromptOpen(false);
                   handle('checkout');
@@ -1524,11 +1539,13 @@ export default function Mockup() {
                 disabled={busy}
                 className={styles.modalSecondary}
                 onClick={() => {
-                  trackEvent('checkout_private_click', {
+                  debugTrackFire('cta_click_private', rid);
+                  trackEvent('cta_click_private', {
                     rid,
                     design_slug: designSlug,
                     product_id: lastProductId,
                     variant_id: lastVariantId,
+                    cta: 'private',
                   });
                   setBuyPromptOpen(false);
                   handle('private');


### PR DESCRIPTION
## Summary
- normalize and centralize strict origin allowlist logic so `/api/track` can log per-request CORS decisions
- harden `/api/track` to accept `sendBeacon` payloads, expose an `?echo=1` debugger, log dedupe/denials, and persist events into `track_events`
- wire analytics dashboards to the new events table, add `/api/analytics/last-events`, mirror purchase inserts into `track_events`, and expose debug tooling on the mockup funnel (including CTA renames)

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

## Manual verification
```sh
curl -i -X OPTIONS https://mgm-api.vercel.app/api/track \
  -H 'Origin: https://mgmgamers.store' \
  -H 'Access-Control-Request-Method: POST' \
  -H 'Access-Control-Request-Headers: content-type'

curl -i -X POST https://mgm-api.vercel.app/api/track?echo=1 \
  -H 'Origin: https://mgmgamers.store' \
  -H 'Content-Type: application/json' \
  --data '{"event_name":"mockup_view","rid":"RID_TEST_1"}'
```

> Unable to capture Vercel log screenshots from this environment; please run the commands above in production to gather the requested evidence.


------
https://chatgpt.com/codex/tasks/task_e_68e195792cbc8327af04f8dffe666103