### PR TITLE
Fix CORS headers for moderate image endpoint

### DIFF
--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -5,8 +5,20 @@ import logger from '../_lib/logger.js';
 
 const MOD_PREVIEW_LIMIT_BYTES = Number(process.env.MOD_PREVIEW_LIMIT_BYTES ?? 2_000_000);
 const DEFAULT_FRONT_ORIGIN = 'https://mgm-app.vercel.app';
-const ALLOW_METHODS = 'POST, OPTIONS';
-const ALLOW_HEADERS = 'Content-Type, Authorization, X-Preview, X-Debug, X-Requested-With';
+const ALLOW_METHODS = 'GET, POST, OPTIONS';
+const ACCESS_CONTROL_MAX_AGE = '86400';
+const BASE_ALLOW_HEADERS = [
+  'content-type',
+  'authorization',
+  'x-preview',
+  'x-debug',
+  'x-requested-with',
+  'x-admin-token',
+  'x-rid',
+  'cache-control',
+  'pragma',
+];
+const SAFE_HEADER_REGEX = /^[a-z0-9-]+$/;
 
 function sanitizeOrigin(value) {
   if (typeof value !== 'string') {
@@ -63,14 +75,46 @@ function resolveAllowedOrigin(req) {
   return sanitizeOrigin(process.env.FRONT_ORIGIN) || DEFAULT_FRONT_ORIGIN;
 }
 
+function buildAllowHeaders(req) {
+  const seen = new Set();
+  const result = [];
+
+  const addHeader = (value) => {
+    if (typeof value !== 'string') return;
+    const normalized = value.trim().toLowerCase();
+    if (!normalized || !SAFE_HEADER_REGEX.test(normalized)) return;
+    if (seen.has(normalized)) return;
+    seen.add(normalized);
+    result.push(normalized);
+  };
+
+  for (const header of BASE_ALLOW_HEADERS) {
+    addHeader(header);
+  }
+
+  const requestedHeaders = req?.headers?.['access-control-request-headers'];
+  if (typeof requestedHeaders === 'string') {
+    for (const segment of requestedHeaders.split(',')) {
+      addHeader(segment);
+    }
+  } else if (Array.isArray(requestedHeaders)) {
+    for (const value of requestedHeaders) {
+      addHeader(value);
+    }
+  }
+
+  return result.join(', ');
+}
+
 function applyCors(req, res) {
   const origin = resolveAllowedOrigin(req);
   if (origin) {
     res.setHeader?.('Access-Control-Allow-Origin', origin);
   }
-  res.setHeader?.('Vary', 'Origin');
+  res.setHeader?.('Vary', 'Origin, Access-Control-Request-Headers');
   res.setHeader?.('Access-Control-Allow-Methods', ALLOW_METHODS);
-  res.setHeader?.('Access-Control-Allow-Headers', ALLOW_HEADERS);
+  res.setHeader?.('Access-Control-Allow-Headers', buildAllowHeaders(req));
+  res.setHeader?.('Access-Control-Max-Age', ACCESS_CONTROL_MAX_AGE);
 }
 
 function sendJson(req, res, statusCode, payload) {


### PR DESCRIPTION
## Summary
- update the moderation CORS helper to merge base headers with Access-Control-Request-Headers and add consistent response metadata
- ensure OPTIONS responses return 204 with the new headers and apply the helper to all outcomes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e455e123688327b04f2a27d516fea2