### PR TITLE
Ensure analytics endpoints expose CORS headers

### DIFF
--- a/api/analytics/_lib/cors.ts
+++ b/api/analytics/_lib/cors.ts
@@ -2,7 +2,7 @@ import type { VercelRequest } from '@vercel/node';
 import { getAllowedOriginsFromEnv, resolveCorsDecision } from '../../_lib/cors.ts';
 
 const ALLOW_METHODS = 'GET,OPTIONS';
-const ALLOW_HEADERS = 'X-Admin-Token, Content-Type';
+const ALLOW_HEADERS = 'X-Admin-Token, Content-Type, Accept';
 
 export type AnalyticsCorsResult = {
   origin: string | null;
@@ -27,6 +27,7 @@ export function applyAnalyticsCors(req: VercelRequest): AnalyticsCorsResult {
     'Access-Control-Allow-Origin': origin ?? 'null',
     'Access-Control-Allow-Methods': ALLOW_METHODS,
     'Access-Control-Allow-Headers': ALLOW_HEADERS,
+    'Access-Control-Expose-Headers': 'X-Diag-Id',
     Vary: 'Origin',
   };
 

--- a/api/analytics/flows.ts
+++ b/api/analytics/flows.ts
@@ -89,6 +89,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader('X-Diag-Id', diagId);
   const { origin, headers, isAllowed } = applyAnalyticsCors(req);
 
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === 'string') {
+      res.setHeader(key, value);
+    }
+  }
+
   if (req.method === 'OPTIONS') {
     return sendResponse(
       res,

--- a/api/analytics/funnel.ts
+++ b/api/analytics/funnel.ts
@@ -86,6 +86,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader('X-Diag-Id', diagId);
   const { origin, headers, isAllowed } = applyAnalyticsCors(req);
 
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === 'string') {
+      res.setHeader(key, value);
+    }
+  }
+
   if (req.method === 'OPTIONS') {
     return sendResponse(
       res,

--- a/api/analytics/last-events.ts
+++ b/api/analytics/last-events.ts
@@ -35,6 +35,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader('X-Diag-Id', diagId);
   const { origin, headers, isAllowed } = applyAnalyticsCors(req);
 
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === 'string') {
+      res.setHeader(key, value);
+    }
+  }
+
   if (req.method === 'OPTIONS') {
     return sendResponse(
       res,


### PR DESCRIPTION
## Summary
- expose the X-Diag-Id header and allow Accept in the analytics CORS helper
- eagerly set the computed CORS headers on each analytics handler before processing the request

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2ff1cc0888327b49d511cf651729b