### PR TITLE
Fix analytics tracking and frontend instrumentation

### DIFF
--- a/api/analytics/flows.ts
+++ b/api/analytics/flows.ts
@@ -2,59 +2,78 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import getSupabaseAdmin from '../../lib/_lib/supabaseAdmin.js';
 import { createDiagId, logApiError } from '../_lib/diag.js';
-import { applyLenientCors } from '../_lib/lenientCors.js';
+import { getAllowedOriginsFromEnv, resolveCorsDecision } from '../_lib/cors.ts';
 
 export const config = { maxDuration: 10 };
 
 const EVENT_NAMES = {
+  view: 'mockup_view',
+  options: 'view_purchase_options',
   public: 'cta_click_public',
   private: 'cta_click_private',
   cart: 'cta_click_cart',
   purchase: 'purchase_completed',
 } as const;
 
-const CTA_EVENTS = [EVENT_NAMES.public, EVENT_NAMES.private, EVENT_NAMES.cart];
-
-interface FlowTotals {
-  clicks: number;
-  purchasers: number;
-  rate: number;
-}
-
-interface TopDesign {
-  design_slug: string;
-  clicks: number;
-}
+const CTA_TYPES = new Set(['public', 'private', 'cart']);
+const ALL_EVENTS = Object.values(EVENT_NAMES);
 
 type DateLike = string | string[] | undefined;
 
-type EventRow = {
+type TrackEventRow = {
   rid: string | null;
-};
-
-type TopDesignRow = {
+  event_name: string | null;
+  cta_type: string | null;
   design_slug: string | null;
 };
+
+type CorsResult = {
+  decision: ReturnType<typeof resolveCorsDecision>;
+};
+
+function applyAnalyticsCors(req: VercelRequest, res: VercelResponse): CorsResult {
+  const originHeader =
+    typeof req.headers.origin === 'string' && req.headers.origin.trim().length > 0
+      ? req.headers.origin
+      : undefined;
+  const decision = resolveCorsDecision(originHeader, getAllowedOriginsFromEnv());
+
+  if (decision.allowed && decision.allowedOrigin) {
+    res.setHeader('Access-Control-Allow-Origin', decision.allowedOrigin);
+  }
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Admin-Token');
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+
+  return { decision };
+}
 
 function parseDateParam(raw: DateLike): Date | null {
   if (Array.isArray(raw)) {
     return parseDateParam(raw[0]);
   }
+
   if (typeof raw !== 'string' || !raw.trim()) {
     return null;
   }
+
   const parsed = new Date(raw);
   return Number.isNaN(parsed.valueOf()) ? null : parsed;
 }
 
-function formatRate(purchasers: number, clicks: number): number {
-  if (!clicks) {
-    return 0;
+function normalizeRid(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') {
+    return null;
   }
-  return Number(((purchasers / clicks) * 100).toFixed(2));
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
 }
 
 function intersectCount(a: Set<string>, b: Set<string>): number {
+  if (!a.size || !b.size) {
+    return 0;
+  }
   let total = 0;
   for (const value of a) {
     if (b.has(value)) {
@@ -64,98 +83,36 @@ function intersectCount(a: Set<string>, b: Set<string>): number {
   return total;
 }
 
-function asRidSet(rows: EventRow[] | null | undefined): Set<string> {
-  const result = new Set<string>();
-  if (!rows) {
-    return result;
+function formatRate(numerator: number, denominator: number): number {
+  if (!denominator) {
+    return 0;
   }
-  for (const row of rows) {
-    if (typeof row?.rid === 'string' && row.rid.trim()) {
-      result.add(row.rid);
-    }
-  }
-  return result;
+  return Number(((numerator / denominator) * 100).toFixed(2));
 }
 
-async function fetchRidSet(
-  supabase: SupabaseClient,
-  eventName: string,
-  fromIso: string,
-  toIso: string,
-): Promise<Set<string>> {
-  const { data, error } = await supabase
-    .from('track_events')
-    .select('rid')
-    .eq('event_name', eventName)
-    .gte('created_at', fromIso)
-    .lte('created_at', toIso);
-
-  if (error) {
-    throw error;
+function resolveCtaType(eventName: string | null | undefined, rawCta: string | null | undefined) {
+  const normalized = typeof rawCta === 'string' ? rawCta.trim().toLowerCase() : '';
+  if (normalized && CTA_TYPES.has(normalized)) {
+    return normalized;
   }
 
-  return asRidSet((data as EventRow[]) ?? []);
-}
-
-async function fetchTopDesigns(
-  supabase: SupabaseClient,
-  fromIso: string,
-  toIso: string,
-): Promise<TopDesign[]> {
-  const { data, error } = await supabase
-    .from('track_events')
-    .select('design_slug')
-    .in('event_name', CTA_EVENTS)
-    .gte('created_at', fromIso)
-    .lte('created_at', toIso)
-    .not('design_slug', 'is', null);
-
-  if (error) {
-    throw error;
-  }
-
-  const rows = Array.isArray(data) ? (data as TopDesignRow[]) : [];
-  if (!rows.length) {
-    return [];
-  }
-
-  const counters = new Map<string, number>();
-  for (const row of rows) {
-    if (typeof row?.design_slug === 'string' && row.design_slug.trim()) {
-      const current = counters.get(row.design_slug) ?? 0;
-      counters.set(row.design_slug, current + 1);
+  if (typeof eventName === 'string' && eventName.startsWith('cta_click_')) {
+    const suffix = eventName.replace('cta_click_', '').trim().toLowerCase();
+    if (CTA_TYPES.has(suffix)) {
+      return suffix;
     }
   }
 
-  return Array.from(counters.entries())
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 10)
-    .map(([design_slug, clicks]) => ({ design_slug, clicks }));
+  return null;
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const diagId = createDiagId();
   res.setHeader('X-Diag-Id', diagId);
-  applyLenientCors(req, res);
+  applyAnalyticsCors(req, res);
 
   if (req.method === 'OPTIONS') {
-    const requestedHeaders = req.headers['access-control-request-headers'];
-    if (requestedHeaders) {
-      const rawList = Array.isArray(requestedHeaders)
-        ? requestedHeaders.join(',')
-        : requestedHeaders;
-      const names = rawList
-        .split(',')
-        .map((name) => name.split(':')[0].trim().toLowerCase())
-        .filter(Boolean);
-      const headerSet = new Set(names);
-      headerSet.add('content-type');
-      headerSet.add('x-admin-token');
-      res.setHeader('Access-Control-Allow-Headers', Array.from(headerSet).join(', '));
-    } else {
-      res.setHeader('Access-Control-Allow-Headers', 'content-type, x-admin-token');
-    }
-    res.status(200).end();
+    res.status(204).end();
     return;
   }
 
@@ -164,11 +121,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return;
   }
 
+  const expectedToken = process.env.ADMIN_ANALYTICS_TOKEN;
+  if (!expectedToken) {
+    res.status(200).json({ ok: false, error: 'missing_env', diagId });
+    return;
+  }
+
   const rawTokenHeader = req.headers['x-admin-token'];
   const providedToken = Array.isArray(rawTokenHeader) ? rawTokenHeader[0] : rawTokenHeader;
-  const expectedToken = process.env.ANALYTICS_ADMIN_TOKEN;
-
-  if (!providedToken || !expectedToken || providedToken !== expectedToken) {
+  if (!providedToken || providedToken !== expectedToken) {
     res.status(401).json({ ok: false, error: 'unauthorized', diagId });
     return;
   }
@@ -176,19 +137,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   let supabase: SupabaseClient;
   try {
     supabase = getSupabaseAdmin();
-  } catch (err) {
-    logApiError('analytics-flows', { diagId, step: 'init_supabase', error: err });
+  } catch (error) {
+    logApiError('analytics-flows', { diagId, step: 'init_supabase', error });
     res.status(200).json({ ok: false, error: 'missing_env', diagId });
     return;
   }
 
-  const rawTo = parseDateParam(req.query?.to);
   const now = new Date();
-  const toDate = rawTo && !Number.isNaN(rawTo.valueOf()) ? rawTo : now;
-  const rawFrom = parseDateParam(req.query?.from);
-  const defaultFrom = new Date(toDate.getTime());
-  defaultFrom.setDate(defaultFrom.getDate() - 30);
-  let fromDate = rawFrom && !Number.isNaN(rawFrom.valueOf()) ? rawFrom : defaultFrom;
+  const toParam = parseDateParam(req.query?.to);
+  const toDate = toParam && !Number.isNaN(toParam.valueOf()) ? toParam : now;
+  const fromParam = parseDateParam(req.query?.from);
+  const defaultFrom = new Date(toDate.getTime() - 30 * 24 * 60 * 60 * 1000);
+  let fromDate = fromParam && !Number.isNaN(fromParam.valueOf()) ? fromParam : defaultFrom;
 
   if (fromDate > toDate) {
     fromDate = defaultFrom;
@@ -198,54 +158,124 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const toIso = toDate.toISOString();
 
   try {
-    const [publicRids, privateRids, cartRids, purchaseRids] = await Promise.all([
-      fetchRidSet(supabase, EVENT_NAMES.public, fromIso, toIso),
-      fetchRidSet(supabase, EVENT_NAMES.private, fromIso, toIso),
-      fetchRidSet(supabase, EVENT_NAMES.cart, fromIso, toIso),
-      fetchRidSet(supabase, EVENT_NAMES.purchase, fromIso, toIso),
-    ]);
+    const { data, error } = await supabase
+      .from('track_events')
+      .select('rid, event_name, cta_type, design_slug')
+      .in('event_name', ALL_EVENTS)
+      .gte('created_at', fromIso)
+      .lte('created_at', toIso);
 
-    const publicPurchasers = intersectCount(publicRids, purchaseRids);
-    const privatePurchasers = intersectCount(privateRids, purchaseRids);
-    const cartPurchasers = intersectCount(cartRids, purchaseRids);
+    if (error) {
+      throw error;
+    }
 
-    const totals: Record<'public' | 'private' | 'cart', FlowTotals> = {
+    const rows = Array.isArray(data) ? (data as TrackEventRow[]) : [];
+
+    const viewSet = new Set<string>();
+    const optionsSet = new Set<string>();
+    const purchaseSet = new Set<string>();
+    const clickSet = new Set<string>();
+    const ctaSets: Record<'public' | 'private' | 'cart', Set<string>> = {
+      public: new Set<string>(),
+      private: new Set<string>(),
+      cart: new Set<string>(),
+    };
+    const designCounters = new Map<string, number>();
+
+    for (const row of rows) {
+      const rid = normalizeRid(row?.rid);
+      if (!rid) {
+        continue;
+      }
+
+      const eventName = row?.event_name ?? '';
+      if (eventName === EVENT_NAMES.view) {
+        viewSet.add(rid);
+      } else if (eventName === EVENT_NAMES.options) {
+        optionsSet.add(rid);
+      } else if (eventName === EVENT_NAMES.purchase) {
+        purchaseSet.add(rid);
+      } else if (
+        eventName === EVENT_NAMES.public
+        || eventName === EVENT_NAMES.private
+        || eventName === EVENT_NAMES.cart
+      ) {
+        clickSet.add(rid);
+        const ctaType = resolveCtaType(eventName, row?.cta_type ?? null);
+        if (ctaType && ctaSets[ctaType as 'public' | 'private' | 'cart']) {
+          ctaSets[ctaType as 'public' | 'private' | 'cart'].add(rid);
+        }
+        const designSlug = normalizeRid(row?.design_slug);
+        if (designSlug) {
+          designCounters.set(designSlug, (designCounters.get(designSlug) ?? 0) + 1);
+        }
+      }
+    }
+
+    const viewToOptions = intersectCount(viewSet, optionsSet);
+    const optionsToClicks = intersectCount(optionsSet, clickSet);
+    const clicksToPurchase = intersectCount(clickSet, purchaseSet);
+    const viewToPurchase = intersectCount(viewSet, purchaseSet);
+
+    const totals = {
+      view: viewSet.size,
+      options: optionsSet.size,
+      clicks: clickSet.size,
+      purchase: purchaseSet.size,
+      view_to_options: viewToOptions,
+      options_to_clicks: optionsToClicks,
+      clicks_to_purchase: clicksToPurchase,
+      view_to_purchase: viewToPurchase,
+    };
+
+    const rates = {
+      view_to_options: formatRate(viewToOptions, viewSet.size),
+      options_to_clicks: formatRate(optionsToClicks, optionsSet.size),
+      clicks_to_purchase: formatRate(clicksToPurchase, clickSet.size),
+      view_to_purchase: formatRate(viewToPurchase, viewSet.size),
+    };
+
+    const publicPurchases = intersectCount(ctaSets.public, purchaseSet);
+    const privatePurchases = intersectCount(ctaSets.private, purchaseSet);
+    const cartPurchases = intersectCount(ctaSets.cart, purchaseSet);
+
+    const ctas = {
       public: {
-        clicks: publicRids.size,
-        purchasers: publicPurchasers,
-        rate: formatRate(publicPurchasers, publicRids.size),
+        clicks: ctaSets.public.size,
+        purchases: publicPurchases,
+        rate: formatRate(publicPurchases, ctaSets.public.size),
       },
       private: {
-        clicks: privateRids.size,
-        purchasers: privatePurchasers,
-        rate: formatRate(privatePurchasers, privateRids.size),
+        clicks: ctaSets.private.size,
+        purchases: privatePurchases,
+        rate: formatRate(privatePurchases, ctaSets.private.size),
       },
       cart: {
-        clicks: cartRids.size,
-        purchasers: cartPurchasers,
-        rate: formatRate(cartPurchasers, cartRids.size),
+        clicks: ctaSets.cart.size,
+        purchases: cartPurchases,
+        rate: formatRate(cartPurchases, ctaSets.cart.size),
       },
     };
 
-    let topDesigns: TopDesign[] = [];
-    try {
-      topDesigns = await fetchTopDesigns(supabase, fromIso, toIso);
-    } catch (err) {
-      logApiError('analytics-flows', { diagId, step: 'top_designs', error: err });
-    }
+    const topDesigns = Array.from(designCounters.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([design_slug, clicks]) => ({ design_slug, clicks }));
+
+    console.log('[analytics-flows]', { diagId });
 
     res.status(200).json({
       ok: true,
-      window: {
-        from: fromIso,
-        to: toIso,
-      },
-      totals,
-      topDesigns,
       diagId,
+      from: fromIso,
+      to: toIso,
+      totals,
+      rates,
+      ctas,
+      topDesigns,
     });
-  } catch (err) {
-    logApiError('analytics-flows', { diagId, step: 'query', error: err });
+  } catch (error) {
+    logApiError('analytics-flows', { diagId, step: 'query', error });
     res.status(200).json({ ok: false, error: 'analytics_failed', diagId });
   }
 }

--- a/api/analytics/last-events.ts
+++ b/api/analytics/last-events.ts
@@ -2,7 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import getSupabaseAdmin from '../../lib/_lib/supabaseAdmin.js';
 import { createDiagId, logApiError } from '../_lib/diag.js';
-import { applyLenientCors } from '../_lib/lenientCors.js';
+import { getAllowedOriginsFromEnv, resolveCorsDecision } from '../_lib/cors.ts';
 
 export const config = { maxDuration: 10 };
 
@@ -33,10 +33,22 @@ function parseLimit(value: string | string[] | undefined): number {
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const diagId = createDiagId();
   res.setHeader('X-Diag-Id', diagId);
-  applyLenientCors(req, res);
+  const originHeader =
+    typeof req.headers.origin === 'string' && req.headers.origin.trim().length > 0
+      ? req.headers.origin
+      : undefined;
+  const decision = resolveCorsDecision(originHeader, getAllowedOriginsFromEnv());
+
+  if (decision.allowed && decision.allowedOrigin) {
+    res.setHeader('Access-Control-Allow-Origin', decision.allowedOrigin);
+  }
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Admin-Token');
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
 
   if (req.method === 'OPTIONS') {
-    res.status(200).end();
+    res.status(204).end();
     return;
   }
 
@@ -45,7 +57,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return;
   }
 
-  const expectedToken = process.env.ANALYTICS_ADMIN_TOKEN;
+  const expectedToken = process.env.ADMIN_ANALYTICS_TOKEN;
   if (!expectedToken) {
     res.status(200).json({ ok: false, error: 'missing_env', diagId });
     return;

--- a/lib/handlers/shopifyWebhook.js
+++ b/lib/handlers/shopifyWebhook.js
@@ -67,12 +67,36 @@ function findInLineItemProperties(lineItems, key) {
   return null;
 }
 
+function findInCustomAttributes(collection, key) {
+  if (!Array.isArray(collection)) return null;
+  const target = String(key || '').toLowerCase();
+  for (const entry of collection) {
+    if (!entry || typeof entry !== 'object') continue;
+    const name = typeof entry.key === 'string' ? entry.key.toLowerCase() : typeof entry.name === 'string' ? entry.name.toLowerCase() : '';
+    if (name === target) {
+      const value = 'value' in entry ? entry.value : undefined;
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed) return trimmed;
+      }
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return String(value);
+      }
+    }
+  }
+  return null;
+}
+
 function extractRid(order) {
   const fromLineItem = findInLineItemProperties(order?.line_items, 'rid');
   if (fromLineItem) return fromLineItem;
 
   const fromNotes = findAttribute(order?.note_attributes, 'rid');
   if (fromNotes) return fromNotes;
+
+  const fromCustomAttrs = findInCustomAttributes(order?.customAttributes || order?.custom_attributes, 'rid')
+    || findInCustomAttributes(order?.checkout?.customAttributes, 'rid');
+  if (fromCustomAttrs) return fromCustomAttrs;
 
   const note = typeof order?.note === 'string' ? order.note : '';
   if (note) {
@@ -88,6 +112,21 @@ function extractDesignSlug(order) {
   const fromLineItem = findInLineItemProperties(order?.line_items, 'design_slug');
   if (fromLineItem) return fromLineItem;
   return findAttribute(order?.note_attributes, 'design_slug');
+}
+
+function extractProductHandle(order) {
+  const fromLineItem = findInLineItemProperties(order?.line_items, 'product_handle');
+  if (fromLineItem) return fromLineItem;
+  const fromNotes = findAttribute(order?.note_attributes, 'product_handle');
+  if (fromNotes) return fromNotes;
+  const firstLineItem = Array.isArray(order?.line_items) && order.line_items.length ? order.line_items[0] : null;
+  if (firstLineItem && typeof firstLineItem.handle === 'string' && firstLineItem.handle.trim()) {
+    return firstLineItem.handle.trim();
+  }
+  const fromCustomAttrs = findInCustomAttributes(order?.customAttributes || order?.custom_attributes, 'product_handle')
+    || findInCustomAttributes(order?.checkout?.customAttributes, 'product_handle');
+  if (fromCustomAttrs) return fromCustomAttrs;
+  return null;
 }
 
 function safeCompare(expected, received) {
@@ -154,6 +193,7 @@ export default async function shopifyWebhook(req, res) {
   const orderIdString = orderId == null ? null : String(orderId);
   const rid = extractRid(payload);
   const designSlug = extractDesignSlug(payload);
+  const productHandle = extractProductHandle(payload);
 
   logger.info('shopify-webhook received', {
     diagId,
@@ -223,13 +263,29 @@ export default async function shopifyWebhook(req, res) {
           event_name: 'purchase_completed',
           rid,
           design_slug: designSlug,
+          product_handle: productHandle,
           origin: shopDomain ? String(shopDomain) : null,
           user_agent: userAgent,
           referer: '',
+          ip:
+            typeof req.headers['x-forwarded-for'] === 'string'
+              ? req.headers['x-forwarded-for'].split(',')[0].trim()
+              : null,
           diag_id: diagId,
-          created_at: new Date().toISOString(),
+          created_at: new Date(Math.floor(Date.now() / 1000) * 1000).toISOString(),
+          extra: {
+            order_id: orderIdString,
+            topic,
+            amount,
+            currency,
+            line_items_count: lineItemsCount,
+            product_handle: productHandle,
+          },
         };
-        await client.from('track_events').insert(trackInsert);
+        const { error: trackError } = await client.from('track_events').insert(trackInsert);
+        if (trackError && trackError.code !== '23505') {
+          throw trackError;
+        }
       } catch (trackErr) {
         logger.warn('shopify-webhook track_events_insert_failed', {
           diagId,
@@ -258,6 +314,10 @@ export default async function shopifyWebhook(req, res) {
     orderId: orderIdString,
     ridFound: Boolean(rid),
   });
+
+  try {
+    console.log('[webhook]', { diagId, rid: rid || null });
+  } catch {}
 
   res.status(200).json({ ok: true });
 }

--- a/mgm-front/README.md
+++ b/mgm-front/README.md
@@ -7,10 +7,11 @@ This template provides a minimal setup to get React working in Vite with HMR and
 Antes de iniciar el entorno de desarrollo crea un archivo `.env.local` con:
 
 ```
-VITE_API_URL=URL_de_tu_API
+VITE_API_BASE=URL_de_tu_API
 VITE_SUPABASE_URL=URL_de_tu_proyecto_Supabase
 VITE_SUPABASE_ANON_KEY=clave_anon_de_Supabase
 VITE_BUSQUEDA_PASSWORD=contraseña_para_el_buscador
+VITE_ADMIN_ANALYTICS_TOKEN=token_para_panel_admin
 ```
 
 Luego ejecuta `npm run dev` para iniciar el frontend.

--- a/mgm-front/src/lib/api.js
+++ b/mgm-front/src/lib/api.js
@@ -1,6 +1,10 @@
 ﻿import logger from './logger';
 
-const RAW_API_URL = typeof import.meta.env.VITE_API_URL === 'string' ? import.meta.env.VITE_API_URL : '';
+const RAW_API_URL = typeof import.meta.env.VITE_API_BASE === 'string'
+  ? import.meta.env.VITE_API_BASE
+  : typeof import.meta.env.VITE_API_URL === 'string'
+    ? import.meta.env.VITE_API_URL
+    : '';
 const USE_PROXY = (import.meta.env.VITE_USE_PROXY || '').trim() === '1';
 const IS_DEV = Boolean(import.meta.env && import.meta.env.DEV);
 
@@ -42,7 +46,7 @@ function resolveRequestUrl(path) {
       hasWarnedAboutFallback = true;
       try {
         logger.warn?.('[api] using_default_base', {
-          message: 'VITE_API_URL not set; defaulting to same-origin.',
+          message: 'VITE_API_BASE not set; defaulting to same-origin.',
         });
       } catch {}
     }

--- a/mgm-front/src/lib/api.ts
+++ b/mgm-front/src/lib/api.ts
@@ -1,6 +1,10 @@
 ﻿import logger from './logger';
 
-const RAW_API_URL = typeof import.meta.env.VITE_API_URL === 'string' ? import.meta.env.VITE_API_URL : '';
+const RAW_API_URL = typeof import.meta.env.VITE_API_BASE === 'string'
+  ? import.meta.env.VITE_API_BASE
+  : typeof import.meta.env.VITE_API_URL === 'string'
+    ? import.meta.env.VITE_API_URL
+    : '';
 const USE_PROXY = (import.meta.env.VITE_USE_PROXY || '').trim() === '1';
 const IS_DEV = Boolean(import.meta.env && import.meta.env.DEV);
 
@@ -42,7 +46,7 @@ function resolveRequestUrl(path: string): string {
       hasWarnedAboutFallback = true;
       try {
         logger.warn?.('[api] using_default_base', {
-          message: 'VITE_API_URL not set; defaulting to same-origin.',
+          message: 'VITE_API_BASE not set; defaulting to same-origin.',
         });
       } catch {}
     }

--- a/mgm-front/src/lib/shopify.ts
+++ b/mgm-front/src/lib/shopify.ts
@@ -691,7 +691,7 @@ export async function createJobAndProduct(
             err.friendlyMessage = 'No pudimos generar el checkout privado, probá de nuevo.';
           }
           if (reason === 'private_checkout_missing_api_url') {
-            err.friendlyMessage = 'Configurá VITE_API_URL para conectar con la API.';
+            err.friendlyMessage = 'Configurá VITE_API_BASE para conectar con la API.';
           }
           if (!err.detail && typeof rawBody === 'string' && rawBody) {
             err.detail = rawBody.slice(0, 200);

--- a/mgm-front/src/lib/tracking.ts
+++ b/mgm-front/src/lib/tracking.ts
@@ -1,6 +1,12 @@
-const API = (import.meta.env.VITE_API_URL || '').replace(/\/$/, '');
-const TRACK_URL = API ? `${API}/track` : '';
-const DEDUP_WINDOW_MS = 1500;
+const RAW_API_BASE = typeof import.meta.env.VITE_API_BASE === 'string'
+  ? import.meta.env.VITE_API_BASE
+  : typeof import.meta.env.VITE_API_URL === 'string'
+    ? import.meta.env.VITE_API_URL
+    : '';
+
+const API_BASE = RAW_API_BASE.trim().replace(/\/+$/, '');
+const TRACK_ENDPOINT = API_BASE ? `${API_BASE}/track` : '/api/track';
+const DEDUPE_WINDOW_MS = 1500;
 const recentEvents = new Map<string, number>();
 
 function resolveTrackingEnabled(): boolean {
@@ -14,6 +20,18 @@ function resolveTrackingEnabled(): boolean {
 
 const isTrackingEnabled = resolveTrackingEnabled();
 
+function resolveDebugEnabled(): boolean {
+  if (typeof window !== 'undefined' && (window as any).__TRACK_DEBUG__ === true) {
+    return true;
+  }
+  const raw = import.meta.env?.VITE_TRACKING_DEBUG;
+  if (raw == null) {
+    return false;
+  }
+  const normalized = String(raw).trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
 function toOptionalString(value: unknown): string | undefined {
   if (typeof value === 'string') {
     const trimmed = value.trim();
@@ -25,54 +43,174 @@ function toOptionalString(value: unknown): string | undefined {
   return undefined;
 }
 
+function generateRidSuffix(length = 12): string {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const targetLength = Number.isFinite(length) && length > 0 ? Math.floor(length) : 12;
+  if (typeof window !== 'undefined' && window.crypto && typeof window.crypto.getRandomValues === 'function') {
+    const buffer = new Uint32Array(targetLength);
+    window.crypto.getRandomValues(buffer);
+    let output = '';
+    for (const value of buffer) {
+      output += alphabet[value % alphabet.length];
+    }
+    return output;
+  }
+  let output = '';
+  for (let index = 0; index < targetLength; index += 1) {
+    const randomIndex = Math.floor(Math.random() * alphabet.length);
+    output += alphabet[randomIndex];
+  }
+  return output;
+}
+
+export function ensureTrackingRid(): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const globalRid = typeof (window as any).__RID === 'string' ? (window as any).__RID.trim() : '';
+  if (globalRid) {
+    return globalRid;
+  }
+
+  try {
+    if (window.localStorage) {
+      const stored = window.localStorage.getItem('rid');
+      if (typeof stored === 'string') {
+        const trimmed = stored.trim();
+        if (trimmed) {
+          (window as any).__RID = trimmed;
+          return trimmed;
+        }
+      }
+    }
+  } catch {
+    // ignore storage errors
+  }
+
+  const suffixLength = 12 + Math.floor(Math.random() * 5);
+  const generated = `mgad${generateRidSuffix(suffixLength)}`;
+  (window as any).__RID = generated;
+  try {
+    if (window.localStorage) {
+      window.localStorage.setItem('rid', generated);
+    }
+  } catch {
+    // ignore storage write errors
+  }
+  return generated;
+}
+
+function buildExtraPayload(data: Record<string, any> | undefined) {
+  if (!data) {
+    return undefined;
+  }
+
+  const extra: Record<string, any> = {};
+  for (const [key, value] of Object.entries(data)) {
+    const lowered = key.toLowerCase();
+    if (
+      lowered === 'event'
+      || lowered === 'event_name'
+      || lowered === 'rid'
+      || lowered === 'design_slug'
+      || lowered === 'designslug'
+      || lowered === 'cta'
+      || lowered === 'cta_type'
+      || lowered === 'ctatype'
+      || lowered === 'product_handle'
+      || lowered === 'producthandle'
+      || lowered === 'extra'
+    ) {
+      continue;
+    }
+    extra[key] = value;
+  }
+
+  if (data.extra) {
+    if (typeof data.extra === 'string') {
+      try {
+        const parsed = JSON.parse(data.extra);
+        if (parsed && typeof parsed === 'object') {
+          Object.assign(extra, parsed as Record<string, any>);
+        }
+      } catch {
+        extra.extra = data.extra;
+      }
+    } else if (typeof data.extra === 'object') {
+      Object.assign(extra, data.extra);
+    }
+  }
+
+  return Object.keys(extra).length ? extra : undefined;
+}
+
 export function trackEvent(eventName: string, data?: Record<string, any>) {
   try {
     if (!eventName || typeof eventName !== 'string') return;
     if (!isTrackingEnabled) return;
     if (typeof window === 'undefined') return;
-    if (!TRACK_URL) return;
+    if (!TRACK_ENDPOINT) return;
 
-    const ridCandidate = data?.rid ?? (window as any)?.__RID;
+    const ridCandidate = data?.rid ?? ensureTrackingRid();
     const rid = toOptionalString(ridCandidate);
-    const dedupKey = `${eventName}|${rid ?? ''}`;
+    const dedupeKey = `${eventName}|${rid ?? ''}`;
     const now = Date.now();
-    const lastTimestamp = recentEvents.get(dedupKey);
-    if (lastTimestamp && now - lastTimestamp < DEDUP_WINDOW_MS) {
+    const lastTimestamp = recentEvents.get(dedupeKey);
+    if (lastTimestamp && now - lastTimestamp < DEDUPE_WINDOW_MS) {
       return;
     }
-    recentEvents.set(dedupKey, now);
+    recentEvents.set(dedupeKey, now);
     for (const [key, timestamp] of Array.from(recentEvents.entries())) {
-      if (now - timestamp > DEDUP_WINDOW_MS) {
+      if (now - timestamp > DEDUPE_WINDOW_MS) {
         recentEvents.delete(key);
       }
     }
 
+    const designSlug = toOptionalString(data?.design_slug ?? (data as any)?.designSlug);
+    const productHandle = toOptionalString(data?.product_handle ?? (data as any)?.productHandle);
+    const rawCta = toOptionalString(data?.cta_type ?? (data as any)?.ctaType ?? data?.cta);
+    let ctaType = rawCta;
+    if (!ctaType && eventName.startsWith('cta_click_')) {
+      ctaType = eventName.replace('cta_click_', '');
+    }
+
     const payload = {
+      event: eventName,
       event_name: eventName,
       rid,
-      design_slug: toOptionalString(data?.design_slug) ?? undefined,
-      product_id: toOptionalString(data?.product_id) ?? undefined,
-      variant_id: toOptionalString(data?.variant_id) ?? undefined,
-      cta: toOptionalString(data?.cta) ?? undefined,
-      amount: data?.amount ?? undefined,
-      currency: data?.currency ?? undefined,
-      order_id: data?.order_id ?? undefined,
+      cta_type: ctaType,
+      design_slug: designSlug,
+      product_handle: productHandle,
+      extra: buildExtraPayload(data),
       origin: typeof location !== 'undefined' && location ? location.origin : undefined,
-      details: data?.details ?? undefined,
     };
 
-    const debugEnabled = Boolean((window as any)?.__TRACK_DEBUG__ === true);
-    const endpoint = debugEnabled && TRACK_URL ? `${TRACK_URL}?echo=1` : TRACK_URL;
-    if (debugEnabled) {
-      console.debug('[track:fire]', { event: eventName, rid });
+    const debugEnabled = resolveDebugEnabled();
+    const endpoint = debugEnabled ? `${TRACK_ENDPOINT}?echo=1` : TRACK_ENDPOINT;
+
+    if (!debugEnabled && typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+      const params = new URLSearchParams();
+      for (const [key, value] of Object.entries(payload)) {
+        if (value == null) continue;
+        if (typeof value === 'object') {
+          try {
+            params.append(key, JSON.stringify(value));
+          } catch {
+            continue;
+          }
+        } else {
+          params.append(key, String(value));
+        }
+      }
+      const sent = navigator.sendBeacon(TRACK_ENDPOINT, params);
+      if (debugEnabled) {
+        console.debug('[track]', { event: eventName, rid, sent });
+      }
+      return;
     }
 
     const bodyJson = JSON.stringify(payload);
-    if (!debugEnabled && typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
-      const blob = new Blob([bodyJson], { type: 'application/json' });
-      navigator.sendBeacon(TRACK_URL, blob);
-      return;
-    }
     fetch(endpoint, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -81,17 +219,19 @@ export function trackEvent(eventName: string, data?: Record<string, any>) {
     })
       .then(async (response) => {
         if (!debugEnabled) return;
-        let json: any = null;
+        let diagId: string | null = null;
         try {
-          json = await response.clone().json();
+          const cloned = response.clone();
+          const json = await cloned.json();
+          diagId = json?.diagId ?? json?.diag_id ?? null;
         } catch {
-          json = null;
+          diagId = null;
         }
         console.debug('[track]', {
           event: eventName,
           rid,
           status: response.status,
-          json,
+          diagId,
         });
       })
       .catch((error) => {
@@ -104,6 +244,8 @@ export function trackEvent(eventName: string, data?: Record<string, any>) {
         });
       });
   } catch {
-    // ignore all tracking errors
+    // ignore tracking errors
   }
 }
+
+export default { trackEvent, ensureTrackingRid };


### PR DESCRIPTION
## Summary
- harden the tracking API and analytics endpoints to accept beacon payloads, require admin tokens, and compute funnel metrics from Supabase data
- log Shopify webhook purchases into track_events with product metadata while respecting the dedupe index
- update the frontend tracking helper, mockup page, and admin analytics UI to send the new events, persist RIDs, and expose recent tracking data

## Testing
- npm --prefix mgm-front run build

------
https://chatgpt.com/codex/tasks/task_e_68e1c164f8408327aa3a8cf7bc85ce18