### PR TITLE
Support large multipart uploads for /api/upload-original

### DIFF
--- a/api/upload-original.ts
+++ b/api/upload-original.ts
@@ -1,130 +1,595 @@
-export const config = { memory: 256, maxDuration: 10 };
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { randomUUID } from 'node:crypto';
+import {
+  ensureCors,
+  handlePreflight,
+  respondCorsDenied,
+  applyCorsHeaders,
+} from './_lib/cors.js';
+import type { CorsDecision } from './_lib/cors.js';
 
 const PASSTHROUGH_PLACEHOLDER_URL = 'https://picsum.photos/seed/mgm/800/600';
+const DEFAULT_MAX_BYTES = 40 * 1024 * 1024;
+const BODY_SIZE_LIMIT = '32mb';
 
-function applyLenientCors(req: any, res: any) {
-  const origin = req?.headers?.origin;
-  const allowOrigin = typeof origin === 'string' && origin.length > 0 ? origin : '*';
+export const config = {
+  api: {
+    bodyParser: false,
+    sizeLimit: BODY_SIZE_LIMIT,
+  },
+  maxDuration: 60,
+};
 
-  res.setHeader('Access-Control-Allow-Origin', allowOrigin);
-  res.setHeader('Vary', 'Origin');
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Debug-Fast');
-  res.setHeader('Content-Type', 'application/json');
-}
+type MultipartFile = {
+  fieldName: string;
+  filename: string;
+  contentType: string;
+  size: number;
+  buffer: Buffer;
+};
 
-function isPlainObject(value: any) {
-  if (value == null) return false;
-  if (Array.isArray(value)) return false;
-  if (typeof value !== 'object') return false;
-  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) return false;
-  return true;
-}
-
-async function readBodyAsString(req: any) {
-  const rawBody = req?.body;
-  if (typeof rawBody === 'string') {
-    return rawBody;
-  }
-  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(rawBody)) {
-    return rawBody.toString('utf8');
-  }
-  if (rawBody == null && req && typeof req.on === 'function') {
-    return new Promise<string | null>((resolve, reject) => {
-      let data = '';
-      req.on('data', (chunk: any) => {
-        if (typeof chunk === 'string') {
-          data += chunk;
-          return;
-        }
-        if (chunk && typeof chunk.toString === 'function') {
-          data += chunk.toString('utf8');
-        }
-      });
-      req.on('end', () => resolve(data.length ? data : null));
-      req.on('error', (err: Error) => reject(err));
-    });
-  }
-  return null;
-}
-
-async function tryReadJsonBody(req: any) {
-  const rawBody = req?.body;
-  if (isPlainObject(rawBody)) {
-    return rawBody;
-  }
-
-  try {
-    const text = await readBodyAsString(req);
-    if (typeof text === 'string' && text.trim().length) {
-      return JSON.parse(text);
+type ParsedRequest =
+  | {
+      kind: 'empty';
+      receivedBytes: number;
+      json: null;
+      fields: Record<string, string>;
+      file: null;
     }
-  } catch (error) {
-    return null;
-  }
+  | {
+      kind: 'json';
+      receivedBytes: number;
+      json: Record<string, any> | null;
+      fields: Record<string, string>;
+      file: null;
+    }
+  | {
+      kind: 'multipart';
+      receivedBytes: number;
+      json: null;
+      fields: Record<string, string>;
+      file: MultipartFile | null;
+    };
 
+type NormalizedPayload = {
+  mode: 'none' | 'url' | 'json_base64' | 'multipart';
+  receivedBytes: number;
+  url: string | null;
+  json: Record<string, any> | null;
+  fields: Record<string, string>;
+  file: MultipartFile | null;
+  buffer:
+    | null
+    | {
+        buffer: Buffer;
+        contentType: string | null;
+      };
+};
+
+class PayloadTooLargeError extends Error {
+  public readonly bytes: number;
+
+  constructor(bytes: number) {
+    super('payload_too_large');
+    this.name = 'PayloadTooLargeError';
+    this.bytes = bytes;
+  }
+}
+
+class InvalidBodyError extends Error {
+  public readonly code: string;
+
+  constructor(code: string) {
+    super(code);
+    this.name = 'InvalidBodyError';
+    this.code = code;
+  }
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
   return null;
 }
 
-function sendJson(res: any, statusCode: number, payload: Record<string, any>) {
+function parseMaxBytes(): number {
+  const raw = process.env.UPLOAD_ORIGINAL_MAX_BYTES;
+  const parsed = toNumber(raw);
+  if (parsed && parsed > 0) {
+    return parsed;
+  }
+  return DEFAULT_MAX_BYTES;
+}
+
+function getContentLength(req: VercelRequest): number | null {
+  const header = req.headers['content-length'];
+  if (Array.isArray(header)) {
+    const first = header.find((value) => typeof value === 'string');
+    return toNumber(first);
+  }
+  return toNumber(header);
+}
+
+function getContentType(req: VercelRequest): string {
+  const header = req.headers['content-type'] || req.headers['Content-Type'];
+  if (Array.isArray(header)) {
+    return (header[0] || '').trim();
+  }
+  return typeof header === 'string' ? header.trim() : '';
+}
+
+function getBaseContentType(contentTypeHeader: string): string {
+  if (!contentTypeHeader) return '';
+  return contentTypeHeader.split(';')[0].trim().toLowerCase();
+}
+
+function respondJson(
+  req: VercelRequest,
+  res: VercelResponse,
+  corsDecision: CorsDecision,
+  statusCode: number,
+  payload: Record<string, any>,
+): void {
+  applyCorsHeaders(req, res, corsDecision);
+  if (typeof res.status === 'function') {
+    res.status(statusCode);
+    if (typeof res.json === 'function') {
+      res.json(payload);
+      return;
+    }
+  }
   res.statusCode = statusCode;
   try {
-    if (!res.headersSent) {
-      res.setHeader?.('Content-Type', 'application/json');
-    }
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
   } catch {}
   res.end(JSON.stringify(payload));
 }
 
-function enhanceResponse(res: any) {
-  const originalStatus = typeof res.status === 'function' ? res.status.bind(res) : null;
-  if (!originalStatus) {
-    res.status = (code: number) => {
-      res.statusCode = code;
-      return res;
+function respondPayloadTooLarge(
+  req: VercelRequest,
+  res: VercelResponse,
+  corsDecision: CorsDecision,
+  diagId: string,
+  limitBytes: number,
+  receivedBytes: number,
+): void {
+  respondJson(req, res, corsDecision, 413, {
+    ok: false,
+    error: 'payload_too_large',
+    limitBytes,
+    receivedBytes,
+    diagId,
+  });
+}
+
+function readRequestBody(
+  req: VercelRequest,
+  limitBytes: number,
+): Promise<{ buffer: Buffer; bytes: number }> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let finished = false;
+
+    const cleanup = () => {
+      req.off?.('data', onData);
+      req.off?.('end', onEnd);
+      req.off?.('error', onError);
     };
+
+    const abort = (err: Error) => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      try {
+        req.pause?.();
+        req.destroy?.();
+      } catch {}
+      reject(err);
+    };
+
+    const onData = (chunk: Buffer | string) => {
+      if (finished) return;
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += buf.length;
+      if (limitBytes > 0 && total > limitBytes) {
+        abort(new PayloadTooLargeError(total));
+        return;
+      }
+      chunks.push(buf);
+    };
+
+    const onEnd = () => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      resolve({ buffer: Buffer.concat(chunks), bytes: total });
+    };
+
+    const onError = (err: Error) => {
+      abort(err);
+    };
+
+    req.on('data', onData);
+    req.on('end', onEnd);
+    req.on('error', onError);
+  });
+}
+
+async function parseMultipartFormData(
+  body: Buffer,
+  contentTypeHeader: string,
+): Promise<{ fields: Record<string, string>; file: MultipartFile | null }> {
+  const RequestCtor = (globalThis as any).Request;
+  if (typeof RequestCtor !== 'function') {
+    throw new Error('Request constructor unavailable');
   }
 
-  const originalJson = typeof res.json === 'function' ? res.json.bind(res) : null;
-  res.json = (body: any) => {
-    let payload = body;
-    if (payload && typeof payload === 'object' && payload.ok === true) {
-      const derivedPublicUrl =
-        payload.publicUrl ?? payload.public_url ?? payload.file_original_url ?? null;
-      if (payload.publicUrl !== derivedPublicUrl) {
-        payload = { ...payload, publicUrl: derivedPublicUrl };
-      }
+  const request = new RequestCtor('http://localhost', {
+    method: 'POST',
+    headers: { 'content-type': contentTypeHeader },
+    body,
+  });
+
+  const formData: any = await (request as any).formData();
+  const fields: Record<string, string> = {};
+  let selectedFile: MultipartFile | null = null;
+
+  for (const [key, value] of formData.entries()) {
+    if (typeof value === 'string') {
+      fields[key] = value;
+      continue;
     }
 
-    if (originalJson) {
-      return originalJson(payload);
-    }
+    const blob = value as any;
+    const arrayBuffer = await blob.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const file: MultipartFile = {
+      fieldName: key,
+      filename:
+        typeof (value as any).name === 'string' && (value as any).name
+          ? String((value as any).name)
+          : typeof blob?.name === 'string' && blob.name
+            ? String(blob.name)
+            : 'upload.bin',
+      contentType:
+        typeof (value as any).type === 'string' && (value as any).type
+          ? String((value as any).type)
+          : typeof blob?.type === 'string' && blob.type
+            ? String(blob.type)
+            : 'application/octet-stream',
+      size: buffer.length,
+      buffer,
+    };
 
-    try {
-      res.setHeader?.('Content-Type', 'application/json');
-    } catch {}
-    res.end(JSON.stringify(payload));
-    return res;
+    if (!selectedFile || key === 'file') {
+      selectedFile = file;
+    }
+  }
+
+  return { fields, file: selectedFile };
+}
+
+function parseJsonBody(body: Buffer): Record<string, any> | null {
+  if (!body || body.length === 0) {
+    return null;
+  }
+  const text = body.toString('utf8');
+  if (!text.trim()) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<string, any>;
+    }
+    return null;
+  } catch (error) {
+    throw new InvalidBodyError('invalid_json');
+  }
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function decodeBase64(value: string): Buffer | null {
+  try {
+    return Buffer.from(value, 'base64');
+  } catch {
+    return null;
+  }
+}
+
+function parseDataUrl(value: string): { buffer: Buffer; contentType: string | null } | null {
+  const trimmed = value.trim();
+  const match = /^data:([^;,]+);base64,(.+)$/i.exec(trimmed);
+  if (!match) {
+    return null;
+  }
+  const [, mime, base64Payload] = match;
+  const buffer = decodeBase64(base64Payload);
+  if (!buffer) return null;
+  return {
+    buffer,
+    contentType: mime?.trim() || null,
   };
 }
 
-export default async function handler(req: any, res: any) {
-  applyLenientCors(req, res);
+function extractBase64Payload(payload: Record<string, any> | null): {
+  buffer: Buffer;
+  contentType: string | null;
+} | null {
+  if (!payload) return null;
+  const candidates: Array<{ value: unknown; isDataUrl?: boolean }> = [
+    { value: payload.imageBase64 },
+    { value: payload.image_base64 },
+    { value: payload.file_base64 },
+    { value: payload.base64 },
+    { value: payload.data_url, isDataUrl: true },
+  ];
 
-  const method = (req?.method || '').toUpperCase();
+  for (const candidate of candidates) {
+    if (typeof candidate.value !== 'string') continue;
+    const trimmed = candidate.value.trim();
+    if (!trimmed) continue;
 
-  if (method === 'OPTIONS') {
-    res.statusCode = 200;
-    res.end();
+    if (candidate.isDataUrl || trimmed.startsWith('data:')) {
+      const parsed = parseDataUrl(trimmed);
+      if (parsed?.buffer?.length) {
+        return parsed;
+      }
+      continue;
+    }
+
+    const buffer = decodeBase64(trimmed);
+    if (buffer?.length) {
+      return { buffer, contentType: null };
+    }
+  }
+
+  return null;
+}
+
+async function parseRequest(
+  req: VercelRequest,
+  limitBytes: number,
+): Promise<ParsedRequest> {
+  const contentTypeHeader = getContentType(req);
+  const baseContentType = getBaseContentType(contentTypeHeader);
+
+  if (!contentTypeHeader && !req.readableEnded && !req.complete) {
+    // fallthrough to body parser
+  }
+
+  const { buffer, bytes } = await readRequestBody(req, limitBytes);
+
+  if (!baseContentType) {
+    const json = parseJsonBody(buffer);
+    if (json) {
+      return {
+        kind: 'json',
+        receivedBytes: bytes,
+        json,
+        fields: {} as Record<string, string>,
+        file: null,
+      };
+    }
+    return {
+      kind: 'empty',
+      receivedBytes: bytes,
+      json: null,
+      fields: {} as Record<string, string>,
+      file: null,
+    };
+  }
+
+  if (baseContentType === 'application/json' || baseContentType === 'text/json') {
+    const json = parseJsonBody(buffer);
+    return {
+      kind: 'json',
+      receivedBytes: bytes,
+      json,
+      fields: {} as Record<string, string>,
+      file: null,
+    };
+  }
+
+  if (baseContentType === 'multipart/form-data') {
+    const parsed = await parseMultipartFormData(buffer, contentTypeHeader);
+    return {
+      kind: 'multipart',
+      receivedBytes: bytes,
+      json: null,
+      fields: parsed.fields,
+      file: parsed.file,
+    };
+  }
+
+  const json = parseJsonBody(buffer);
+  if (json) {
+    return {
+      kind: 'json',
+      receivedBytes: bytes,
+      json,
+      fields: {} as Record<string, string>,
+      file: null,
+    };
+  }
+
+  return {
+    kind: 'empty',
+    receivedBytes: bytes,
+    json: null,
+    fields: {} as Record<string, string>,
+    file: null,
+  };
+}
+
+function normalizePayload(parsed: ParsedRequest): NormalizedPayload {
+  const urlCandidate = parsed.kind === 'json' && parsed.json ? normalizeString(parsed.json.url) : '';
+  const url = urlCandidate || null;
+
+  let buffer: NormalizedPayload['buffer'] = null;
+  if (parsed.kind === 'json' && parsed.json) {
+    const base64 = extractBase64Payload(parsed.json);
+    if (base64?.buffer?.length) {
+      buffer = base64;
+    }
+  }
+
+  const fields = parsed.kind === 'multipart' ? parsed.fields : parsed.kind === 'json' && parsed.json ? { ...parsed.json } : {};
+  const file = parsed.kind === 'multipart' ? parsed.file : null;
+
+  let mode: NormalizedPayload['mode'] = 'none';
+  if (file && file.size > 0) {
+    mode = 'multipart';
+  } else if (buffer && buffer.buffer.length > 0) {
+    mode = 'json_base64';
+  } else if (url) {
+    mode = 'url';
+  }
+
+  return {
+    mode,
+    receivedBytes: parsed.receivedBytes,
+    url,
+    json: parsed.kind === 'json' ? parsed.json : null,
+    fields,
+    file,
+    buffer,
+  };
+}
+
+function buildHandlerPayload(normalized: NormalizedPayload): Record<string, any> {
+  if (normalized.mode === 'multipart') {
+    const payload: Record<string, any> = { ...normalized.fields };
+    const file = normalized.file;
+    if (file) {
+      payload.file_buffer = file.buffer;
+      payload.file_fieldname = file.fieldName;
+      if (!payload.file_name) {
+        payload.file_name = payload.fileName || payload.filename || file.filename;
+      }
+      if (!payload.filename) {
+        payload.filename = file.filename;
+      }
+      const contentTypeCandidate =
+        payload.file_content_type
+        || payload.fileContentType
+        || payload.file_mime
+        || payload.fileMime
+        || payload.mime
+        || payload.mime_type
+        || payload.content_type
+        || file.contentType;
+      if (!payload.file_content_type) {
+        payload.file_content_type = contentTypeCandidate;
+      }
+      if (!payload.mime) {
+        payload.mime = contentTypeCandidate;
+      }
+      if (!payload.content_type) {
+        payload.content_type = contentTypeCandidate;
+      }
+      if (!payload.size_bytes) {
+        payload.size_bytes = payload.sizeBytes || payload.file_size || payload.fileSize || file.size;
+      }
+    }
+    return payload;
+  }
+
+  const payload = normalized.json ? { ...normalized.json } : {};
+  if (normalized.buffer) {
+    payload.file_buffer = normalized.buffer.buffer;
+    if (!payload.mime && !payload.mime_type && !payload.content_type && !payload.file_content_type && normalized.buffer.contentType) {
+      payload.mime = normalized.buffer.contentType;
+    }
+    if (!payload.file_content_type && normalized.buffer.contentType) {
+      payload.file_content_type = normalized.buffer.contentType;
+    }
+    if (!payload.content_type && normalized.buffer.contentType) {
+      payload.content_type = normalized.buffer.contentType;
+    }
+    if (!payload.size_bytes && !payload.sizeBytes) {
+      payload.size_bytes = normalized.buffer.buffer.length;
+    }
+  }
+  return payload;
+}
+
+function calculateEffectiveReceivedBytes(
+  normalized: NormalizedPayload,
+  fallback: number,
+): number {
+  const bufferSize = normalized.buffer?.buffer?.length ?? 0;
+  const fileSize = normalized.file?.size ?? 0;
+  return Math.max(fallback, bufferSize, fileSize);
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const diagId = randomUUID();
+  res.setHeader('X-Upload-Diag-Id', diagId);
+
+  const corsDecision = ensureCors(req, res);
+
+  if (!corsDecision.allowed || !corsDecision.allowedOrigin) {
+    respondCorsDenied(req, res, corsDecision, diagId);
     return;
   }
 
-  if (method !== 'POST') {
-    sendJson(res, 405, { ok: false, error: 'method_not_allowed' });
+  if (req.method === 'OPTIONS') {
+    handlePreflight(req, res, corsDecision);
     return;
   }
 
-  if (process?.env?.UPLOAD_ENABLED === '1') {
+  if (req.method !== 'POST') {
+    respondJson(req, res, corsDecision, 405, { ok: false, error: 'method_not_allowed', diagId });
+    return;
+  }
+
+  const maxBytes = parseMaxBytes();
+  const contentLength = getContentLength(req);
+  if (contentLength && contentLength > maxBytes) {
+    respondPayloadTooLarge(req, res, corsDecision, diagId, maxBytes, contentLength);
+    return;
+  }
+
+  let parsed: ParsedRequest;
+  try {
+    parsed = await parseRequest(req, maxBytes);
+  } catch (error) {
+    if (error instanceof PayloadTooLargeError) {
+      respondPayloadTooLarge(req, res, corsDecision, diagId, maxBytes, error.bytes);
+      return;
+    }
+    const code = error instanceof InvalidBodyError ? error.code : 'invalid_body';
+    respondJson(req, res, corsDecision, 400, { ok: false, error: code, diagId });
+    return;
+  }
+
+  const normalized = normalizePayload(parsed);
+  const effectiveBytes = calculateEffectiveReceivedBytes(normalized, parsed.receivedBytes);
+
+  if (effectiveBytes > maxBytes) {
+    respondPayloadTooLarge(req, res, corsDecision, diagId, maxBytes, effectiveBytes);
+    return;
+  }
+
+  const uploadEnabled = process?.env?.UPLOAD_ENABLED === '1';
+  const shouldCallHandler =
+    uploadEnabled && (normalized.mode === 'multipart' || normalized.mode === 'json_base64');
+
+  if (shouldCallHandler) {
     try {
       const module = await import('../lib/handlers/uploadOriginal.js');
       const realHandler = module?.default;
@@ -132,30 +597,51 @@ export default async function handler(req: any, res: any) {
         throw new Error('upload_handler_unavailable');
       }
 
-      enhanceResponse(res);
-      await realHandler(req, res);
+      const payloadForHandler = buildHandlerPayload(normalized);
+      (req as any).body = payloadForHandler;
+
+      const enhancedRes = res as VercelResponse & { status?: any; json?: any };
+      const originalStatus = typeof enhancedRes.status === 'function' ? enhancedRes.status.bind(enhancedRes) : null;
+      if (!originalStatus) {
+        enhancedRes.status = (code: number) => {
+          enhancedRes.statusCode = code;
+          return enhancedRes;
+        };
+      }
+      const originalJson = typeof enhancedRes.json === 'function' ? enhancedRes.json.bind(enhancedRes) : null;
+      enhancedRes.json = (body: any) => {
+        let payload = body;
+        if (payload && typeof payload === 'object' && payload.ok === true) {
+          const derivedPublicUrl =
+            payload.publicUrl ?? payload.public_url ?? payload.file_original_url ?? null;
+          if (payload.publicUrl !== derivedPublicUrl) {
+            payload = { ...payload, publicUrl: derivedPublicUrl };
+          }
+        }
+        if (originalJson) {
+          return originalJson(payload);
+        }
+        try {
+          enhancedRes.setHeader?.('Content-Type', 'application/json');
+        } catch {}
+        enhancedRes.end(JSON.stringify(payload));
+        return enhancedRes;
+      };
+
+      await realHandler(req, enhancedRes);
     } catch (error) {
       if (!res.headersSent) {
-        sendJson(res, 500, { ok: false, error: 'upload_unavailable' });
+        respondJson(req, res, corsDecision, 500, { ok: false, error: 'upload_unavailable', diagId });
       }
     }
     return;
   }
 
-  let publicUrl = PASSTHROUGH_PLACEHOLDER_URL;
-  const contentType = String(req?.headers?.['content-type'] || req?.headers?.['Content-Type'] || '')
-    .toLowerCase()
-    .trim();
-
-  const shouldAttemptJson = contentType.includes('application/json') || isPlainObject(req?.body);
-
-  if (shouldAttemptJson) {
-    const parsed = await tryReadJsonBody(req);
-    const candidateUrl = parsed && typeof parsed.url === 'string' ? parsed.url.trim() : '';
-    if (candidateUrl) {
-      publicUrl = candidateUrl;
-    }
-  }
-
-  sendJson(res, 200, { ok: true, mode: 'passthrough', publicUrl });
+  const publicUrl = normalized.url || PASSTHROUGH_PLACEHOLDER_URL;
+  respondJson(req, res, corsDecision, 200, {
+    ok: true,
+    mode: 'passthrough',
+    publicUrl,
+    diagId,
+  });
 }

--- a/api/upload-original.ts
+++ b/api/upload-original.ts
@@ -10,12 +10,11 @@ import type { CorsDecision } from './_lib/cors.js';
 
 const PASSTHROUGH_PLACEHOLDER_URL = 'https://picsum.photos/seed/mgm/800/600';
 const DEFAULT_MAX_BYTES = 40 * 1024 * 1024;
-const BODY_SIZE_LIMIT = '32mb';
-
 export const config = {
   api: {
     bodyParser: false,
-    sizeLimit: BODY_SIZE_LIMIT,
+    // NOTE: Vercel requires a literal here when statically analyzing the route.
+    sizeLimit: '32mb',
   },
   maxDuration: 60,
 };

--- a/lib/handlers/uploadOriginal.js
+++ b/lib/handlers/uploadOriginal.js
@@ -105,15 +105,26 @@ export default async function uploadOriginal(req, res) {
     height_cm,
     size_bytes,
     sizeBytes,
+    file_size,
+    fileSize,
     mime,
     mime_type,
     content_type,
+    file_content_type,
+    fileContentType,
+    file_mime,
+    fileMime,
     data_url,
     file_base64,
     base64,
     filename,
+    file_name,
+    fileName,
     ext,
     sha256,
+    file_buffer,
+    fileBuffer,
+    file,
   } = payload;
 
   const normalizedName = typeof design_name === 'string' && design_name.trim()
@@ -125,17 +136,36 @@ export default async function uploadOriginal(req, res) {
   const materialValue = typeof material === 'string' ? material : '';
   const widthValue = Number.isFinite(Number(w_cm)) ? Number(w_cm) : Number(width_cm);
   const heightValue = Number.isFinite(Number(h_cm)) ? Number(h_cm) : Number(height_cm);
-  const declaredSize = Number.isFinite(Number(size_bytes))
-    ? Number(size_bytes)
-    : Number(sizeBytes);
-  const declaredContentType =
-    typeof mime === 'string'
-      ? mime
-      : typeof mime_type === 'string'
-        ? mime_type
-        : typeof content_type === 'string'
-          ? content_type
-          : undefined;
+  const sizeCandidates = [size_bytes, sizeBytes, file_size, fileSize, file?.size, payload?.file?.size];
+  let declaredSize = 0;
+  for (const candidate of sizeCandidates) {
+    const parsedSize = Number(candidate);
+    if (Number.isFinite(parsedSize) && parsedSize > 0) {
+      declaredSize = parsedSize;
+      break;
+    }
+  }
+  const declaredContentType = (() => {
+    const candidates = [
+      mime,
+      mime_type,
+      content_type,
+      file_content_type,
+      fileContentType,
+      file_mime,
+      fileMime,
+      file?.contentType,
+      payload?.file?.contentType,
+      file?.type,
+      payload?.file?.type,
+    ];
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim()) {
+        return candidate.trim();
+      }
+    }
+    return undefined;
+  })();
 
   const sha = typeof sha256 === 'string' ? sha256.trim().toLowerCase() : '';
 
@@ -161,6 +191,32 @@ export default async function uploadOriginal(req, res) {
   }
 
   if (!parsed || !parsed.buffer?.length) {
+    const directBuffer = (() => {
+      if (file_buffer && Buffer.isBuffer(file_buffer) && file_buffer.length) {
+        return file_buffer;
+      }
+      if (fileBuffer && Buffer.isBuffer(fileBuffer) && fileBuffer.length) {
+        return fileBuffer;
+      }
+      if (file && typeof file === 'object' && Buffer.isBuffer(file.buffer) && file.buffer.length) {
+        return file.buffer;
+      }
+      if (payload?.file && typeof payload.file === 'object' && Buffer.isBuffer(payload.file.buffer) && payload.file.buffer.length) {
+        return payload.file.buffer;
+      }
+      return null;
+    })();
+
+    if (directBuffer) {
+      parsed = {
+        buffer: directBuffer,
+        size: directBuffer.length,
+        contentType: declaredContentType || undefined,
+      };
+    }
+  }
+
+  if (!parsed || !parsed.buffer?.length) {
     return res.status(400).json({ ok: false, diag_id: diagId, error: 'file_missing' });
   }
 
@@ -175,7 +231,16 @@ export default async function uploadOriginal(req, res) {
     });
   }
 
-  const extension = inferExtension({ ext, filename, contentType });
+  const filenameCandidates = [filename, file_name, fileName, file?.name, payload?.file?.name];
+  let inferredFilename = '';
+  for (const candidate of filenameCandidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      inferredFilename = candidate.trim();
+      break;
+    }
+  }
+
+  const extension = inferExtension({ ext, filename: inferredFilename || filename, contentType });
   const objectKey = buildObjectKey({
     design_name: normalizedName,
     w_cm: widthValue,


### PR DESCRIPTION
## Summary
- replace the upload-original API shim with the shared CORS helper, higher size limits, multipart parsing, and structured 413 responses
- extend the upload handler to accept direct file buffers and richer metadata so multipart requests continue to work when the real uploader is enabled
- send binary uploads from the home page via FormData while keeping existing URL/base64 fallbacks

## Testing
- npx tsc --noEmit *(fails: repository already contains unrelated TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e520b580508327a5b133e4a549943e