### PR TITLE
Allow analytics CORS when allowlist empty

### DIFF
--- a/api/analytics/flows.ts
+++ b/api/analytics/flows.ts
@@ -89,6 +89,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader('X-Diag-Id', diagId);
   const { origin, headers, isAllowed } = applyAnalyticsCors(req);
 
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === 'string') {
+      res.setHeader(key, value);
+    }
+  }
+
   if (req.method === 'OPTIONS') {
     return sendResponse(
       res,

--- a/api/analytics/funnel.ts
+++ b/api/analytics/funnel.ts
@@ -86,6 +86,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader('X-Diag-Id', diagId);
   const { origin, headers, isAllowed } = applyAnalyticsCors(req);
 
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === 'string') {
+      res.setHeader(key, value);
+    }
+  }
+
   if (req.method === 'OPTIONS') {
     return sendResponse(
       res,

--- a/api/analytics/last-events.ts
+++ b/api/analytics/last-events.ts
@@ -35,6 +35,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader('X-Diag-Id', diagId);
   const { origin, headers, isAllowed } = applyAnalyticsCors(req);
 
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === 'string') {
+      res.setHeader(key, value);
+    }
+  }
+
   if (req.method === 'OPTIONS') {
     return sendResponse(
       res,


### PR DESCRIPTION
## Summary
- treat an empty analytics CORS allow list as permissive and return `*`
- keep the existing header set so preflight responses still expose diagnostics

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2ff1cc0888327b49d511cf651729b