### PR TITLE
Refactor CORS handling for moderation and tracking endpoints

### DIFF
--- a/api/_lib/cors.ts
+++ b/api/_lib/cors.ts
@@ -1,130 +1,63 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+import {
+  applyCorsHeaders as applySharedCorsHeaders,
+  ensureCors as ensureSharedCors,
+  getAllowedOriginsFromEnv as sharedGetAllowedOrigins,
+  handlePreflight as handleSharedPreflight,
+  respondCorsDenied as respondSharedCorsDenied,
+  resolveCorsDecision as sharedResolveCorsDecision,
+  type CorsDecision,
+} from '../../lib/cors.js';
 
-const ALLOW_HEADERS = 'content-type, authorization, x-debug-fast, accept, x-requested-with';
-const ALLOW_METHODS = 'POST, OPTIONS';
+export type { CorsDecision } from '../../lib/cors.js';
 
-type CorsDecision = {
-  requestedOrigin: string | null;
-  normalizedOrigin: string | null;
-  allowedOrigin: string | null;
-  allowed: boolean;
-};
+export const getAllowedOriginsFromEnv = sharedGetAllowedOrigins;
 
-function sanitizeOrigin(value: string | null | undefined): string | null {
-  if (typeof value !== 'string') {
-    return null;
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-  return trimmed.replace(/\/+$/, '');
+export const resolveCorsDecision = sharedResolveCorsDecision;
+
+export function ensureCors(req: VercelRequest, res: VercelResponse): CorsDecision {
+  return ensureSharedCors(req, res);
 }
 
-export function normalizeOrigin(value: string | null | undefined): string | null {
-  const sanitized = sanitizeOrigin(value);
-  return sanitized ? sanitized.toLowerCase() : null;
+export function applyCors(
+  req: VercelRequest,
+  res: VercelResponse,
+  decision?: CorsDecision,
+): CorsDecision {
+  const resolved = applySharedCorsHeaders(req, res, decision);
+  if (!res.getHeader('Content-Type')) {
+    res.setHeader('Content-Type', 'application/json');
+  }
+  return resolved;
 }
 
-export function getAllowedOriginsFromEnv(): string[] {
-  const allowSet = new Map<string, string>();
-
-  const frontOrigin = sanitizeOrigin(process.env.FRONT_ORIGIN);
-  if (frontOrigin) {
-    const normalized = normalizeOrigin(frontOrigin);
-    if (normalized) {
-      allowSet.set(normalized, frontOrigin);
-    }
-  }
-
-  const envOrigins = typeof process.env.ALLOWED_ORIGINS === 'string'
-    ? process.env.ALLOWED_ORIGINS.split(',')
-    : [];
-
-  for (const entry of envOrigins) {
-    const sanitized = sanitizeOrigin(entry);
-    if (!sanitized) continue;
-    const normalized = normalizeOrigin(sanitized);
-    if (normalized) {
-      allowSet.set(normalized, sanitized);
-    }
-  }
-
-  return Array.from(allowSet.values());
+export function handlePreflight(
+  req: VercelRequest,
+  res: VercelResponse,
+  decision: CorsDecision,
+): void {
+  handleSharedPreflight(req, res, decision);
 }
 
-export function resolveCorsDecision(originHeader: string | undefined, allowList?: string[]): CorsDecision {
-  const requestedOrigin = sanitizeOrigin(originHeader);
-  const normalizedOrigin = normalizeOrigin(originHeader);
-  const allowedOrigins = allowList && allowList.length ? allowList : getAllowedOriginsFromEnv();
-
-  const allowMap = new Map<string, string>();
-  for (const entry of allowedOrigins) {
-    const sanitized = sanitizeOrigin(entry);
-    const normalized = normalizeOrigin(entry);
-    if (sanitized && normalized) {
-      allowMap.set(normalized, sanitized);
-    }
-  }
-
-  if (normalizedOrigin && allowMap.has(normalizedOrigin)) {
-    return {
-      requestedOrigin,
-      normalizedOrigin,
-      allowedOrigin: allowMap.get(normalizedOrigin) ?? null,
-      allowed: true,
-    };
-  }
-
-  if (normalizedOrigin && normalizedOrigin.startsWith('http://localhost')) {
-    return {
-      requestedOrigin,
-      normalizedOrigin,
-      allowedOrigin: requestedOrigin,
-      allowed: true,
-    };
-  }
-
-  if (normalizedOrigin && normalizedOrigin.startsWith('http://127.0.0.1')) {
-    return {
-      requestedOrigin,
-      normalizedOrigin,
-      allowedOrigin: requestedOrigin,
-      allowed: true,
-    };
-  }
-
-  return {
-    requestedOrigin,
-    normalizedOrigin,
-    allowedOrigin: null,
-    allowed: false,
-  };
+export function respondCorsDenied(
+  req: VercelRequest,
+  res: VercelResponse,
+  decision: CorsDecision,
+  diagId: string,
+): void {
+  respondSharedCorsDenied(req, res, decision, diagId);
 }
 
-export function applyCors(req: VercelRequest, res: VercelResponse): void {
-  const originHeader =
-    typeof req.headers.origin === 'string' && req.headers.origin.trim().length > 0
-      ? req.headers.origin
-      : undefined;
-  const decision = resolveCorsDecision(originHeader);
+export function applyCorsHeaders(
+  req: VercelRequest,
+  res: VercelResponse,
+  decision?: CorsDecision,
+): CorsDecision {
+  return applySharedCorsHeaders(req, res, decision);
+}
 
-  if (decision.allowed && decision.allowedOrigin) {
-    res.setHeader('Access-Control-Allow-Origin', decision.allowedOrigin);
-  }
-  res.setHeader('Vary', 'Origin');
-  res.setHeader('Access-Control-Allow-Methods', ALLOW_METHODS);
-  res.setHeader('Access-Control-Allow-Headers', ALLOW_HEADERS);
-
+export function ensureJsonContentType(res: VercelResponse): void {
   if (!res.getHeader('Content-Type')) {
     res.setHeader('Content-Type', 'application/json');
   }
 }
-
-export function ensureJsonContentType(res: VercelResponse) {
-  if (!res.getHeader('Content-Type')) {
-    res.setHeader('Content-Type', 'application/json');
-  }
-}
-
-export type { CorsDecision };

--- a/lib/cors.d.ts
+++ b/lib/cors.d.ts
@@ -1,0 +1,50 @@
+export interface CorsDecision {
+  requestedOrigin: string | null;
+  normalizedOrigin: string | null;
+  allowedOrigin: string | null;
+  allowed: boolean;
+  allowHeaders?: string;
+}
+
+export declare const BASE_ALLOW_HEADERS: string[];
+export declare const SAFE_HEADER_REGEX: RegExp;
+
+export declare function sanitizeOrigin(value: string | null | undefined): string | null;
+export declare function normalizeOrigin(value: string | null | undefined): string | null;
+export declare function getAllowedOriginsFromEnv(): string[];
+export declare function resolveCorsDecision(
+  originHeader?: string,
+  allowList?: string[],
+): CorsDecision;
+export declare function buildAllowHeaders(
+  req: { headers?: Record<string, any> | undefined } | null,
+  baseHeaders?: string[],
+): string;
+export declare function resolveRequestCors(
+  req: { headers?: Record<string, any> | undefined } | null,
+  allowList?: string[],
+): CorsDecision;
+export declare function applyCorsHeaders(
+  req: { headers?: Record<string, any> | undefined } | null,
+  res: any,
+  decision?: CorsDecision,
+): CorsDecision;
+export declare function ensureCors(
+  req: { headers?: Record<string, any> | undefined } | null,
+  res: any,
+  allowList?: string[],
+): CorsDecision;
+export declare function handlePreflight(
+  req: { headers?: Record<string, any> | undefined } | null,
+  res: any,
+  decision?: CorsDecision,
+): CorsDecision;
+export declare function respondCorsDenied(
+  req: { headers?: Record<string, any> | undefined } | null,
+  res: any,
+  decision: CorsDecision,
+  diagId: string,
+): void;
+export declare function withCors(
+  handler: (req: any, res: any) => any | Promise<any>,
+): (req: any, res: any) => Promise<any>;

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -1,85 +1,79 @@
+import { randomUUID } from 'crypto';
 import logger from './_lib/logger.js';
 
+export const BASE_ALLOW_HEADERS = [
+  'content-type',
+  'authorization',
+  'x-requested-with',
+  'x-admin-token',
+  'x-preview',
+  'x-debug',
+  'x-debug-fast',
+  'x-rid',
+  'cache-control',
+  'pragma',
+];
+
+export const SAFE_HEADER_REGEX = /^[a-z0-9-]+$/;
+
+const ACCESS_CONTROL_MAX_AGE = '86400';
+const ALLOW_METHODS = 'GET, POST, OPTIONS';
+const DEFAULT_FRONT_ORIGIN = 'https://mgm-app.vercel.app';
 const STATIC_ALLOWED = [
+  'http://localhost:3000',
   'http://localhost:5173',
+  'http://127.0.0.1:3000',
   'http://127.0.0.1:5173',
   'https://mgmgamers.store',
   'https://www.mgmgamers.store',
   'https://tu-mousepad-personalizado.mgmgamers.store',
   'https://mgm-api.vercel.app',
 ];
+const STATIC_SUFFIXES = ['.vercel.app', '.mgmgamers.store'];
 
-const SUFFIX_ALLOWED = new Set(['.vercel.app', '.mgmgamers.store']);
+function toArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  return String(value)
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
 
-if (process.env?.ALLOWED_ORIGIN_SUFFIXES) {
-  for (const entry of process.env.ALLOWED_ORIGIN_SUFFIXES.split(',')) {
-    if (entry && entry.trim()) {
-      SUFFIX_ALLOWED.add(entry.trim());
+export function sanitizeOrigin(value) {
+  if (typeof value !== 'string') return null;
+  let trimmed = value.trim();
+  if (!trimmed) return null;
+  if (!/^https?:\/\//i.test(trimmed)) {
+    trimmed = `https://${trimmed.replace(/^\/+/, '')}`;
+  }
+  try {
+    const url = new URL(trimmed);
+    if (!/^https?:$/.test(url.protocol)) return null;
+    const host = url.host.toLowerCase();
+    const protocol = url.protocol.toLowerCase();
+    return `${protocol}//${host}`;
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeOrigin(value) {
+  const sanitized = sanitizeOrigin(value);
+  return sanitized ? sanitized.toLowerCase() : null;
+}
+
+function getAllowedOriginSuffixes() {
+  const suffixes = new Set();
+  for (const suffix of STATIC_SUFFIXES) {
+    if (typeof suffix === 'string' && suffix.trim()) {
+      suffixes.add(suffix.trim().toLowerCase());
     }
   }
-}
-
-const DEFAULT_FALLBACK_ORIGIN = 'https://www.mgmgamers.store';
-const ACCESS_CONTROL_MAX_AGE = '86400';
-const ALLOW_METHODS = 'GET, POST, OPTIONS';
-const BASE_ALLOW_HEADERS = [
-  'content-type',
-  'authorization',
-  'x-preview',
-  'x-debug',
-  'x-requested-with',
-  'x-admin-token',
-  'x-rid',
-  'cache-control',
-  'pragma',
-];
-const SAFE_HEADER_REGEX = /^[a-z0-9-]+$/;
-
-function normalizeOrigin(origin) {
-  if (!origin) return null;
-  let normalized = String(origin).trim();
-  if (!normalized) return null;
-  if (!/^https?:\/\//i.test(normalized)) {
-    normalized = `https://${normalized.replace(/^\/+/, '')}`;
+  for (const entry of toArray(process.env.ALLOWED_ORIGIN_SUFFIXES)) {
+    suffixes.add(entry.toLowerCase());
   }
-  normalized = normalized.replace(/\/+$/, '');
-  return normalized;
-}
-
-const ALLOWED = new Set();
-function addAllowed(origin) {
-  const normalized = normalizeOrigin(origin);
-  if (normalized) {
-    ALLOWED.add(normalized);
-  }
-}
-
-STATIC_ALLOWED.forEach(addAllowed);
-
-if (typeof process !== 'undefined' && process.env && process.env.ALLOWED_ORIGINS) {
-  const extra = process.env.ALLOWED_ORIGINS.split(',');
-  for (const entry of extra) {
-    if (entry && entry.trim()) addAllowed(entry.trim());
-  }
-}
-
-const FALLBACK_ORIGIN = normalizeOrigin(DEFAULT_FALLBACK_ORIGIN);
-
-function getApiOriginFromEnv() {
-  const host = process.env?.VERCEL_URL;
-  if (host && /^[-a-z0-9.]+$/.test(host)) return normalizeOrigin(`https://${host}`);
-  if (process.env?.API_PUBLIC_ORIGIN) return normalizeOrigin(process.env.API_PUBLIC_ORIGIN);
-  return null;
-}
-
-function pickOrigin(req) {
-  const requestOrigin = normalizeOrigin(req.headers?.origin || '');
-  const apiOrigin = getApiOriginFromEnv();
-  if (apiOrigin) addAllowed(apiOrigin);
-  if (requestOrigin && (ALLOWED.has(requestOrigin) || isSuffixAllowed(requestOrigin))) {
-    return requestOrigin;
-  }
-  return FALLBACK_ORIGIN;
+  return suffixes;
 }
 
 function isSuffixAllowed(origin) {
@@ -88,16 +82,119 @@ function isSuffixAllowed(origin) {
     if (!/^https?:$/.test(url.protocol)) {
       return false;
     }
-    for (const suffix of SUFFIX_ALLOWED) {
-      if (url.hostname === suffix || url.hostname.endsWith(suffix)) {
+    const hostname = url.hostname.toLowerCase();
+    for (const suffix of getAllowedOriginSuffixes()) {
+      if (hostname === suffix || hostname.endsWith(suffix)) {
         return true;
       }
     }
     return false;
   } catch (err) {
-    logger.warn?.('[CORS] invalid_origin', { origin, err: err?.message || err });
+    logger.warn?.('[cors] invalid_origin', { origin, error: err?.message || err });
     return false;
   }
+}
+
+function isLocalhost(normalizedOrigin) {
+  if (!normalizedOrigin) return false;
+  return (
+    normalizedOrigin.startsWith('http://localhost') || normalizedOrigin.startsWith('http://127.0.0.1')
+  );
+}
+
+function getApiOriginFromEnv() {
+  const host = process.env?.VERCEL_URL;
+  if (host && /^[-a-z0-9.]+$/i.test(host)) {
+    const sanitized = sanitizeOrigin(`https://${host}`);
+    if (sanitized) return sanitized;
+  }
+  if (process.env?.API_PUBLIC_ORIGIN) {
+    const sanitized = sanitizeOrigin(process.env.API_PUBLIC_ORIGIN);
+    if (sanitized) return sanitized;
+  }
+  return null;
+}
+
+function createAllowMap(allowList) {
+  const allowMap = new Map();
+
+  const add = (origin) => {
+    const sanitized = sanitizeOrigin(origin);
+    const normalized = normalizeOrigin(origin);
+    if (sanitized && normalized) {
+      allowMap.set(normalized, sanitized);
+    }
+  };
+
+  const frontOrigin = sanitizeOrigin(process.env.FRONT_ORIGIN) || sanitizeOrigin(DEFAULT_FRONT_ORIGIN);
+  if (frontOrigin) {
+    add(frontOrigin);
+  }
+
+  for (const entry of STATIC_ALLOWED) {
+    add(entry);
+  }
+
+  for (const entry of toArray(process.env.ALLOWED_ORIGINS)) {
+    add(entry);
+  }
+
+  if (Array.isArray(allowList)) {
+    for (const entry of allowList) {
+      add(entry);
+    }
+  }
+
+  const apiOrigin = getApiOriginFromEnv();
+  if (apiOrigin) {
+    add(apiOrigin);
+  }
+
+  return allowMap;
+}
+
+export function getAllowedOriginsFromEnv() {
+  return Array.from(createAllowMap([]).values());
+}
+
+export function resolveCorsDecision(originHeader, allowList) {
+  const requestedOrigin = sanitizeOrigin(originHeader);
+  const normalizedOrigin = normalizeOrigin(originHeader);
+  const allowMap = createAllowMap(allowList);
+
+  if (normalizedOrigin && allowMap.has(normalizedOrigin)) {
+    return {
+      requestedOrigin,
+      normalizedOrigin,
+      allowedOrigin: allowMap.get(normalizedOrigin) ?? null,
+      allowed: true,
+    };
+  }
+
+  if (requestedOrigin && isSuffixAllowed(requestedOrigin)) {
+    return {
+      requestedOrigin,
+      normalizedOrigin,
+      allowedOrigin: requestedOrigin,
+      allowed: true,
+    };
+  }
+
+  if (isLocalhost(normalizedOrigin)) {
+    return {
+      requestedOrigin,
+      normalizedOrigin,
+      allowedOrigin: requestedOrigin,
+      allowed: true,
+    };
+  }
+
+  return {
+    requestedOrigin,
+    normalizedOrigin,
+    allowedOrigin: null,
+    allowed: false,
+  };
 }
 
 function normalizeHeaderValue(value) {
@@ -109,7 +206,7 @@ function normalizeHeaderValue(value) {
   return trimmed;
 }
 
-function buildAllowHeaders(req) {
+export function buildAllowHeaders(req, baseHeaders = BASE_ALLOW_HEADERS) {
   const seen = new Set();
   const allowHeaders = [];
 
@@ -120,7 +217,7 @@ function buildAllowHeaders(req) {
     allowHeaders.push(normalized);
   };
 
-  for (const header of BASE_ALLOW_HEADERS) {
+  for (const header of baseHeaders) {
     push(header);
   }
 
@@ -138,32 +235,102 @@ function buildAllowHeaders(req) {
   return allowHeaders.join(', ');
 }
 
-export function applyCorsHeaders(req, res, origin) {
-  if (origin) {
-    res.setHeader('Access-Control-Allow-Origin', origin);
+function getOriginHeader(req) {
+  const header = req?.headers?.origin;
+  if (Array.isArray(header)) {
+    return header.find((value) => typeof value === 'string' && value.trim().length > 0);
   }
+  return typeof header === 'string' ? header : undefined;
+}
+
+export function resolveRequestCors(req, allowList) {
+  const originHeader = getOriginHeader(req);
+  const decision = resolveCorsDecision(originHeader, allowList);
+  return {
+    ...decision,
+    allowHeaders: buildAllowHeaders(req),
+  };
+}
+
+export function applyCorsHeaders(req, res, decision) {
+  const resolved = decision || resolveRequestCors(req);
+  const allowHeaders = resolved.allowHeaders || buildAllowHeaders(req);
+
+  if (resolved.allowed && resolved.allowedOrigin) {
+    res.setHeader('Access-Control-Allow-Origin', resolved.allowedOrigin);
+  }
+
   res.setHeader('Vary', 'Origin, Access-Control-Request-Headers');
   res.setHeader('Access-Control-Allow-Methods', ALLOW_METHODS);
-  res.setHeader('Access-Control-Allow-Headers', buildAllowHeaders(req));
+  res.setHeader('Access-Control-Allow-Headers', allowHeaders);
   res.setHeader('Access-Control-Max-Age', ACCESS_CONTROL_MAX_AGE);
+
+  return { ...resolved, allowHeaders };
+}
+
+export function ensureCors(req, res, allowList) {
+  const decision = resolveRequestCors(req, allowList);
+  return applyCorsHeaders(req, res, decision);
+}
+
+export function handlePreflight(req, res, decision) {
+  const resolved = applyCorsHeaders(req, res, decision);
+  if (typeof res.status === 'function') {
+    res.status(204);
+  } else {
+    res.statusCode = 204;
+  }
+  res.end();
+  return resolved;
+}
+
+export function respondCorsDenied(req, res, decision, diagId) {
+  applyCorsHeaders(req, res, decision);
+  if (typeof res.status === 'function') {
+    res.status(403);
+  } else {
+    res.statusCode = 403;
+  }
+  try {
+    res.setHeader?.('Content-Type', 'application/json; charset=utf-8');
+  } catch {}
+  res.end(JSON.stringify({ ok: false, error: 'origin_not_allowed', diagId }));
 }
 
 export function withCors(handler) {
   return async (req, res) => {
-    try {
-      const o = req.headers?.origin || '';
-      if (process.env?.DEBUG_CORS === '1') {
-        logger.debug('[CORS]', { method: req.method, origin: o, url: req.url });
-      }
-    } catch {}
-    const origin = pickOrigin(req);
-    if (String(req.method || '').toUpperCase() === 'OPTIONS') {
-      applyCorsHeaders(req, res, origin);
-      res.statusCode = 204;
-      return res.end();
+    const decision = ensureCors(req, res);
+
+    if (!decision.allowed || !decision.allowedOrigin) {
+      const diagId = randomUUID();
+      try {
+        logger.warn?.('[cors] denied', {
+          diagId,
+          origin: decision.requestedOrigin,
+          method: req?.method,
+          url: req?.url,
+        });
+      } catch {}
+      respondCorsDenied(req, res, decision, diagId);
+      return;
     }
-    applyCorsHeaders(req, res, origin);
+
+    if (String(req.method || '').toUpperCase() === 'OPTIONS') {
+      handlePreflight(req, res, decision);
+      return;
+    }
+
     return handler(req, res);
   };
 }
 
+export default {
+  withCors,
+  applyCorsHeaders,
+  ensureCors,
+  resolveCorsDecision,
+  getAllowedOriginsFromEnv,
+  respondCorsDenied,
+  handlePreflight,
+  resolveRequestCors,
+};

--- a/lib/handlers/moderateImage.js
+++ b/lib/handlers/moderateImage.js
@@ -1,105 +1,18 @@
+import { randomUUID } from 'crypto';
 import sharp from 'sharp';
 import { pHashFromGray, hamming } from '../hashing.js';
 import { hateTextCheck } from '../moderation/hate.js';
 import logger from '../_lib/logger.js';
-import { applyCorsHeaders } from '../cors.js';
+import {
+  applyCorsHeaders,
+  ensureCors,
+  handlePreflight,
+  respondCorsDenied,
+} from '../cors.js';
 
 const MOD_PREVIEW_LIMIT_BYTES = Number(process.env.MOD_PREVIEW_LIMIT_BYTES ?? 2_000_000);
-const DEFAULT_FRONT_ORIGIN = 'https://mgm-app.vercel.app';
-
-function sanitizeOrigin(value) {
-  if (typeof value !== 'string') {
-    return null;
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-  return trimmed.replace(/\/+$/, '');
-}
-
-function normalizeOrigin(value) {
-  const sanitized = sanitizeOrigin(value);
-  return sanitized ? sanitized.toLowerCase() : null;
-}
-
-function getAllowedOrigins() {
-  const allowList = new Map();
-  const frontOrigin = sanitizeOrigin(process.env.FRONT_ORIGIN) || DEFAULT_FRONT_ORIGIN;
-  const normalizedFront = normalizeOrigin(frontOrigin);
-  if (normalizedFront) {
-    allowList.set(normalizedFront, frontOrigin);
-  }
-
-  const extra = typeof process.env.ALLOWED_ORIGINS === 'string'
-    ? process.env.ALLOWED_ORIGINS.split(',')
-    : [];
-  for (const candidate of extra) {
-    const sanitized = sanitizeOrigin(candidate);
-    const normalized = normalizeOrigin(candidate);
-    if (sanitized && normalized) {
-      allowList.set(normalized, sanitized);
-    }
-  }
-
-  return allowList;
-}
-
-function resolveAllowedOrigin(req) {
-  const requested = sanitizeOrigin(req?.headers?.origin);
-  const normalizedRequested = normalizeOrigin(requested);
-  const allowList = getAllowedOrigins();
-  if (normalizedRequested && allowList.has(normalizedRequested)) {
-    return allowList.get(normalizedRequested);
-  }
-  if (normalizedRequested && (normalizedRequested.startsWith('http://localhost') || normalizedRequested.startsWith('http://127.0.0.1'))) {
-    return requested;
-  }
-  const first = allowList.values().next();
-  if (!first.done && first.value) {
-    return first.value;
-  }
-  return sanitizeOrigin(process.env.FRONT_ORIGIN) || DEFAULT_FRONT_ORIGIN;
-}
-
-function buildAllowHeaders(req) {
-  const seen = new Set();
-  const result = [];
-
-  const addHeader = (value) => {
-    if (typeof value !== 'string') return;
-    const normalized = value.trim().toLowerCase();
-    if (!normalized || !SAFE_HEADER_REGEX.test(normalized)) return;
-    if (seen.has(normalized)) return;
-    seen.add(normalized);
-    result.push(normalized);
-  };
-
-  for (const header of BASE_ALLOW_HEADERS) {
-    addHeader(header);
-  }
-
-  const requestedHeaders = req?.headers?.['access-control-request-headers'];
-  if (typeof requestedHeaders === 'string') {
-    for (const segment of requestedHeaders.split(',')) {
-      addHeader(segment);
-    }
-  } else if (Array.isArray(requestedHeaders)) {
-    for (const value of requestedHeaders) {
-      addHeader(value);
-    }
-  }
-
-  return result.join(', ');
-}
-
-function applyCors(req, res) {
-  const origin = resolveAllowedOrigin(req);
-  applyCorsHeaders(req, res, origin);
-}
-
-function sendJson(req, res, statusCode, payload) {
-  applyCors(req, res);
+function sendJson(req, res, statusCode, payload, corsDecision) {
+  applyCorsHeaders(req, res, corsDecision);
   if (typeof res.status === 'function') {
     res.status(statusCode);
   } else {
@@ -817,19 +730,27 @@ export async function evaluateImage(buffer, filename, designName = '', options =
 }
 
 export default async function moderateImage(req, res) {
+  const corsDecision = ensureCors(req, res);
+
+  if (!corsDecision.allowed || !corsDecision.allowedOrigin) {
+    const diagId = randomUUID();
+    try {
+      logger.warn?.('[moderate-image] cors_denied', {
+        diagId,
+        origin: corsDecision.requestedOrigin,
+      });
+    } catch {}
+    respondCorsDenied(req, res, corsDecision, diagId);
+    return;
+  }
+
   if (req.method === 'OPTIONS') {
-    applyCors(req, res);
-    if (typeof res.status === 'function') {
-      res.status(204);
-    } else {
-      res.statusCode = 204;
-    }
-    res.end();
+    handlePreflight(req, res, corsDecision);
     return;
   }
 
   if (req.method !== 'POST') {
-    sendJson(req, res, 405, { ok: false, error: 'method_not_allowed' });
+    sendJson(req, res, 405, { ok: false, error: 'method_not_allowed' }, corsDecision);
     return;
   }
 
@@ -839,7 +760,7 @@ export default async function moderateImage(req, res) {
     try {
       data = JSON.parse(raw || '{}');
     } catch {
-      sendJson(req, res, 400, { ok: false, reason: 'invalid_body' });
+      sendJson(req, res, 400, { ok: false, reason: 'invalid_body' }, corsDecision);
       return;
     }
 
@@ -863,7 +784,7 @@ export default async function moderateImage(req, res) {
       buffer = Buffer.from(data.imageBase64, 'base64');
     }
     if (!buffer) {
-      sendJson(req, res, 400, { ok: false, reason: 'invalid_body' });
+      sendJson(req, res, 400, { ok: false, reason: 'invalid_body' }, corsDecision);
       return;
     }
 
@@ -877,7 +798,7 @@ export default async function moderateImage(req, res) {
           receivedBytes: size,
           preview: true,
           diagId: rid || null,
-        });
+        }, corsDecision);
         return;
       }
       // El original se sigue subiendo por /api/upload-original sin recomprimir.
@@ -889,17 +810,17 @@ export default async function moderateImage(req, res) {
         ok: false,
         reason: result.reasons?.[0] || 'blocked',
         ...result,
-      });
+      }, corsDecision);
       return;
     }
 
-    sendJson(req, res, 200, { ok: true, ...result });
+    sendJson(req, res, 200, { ok: true, ...result }, corsDecision);
   } catch (e) {
     logger.error(e);
     sendJson(req, res, 500, {
       ok: false,
       reason: 'server_error',
       error: String(e?.message || e),
-    });
+    }, corsDecision);
   }
 }

--- a/mgm-front/src/pages/Home.jsx
+++ b/mgm-front/src/pages/Home.jsx
@@ -507,7 +507,6 @@ export default function Home() {
           getResolvedApiUrl('/api/moderate-image?preview=1&debug=1'),
           { ...baseModerationPayload, imageBase64: preview.base64 },
           60000,
-          { headers: { 'X-Preview': '1' } },
         );
       };
 


### PR DESCRIPTION
## Summary
- centralize CORS resolution, header merging, and denial handling so every API route can share the same origin rules and preflight responses. 【F:lib/cors.js†L1-L335】
- update `/api/moderate-image` and `/api/track` to use the shared helper, consistently apply CORS on all status codes, and rely on `?preview=1` instead of the `X-Preview` header while keeping the preview size guardrails. 【F:lib/handlers/moderateImage.js†L1-L818】【F:api/track.ts†L1-L516】
- re-export the helper for existing TypeScript endpoints and drop the preview header from the front-end request so only the query flag is sent. 【F:api/_lib/cors.ts†L1-L63】【F:mgm-front/src/pages/Home.jsx†L505-L511】

## Testing
- ⚠️ `npx tsc --noEmit` *(fails: repository already contains analytics/prints type errors such as imports ending in .ts and Response.json usages)* 【e2fe55†L1-L110】

------
https://chatgpt.com/codex/tasks/task_e_68e45bb6cf108327b654a46eaa4a50aa