### PR TITLE
Add preview payload size guard for image moderation API

### DIFF
--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -3,6 +3,8 @@ import { pHashFromGray, hamming } from '../hashing.js';
 import { hateTextCheck } from '../moderation/hate.js';
 import logger from '../_lib/logger.js';
 
+const PREVIEW_LIMIT_BYTES = Number(process.env.MOD_PREVIEW_LIMIT_BYTES ?? 4_000_000);
+
 const SKIP_OCR = process.env.MODERATION_SKIP_OCR === '1';
 
 const clamp = (value, min = 0, max = 1) => Math.max(min, Math.min(max, value));
@@ -718,12 +720,38 @@ export default async function moderateImage(req, res) {
       return res.status(400).json({ ok: false, reason: 'invalid_body' });
     }
 
+    const isPreview = req?.query?.preview === '1' || req?.headers?.['x-preview'] === '1';
+
     let buffer = null;
+    let previewBytes = null;
     const filename = data?.filename || '';
     const designName = data?.designName || '';
-    if (data?.dataUrl) buffer = toBufferFromDataUrl(data.dataUrl);
-    if (!buffer && data?.imageBase64) buffer = Buffer.from(data.imageBase64, 'base64');
+    if (data?.dataUrl) {
+      buffer = toBufferFromDataUrl(data.dataUrl);
+      if (buffer && isPreview) {
+        previewBytes = buffer.length;
+      }
+    }
+    if (!buffer && data?.imageBase64) {
+      if (isPreview) {
+        previewBytes = Buffer.byteLength(data.imageBase64, 'base64');
+      }
+      buffer = Buffer.from(data.imageBase64, 'base64');
+    }
     if (!buffer) return res.status(400).json({ ok: false, reason: 'invalid_body' });
+
+    if (isPreview) {
+      const size = previewBytes ?? buffer.length;
+      if (Number.isFinite(size) && size > PREVIEW_LIMIT_BYTES) {
+        return res.status(413).json({
+          ok: false,
+          error: 'image_too_large',
+          preview: true,
+          limit: PREVIEW_LIMIT_BYTES,
+        });
+      }
+      // El original se sigue subiendo por /api/upload-original sin recomprimir.
+    }
 
     const result = await evaluateImage(buffer, filename, designName);
     if (result.label === 'BLOCK') {


### PR DESCRIPTION
## Summary
- add configurable preview size limit for the /api/moderate-image handler
- detect preview mode via query or header and return a structured 413 error when the payload exceeds the limit
- clarify that the original asset continues to upload through /api/upload-original without recompression

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4465b26a88327b29820289a82d442