### PR TITLE
Fix analytics endpoints CORS handling

### DIFF
--- a/api/analytics/_lib/cors.ts
+++ b/api/analytics/_lib/cors.ts
@@ -1,38 +1,38 @@
-import type { VercelRequest, VercelResponse } from '@vercel/node';
+import type { VercelRequest } from '@vercel/node';
 import { getAllowedOriginsFromEnv, resolveCorsDecision } from '../../_lib/cors.ts';
 
 const ALLOW_METHODS = 'GET,OPTIONS';
 const ALLOW_HEADERS = 'X-Admin-Token, Content-Type';
 
 export type AnalyticsCorsResult = {
-  decision: ReturnType<typeof resolveCorsDecision>;
+  origin: string | null;
+  headers: Record<string, string>;
+  isAllowed: boolean;
 };
 
-function resolveOriginHeader(req: VercelRequest): string | undefined {
-  const { origin } = req.headers;
-  if (typeof origin === 'string' && origin.trim().length > 0) {
-    return origin;
-  }
-  return undefined;
-}
+export function applyAnalyticsCors(req: VercelRequest): AnalyticsCorsResult {
+  const originHeader =
+    typeof req.headers.origin === 'string' && req.headers.origin.trim().length > 0
+      ? req.headers.origin
+      : undefined;
 
-export function applyAnalyticsCors(
-  req: VercelRequest,
-  res: VercelResponse,
-): AnalyticsCorsResult {
-  const originHeader = resolveOriginHeader(req);
   const decision = resolveCorsDecision(originHeader, getAllowedOriginsFromEnv());
-  const allowOrigin = decision.allowedOrigin ?? decision.requestedOrigin ?? null;
 
-  if (allowOrigin) {
-    res.setHeader('Access-Control-Allow-Origin', allowOrigin);
-  }
-  res.setHeader('Vary', 'Origin');
-  res.setHeader('Access-Control-Allow-Methods', ALLOW_METHODS);
-  res.setHeader('Access-Control-Allow-Headers', ALLOW_HEADERS);
-  if (!res.getHeader('Content-Type')) {
-    res.setHeader('Content-Type', 'application/json; charset=utf-8');
-  }
+  const resolvedOrigin = decision.allowed
+    ? decision.allowedOrigin ?? decision.requestedOrigin
+    : decision.requestedOrigin ?? decision.allowedOrigin;
 
-  return { decision };
+  const origin = resolvedOrigin ?? null;
+  const headers: Record<string, string> = {
+    'Access-Control-Allow-Origin': origin ?? 'null',
+    'Access-Control-Allow-Methods': ALLOW_METHODS,
+    'Access-Control-Allow-Headers': ALLOW_HEADERS,
+    Vary: 'Origin',
+  };
+
+  return {
+    origin,
+    headers,
+    isAllowed: decision.allowed,
+  };
 }

--- a/api/analytics/funnel.ts
+++ b/api/analytics/funnel.ts
@@ -84,63 +84,86 @@ function formatRate(numerator: number, denominator: number): number {
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const diagId = createDiagId();
   res.setHeader('X-Diag-Id', diagId);
-  const { decision } = applyAnalyticsCors(req, res);
+  const { origin, headers, isAllowed } = applyAnalyticsCors(req);
 
   if (req.method === 'OPTIONS') {
-    if (!decision.allowed) {
-      res.status(403).json({ ok: false, error: 'origin_not_allowed', diagId });
-      return;
-    }
-    res.status(204).end();
-    return;
+    return sendResponse(
+      res,
+      new Response(null, { status: isAllowed ? 204 : 403, headers }),
+    );
   }
 
   if (req.method !== 'GET') {
-    res.status(405).json({ ok: false, error: 'method_not_allowed', diagId });
-    return;
+    return sendResponse(
+      res,
+      Response.json(
+        { ok: false, error: 'method_not_allowed', diagId },
+        { status: 405, headers },
+      ),
+    );
   }
 
-  if (!decision.allowed) {
-    res.status(403).json({ ok: false, error: 'origin_not_allowed', diagId });
-    return;
+  if (!isAllowed) {
+    return sendResponse(
+      res,
+      Response.json(
+        { ok: false, error: 'forbidden_origin', diagId },
+        { status: 403, headers },
+      ),
+    );
   }
-
-  const expectedToken = process.env.ADMIN_ANALYTICS_TOKEN;
-  if (!expectedToken) {
-    res.status(200).json({ ok: false, error: 'missing_env', diagId });
-    return;
-  }
-
-  const rawTokenHeader = req.headers['x-admin-token'];
-  const providedToken = Array.isArray(rawTokenHeader) ? rawTokenHeader[0] : rawTokenHeader;
-  if (!providedToken || providedToken !== expectedToken) {
-    res.status(401).json({ ok: false, error: 'unauthorized', diagId });
-    return;
-  }
-
-  let supabase: SupabaseClient;
-  try {
-    supabase = getSupabaseAdmin();
-  } catch (error) {
-    logApiError('analytics-funnel', { diagId, step: 'init_supabase', error });
-    res.status(200).json({ ok: false, error: 'missing_env', diagId });
-    return;
-  }
-
-  const now = new Date();
-  const toParam = parseDateParam(req.query?.to);
-  const toDate = toParam && !Number.isNaN(toParam.valueOf()) ? toParam : now;
-  const fromParam = parseDateParam(req.query?.from);
-  const defaultFrom = new Date(toDate.getTime() - 30 * 24 * 60 * 60 * 1000);
-  let fromDate = fromParam && !Number.isNaN(fromParam.valueOf()) ? fromParam : defaultFrom;
-  if (fromDate > toDate) {
-    fromDate = defaultFrom;
-  }
-
-  const fromIso = fromDate.toISOString();
-  const toIso = toDate.toISOString();
 
   try {
+    const expectedToken = process.env.ADMIN_ANALYTICS_TOKEN;
+    if (!expectedToken) {
+      return sendResponse(
+        res,
+        Response.json(
+          { ok: false, error: 'missing_env', diagId },
+          { status: 200, headers },
+        ),
+      );
+    }
+
+    const rawTokenHeader = req.headers['x-admin-token'];
+    const providedToken = Array.isArray(rawTokenHeader) ? rawTokenHeader[0] : rawTokenHeader;
+    if (!providedToken || providedToken !== expectedToken) {
+      return sendResponse(
+        res,
+        Response.json(
+          { ok: false, error: 'unauthorized', diagId },
+          { status: 401, headers },
+        ),
+      );
+    }
+
+    let supabase: SupabaseClient;
+    try {
+      supabase = getSupabaseAdmin();
+    } catch (error) {
+      logApiError('analytics-funnel', { diagId, step: 'init_supabase', error });
+      return sendResponse(
+        res,
+        Response.json(
+          { ok: false, error: 'missing_env', diagId },
+          { status: 200, headers },
+        ),
+      );
+    }
+
+    const now = new Date();
+    const toParam = parseDateParam(req.query?.to);
+    const toDate = toParam && !Number.isNaN(toParam.valueOf()) ? toParam : now;
+    const fromParam = parseDateParam(req.query?.from);
+    const defaultFrom = new Date(toDate.getTime() - 30 * 24 * 60 * 60 * 1000);
+    let fromDate = fromParam && !Number.isNaN(fromParam.valueOf()) ? fromParam : defaultFrom;
+    if (fromDate > toDate) {
+      fromDate = defaultFrom;
+    }
+
+    const fromIso = fromDate.toISOString();
+    const toIso = toDate.toISOString();
+
     const { data, error } = await supabase
       .from('track_events')
       .select('rid, event_name, cta_type')
@@ -149,7 +172,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       .lte('created_at', toIso);
 
     if (error) {
-      throw error;
+      const queryError =
+        error instanceof Error
+          ? Object.assign(error, { step: 'query' as const })
+          : Object.assign(new Error(JSON.stringify(error)), { step: 'query' as const });
+      throw queryError;
     }
 
     const rows = Array.isArray(data) ? (data as TrackEventRow[]) : [];
@@ -258,20 +285,53 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       view_to_purchase: formatRate(viewToPurchase, viewSet.size),
     };
 
-    console.log('[analytics-funnel]', { diagId });
+    console.log('[analytics-funnel]', { diagId, origin });
 
-    res.status(200).json({
-      ok: true,
-      diagId,
-      from: fromIso,
-      to: toIso,
-      stages,
-      cta,
-      totals,
-      rates,
-    });
+    return sendResponse(
+      res,
+      Response.json(
+        {
+          ok: true,
+          diagId,
+          from: fromIso,
+          to: toIso,
+          stages,
+          cta,
+          totals,
+          rates,
+        },
+        { status: 200, headers },
+      ),
+    );
   } catch (error) {
-    logApiError('analytics-funnel', { diagId, step: 'query', error });
-    res.status(200).json({ ok: false, error: 'funnel_failed', diagId });
+    const step =
+      typeof error === 'object' && error && 'step' in error
+        ? String((error as { step: string }).step)
+        : 'unhandled';
+    logApiError('analytics-funnel', { diagId, step, error });
+    return sendResponse(
+      res,
+      Response.json(
+        { ok: false, error: String(error), diagId },
+        { status: 500, headers },
+      ),
+    );
+  }
+}
+
+async function sendResponse(res: VercelResponse, response: Response) {
+  res.status(response.status);
+  response.headers.forEach((value, key) => {
+    res.setHeader(key, value);
+  });
+  if (response.status === 204) {
+    res.end();
+    return;
+  }
+  const body = await response.text();
+  if (body.length > 0) {
+    res.send(body);
+  } else {
+    res.end();
   }
 }


### PR DESCRIPTION
## Summary
- add a reusable analytics CORS helper that normalizes the request origin and returns consistent headers
- update the flows, funnel, and last-events handlers to short-circuit OPTIONS, reject forbidden origins, and reuse the shared headers on every response
- wrap GET logic in try/catch so unexpected failures return 500 with diagnostics while preserving existing Supabase querying behaviour

## Testing
- not run

## Smoke Tests
```bash
curl -i -X OPTIONS 'https://mgm-api.vercel.app/api/analytics/flows' \
  -H 'Origin: https://mgm-app.vercel.app' \
  -H 'Access-Control-Request-Method: GET' \
  -H 'Access-Control-Request-Headers: X-Admin-Token, Content-Type'

curl -i 'https://mgm-api.vercel.app/api/analytics/flows' \
  -H 'Origin: https://mgm-app.vercel.app' \
  -H 'X-Admin-Token: <ADMIN_ANALYTICS_TOKEN>'

curl -i 'https://mgm-api.vercel.app/api/analytics/flows' \
  -H 'Origin: https://not-allowed.example' \
  -H 'X-Admin-Token: <ADMIN_ANALYTICS_TOKEN>'
```

------
https://chatgpt.com/codex/tasks/task_e_68e1fa6760dc8327b9690ba978f2d6cd