### PR TITLE
Allow banknote moderation labels

### DIFF
--- a/api/_lib/moderation/labels.ts
+++ b/api/_lib/moderation/labels.ts
@@ -1,0 +1,206 @@
+const LABEL_KEYWORDS = [
+  'nud',
+  'sexual',
+  'sex',
+  'porn',
+  'adult',
+  'nazi',
+  'nazism',
+  'swastika',
+  'hitler',
+  'reich',
+  'extrem',
+  'hate',
+  'symbol',
+  'bank',
+  'money',
+  'currency',
+  'cash',
+  'bill',
+  'banknote',
+  'bank_note',
+];
+
+const LABEL_ALIASES: Record<string, string> = {
+  explicitnudity: 'explicit_nudity',
+  explicit_nudity: 'explicit_nudity',
+  graphicnudity: 'graphic_nudity',
+  graphic_nudity: 'graphic_nudity',
+  sexuallyexplicit: 'sexual',
+  sexual_content: 'sexual',
+  sexualcontent: 'sexual',
+  sexual_activity: 'sexual_activity',
+  sexualactivity: 'sexual_activity',
+  adult: 'adult_content',
+  adultcontent: 'adult_content',
+  adult_content: 'adult_content',
+  pornographic: 'porn',
+  pornography: 'porn',
+  porn_content: 'porn',
+  sexualandminors: 'sexual_minors',
+  sexual_minors: 'sexual_minors',
+  sexual_minors_content: 'sexual_minors',
+  sexualminor: 'sexual_minors',
+  sexualminors: 'sexual_minors',
+  child_sexual_abuse: 'sexual_minors',
+  child_sexual_assault: 'sexual_minors',
+  child_exploitation: 'sexual_minors',
+  childnudity: 'sexual_minors',
+  child_nudity: 'sexual_minors',
+  childpornography: 'sexual_minors',
+  child_pornography: 'sexual_minors',
+  minorssexual: 'sexual_minors',
+  minors_sexual: 'sexual_minors',
+  nazi: 'nazi',
+  nazism: 'nazism',
+  nazis: 'nazism',
+  nazi_symbol: 'nazi',
+  nazi_symbols: 'nazi',
+  swastika: 'swastika',
+  swastica: 'swastika',
+  svastika: 'swastika',
+  esvastica: 'swastika',
+  esvastika: 'swastika',
+  hitler: 'hitler',
+  hitlersymbol: 'hitler',
+  ss: 'ss_symbol',
+  ss_symbol: 'ss_symbol',
+  sssymbol: 'ss_symbol',
+  thirdreich: 'third_reich',
+  third_reich: 'third_reich',
+  hate_symbol: 'hate_symbol',
+  hate_symbols: 'hate_symbol',
+  extremistsymbol: 'extremist_symbol',
+  extremist_symbol: 'extremist_symbol',
+  extremist_symbols: 'extremist_symbol',
+  extremistpropaganda: 'extremist_symbol',
+  extremist: 'extremist_symbol',
+  extremist_content: 'extremist_symbol',
+  extremisticonography: 'extremist_symbol',
+  extremisticon: 'extremist_symbol',
+  extremistlogo: 'extremist_symbol',
+  extremistlogo_symbol: 'extremist_symbol',
+  currency: 'currency',
+  currencies: 'currency',
+  money: 'money',
+  cash: 'money',
+  banknote: 'banknote',
+  banknotes: 'banknote',
+  bank_note: 'bank_note',
+  bank_notes: 'bank_note',
+  banknoteusd: 'banknote',
+  banknote_usd: 'banknote',
+  banknote_eur: 'banknote',
+  banknoteeur: 'banknote',
+  banknote_gbp: 'banknote',
+  banknotecurrency: 'banknote',
+  paper_money: 'money',
+  papermoney: 'money',
+  money_bill: 'bill',
+  moneybill: 'bill',
+  dollar_bill: 'bill',
+  dollarbill: 'bill',
+  euro_bill: 'bill',
+  eurobill: 'bill',
+};
+
+const MAX_LABEL_LENGTH = 64;
+
+function normalizeString(value: unknown): string | null {
+  if (value == null) return null;
+  const raw = String(value).trim().toLowerCase();
+  if (!raw) return null;
+  const replaced = raw.replace(/[^a-z0-9]+/g, '_');
+  const collapsed = replaced.replace(/_+/g, '_').replace(/^_+|_+$/g, '');
+  if (!collapsed) return null;
+  if (collapsed.length > MAX_LABEL_LENGTH) return null;
+  const alias = LABEL_ALIASES[collapsed];
+  if (alias) return alias;
+  return collapsed;
+}
+
+function shouldConsider(label: string): boolean {
+  for (const keyword of LABEL_KEYWORDS) {
+    if (label.includes(keyword)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function visit(value: unknown, results: Set<string>, seen: WeakSet<object>) {
+  if (value == null) return;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    const normalized = normalizeString(value);
+    if (normalized && shouldConsider(normalized)) {
+      results.add(normalized);
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      visit(entry, results, seen);
+    }
+    return;
+  }
+  if (typeof value === 'object') {
+    if (seen.has(value)) return;
+    seen.add(value);
+    const candidateKeys = [
+      'label',
+      'labels',
+      'name',
+      'names',
+      'category',
+      'categories',
+      'class',
+      'classes',
+      'tag',
+      'tags',
+      'type',
+      'types',
+      'reason',
+      'reasons',
+      'value',
+      'values',
+      'description',
+      'descriptions',
+      'code',
+      'codes',
+      'keyword',
+      'keywords',
+      'concept',
+      'concepts',
+      'annotation',
+      'annotations',
+      'labelName',
+      'labelNames',
+      'moderationLabel',
+      'moderationLabels',
+      'ModerationLabel',
+      'ModerationLabels',
+    ];
+    for (const key of candidateKeys) {
+      const entry = (value as Record<string, unknown>)[key];
+      if (entry != null) {
+        visit(entry, results, seen);
+      }
+    }
+  }
+}
+
+export function normalizeLabels(input: unknown): string[] {
+  const results = new Set<string>();
+  const seen = new WeakSet<object>();
+  visit(input, results, seen);
+  return Array.from(results);
+}
+
+export function normalizeLabel(input: unknown): string | null {
+  const normalized = normalizeString(input);
+  if (!normalized) return null;
+  if (!shouldConsider(normalized)) return null;
+  return normalized;
+}
+
+export default { normalizeLabels, normalizeLabel };

--- a/api/moderate-image.ts
+++ b/api/moderate-image.ts
@@ -1,29 +1,429 @@
-export const config = { memory: 256, maxDuration: 10 } as const;
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import {
+  applyCors,
+  ensureCors,
+  handlePreflight,
+  respondCorsDenied,
+  type CorsDecision,
+} from './_lib/cors.js';
+import { createDiagId } from './_lib/diag.js';
+import logger from '../lib/_lib/logger.js';
+import { normalizeLabels } from './_lib/moderation/labels.js';
 
-function setCors(req: any, res: any) {
-  const origin = req?.headers?.origin;
-  res.setHeader('Access-Control-Allow-Origin', origin || '*');
-  res.setHeader('Vary', 'Origin');
-  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Debug-Fast');
-  res.setHeader('Content-Type', 'application/json');
+const DEFAULT_PREVIEW_LIMIT_BYTES = 2_000_000;
+const PREVIEW_LIMIT_BYTES = Number.isFinite(Number(process.env.MOD_PREVIEW_LIMIT_BYTES))
+  ? Number(process.env.MOD_PREVIEW_LIMIT_BYTES)
+  : DEFAULT_PREVIEW_LIMIT_BYTES;
+const BLOCK_NUDITY = new Set([
+  'nudity',
+  'explicit_nudity',
+  'graphic_nudity',
+  'sexual',
+  'porn',
+  'adult_content',
+  'sexual_activity',
+  'sexual_minors',
+]);
+const BLOCK_EXTREMISM = new Set([
+  'nazi',
+  'nazism',
+  'swastika',
+  'hitler',
+  'ss_symbol',
+  'third_reich',
+  'hate_symbol',
+  'extremist_symbol',
+]);
+const ALLOW_CURRENCY = new Set(['currency', 'banknote', 'bank_note', 'money', 'bill']);
+const BODY_LIMIT_BYTES = 8 * 1024 * 1024;
+
+class PayloadTooLargeError extends Error {
+  bytes: number;
+
+  constructor(bytes: number) {
+    super('payload_too_large');
+    this.name = 'PayloadTooLargeError';
+    this.bytes = bytes;
+  }
 }
 
-export default async function handler(req: any, res: any) {
-  setCors(req, res);
+function parseBooleanish(value: unknown): boolean {
+  if (value == null) return false;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) && value !== 0;
+  if (Array.isArray(value)) {
+    return value.some((entry) => parseBooleanish(entry));
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) return false;
+  return ['1', 'true', 'yes', 'y', 'on'].includes(normalized);
+}
+
+async function readRequestBody(req: VercelRequest): Promise<{ text: string; bytes: number }> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let finished = false;
+
+    const cleanup = () => {
+      req.off?.('data', onData);
+      req.off?.('end', onEnd);
+      req.off?.('error', onError);
+    };
+
+    const abort = (err: Error) => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      try {
+        req.pause?.();
+        req.destroy?.();
+      } catch {}
+      reject(err);
+    };
+
+    const onData = (chunk: Buffer | string) => {
+      if (finished) return;
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += buf.length;
+      if (BODY_LIMIT_BYTES > 0 && total > BODY_LIMIT_BYTES) {
+        abort(new PayloadTooLargeError(total));
+        return;
+      }
+      chunks.push(buf);
+    };
+
+    const onEnd = () => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      resolve({ text: Buffer.concat(chunks).toString('utf8'), bytes: total });
+    };
+
+    const onError = (err: Error) => {
+      abort(err);
+    };
+
+    req.on('data', onData);
+    req.on('end', onEnd);
+    req.on('error', onError);
+  });
+}
+
+function computeBase64Bytes(value: unknown): number {
+  if (typeof value !== 'string') return 0;
+  const trimmed = value.trim();
+  if (!trimmed) return 0;
+  const normalized = trimmed.replace(/^data:[^;]+;base64,/i, '');
+  try {
+    return Buffer.byteLength(normalized, 'base64');
+  } catch {
+    return 0;
+  }
+}
+
+function respondJson(
+  req: VercelRequest,
+  res: VercelResponse,
+  corsDecision: CorsDecision,
+  status: number,
+  payload: Record<string, unknown>,
+): void {
+  const body: Record<string, unknown> = payload ?? {};
+  applyCors(req, res, corsDecision);
+  const diagValue = typeof (body as Record<string, unknown>).diagId === 'string'
+    ? ((body as Record<string, unknown>).diagId as string)
+    : null;
+  if (diagValue) {
+    res.setHeader('X-Diag-Id', diagValue);
+  }
+  if (typeof res.status === 'function' && typeof res.json === 'function') {
+    res.status(status);
+    res.json(body);
+    return;
+  }
+  if (typeof res.status === 'function') {
+    res.status(status);
+  } else {
+    res.statusCode = status;
+  }
+  try {
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  } catch {}
+  res.end(JSON.stringify(body));
+}
+
+function resolveExtremismReason(labels: Set<string>): 'nazism' | 'extremism' {
+  const naziIndicators = ['nazi', 'nazism', 'swastika', 'hitler', 'third_reich'];
+  for (const indicator of naziIndicators) {
+    if (labels.has(indicator)) {
+      return 'nazism';
+    }
+  }
+  return 'extremism';
+}
+
+function collectLabelSources(payload: Record<string, unknown> | null | undefined): unknown[] {
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+  const sources: unknown[] = [];
+  const keys = [
+    'label',
+    'labels',
+    'moderationLabel',
+    'moderationLabels',
+    'ModerationLabel',
+    'ModerationLabels',
+    'moderation_labels',
+    'moderation',
+    'moderationResult',
+    'moderationResults',
+    'moderation_result',
+    'moderation_results',
+    'analysis',
+    'analyses',
+    'category',
+    'categories',
+    'tag',
+    'tags',
+    'concept',
+    'concepts',
+    'class',
+    'classes',
+    'result',
+    'results',
+    'output',
+    'outputs',
+    'prediction',
+    'predictions',
+    'detection',
+    'detections',
+    'flag',
+    'flags',
+    'reason',
+    'reasons',
+  ];
+  const record = payload as Record<string, unknown>;
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(record, key)) {
+      sources.push(record[key]);
+    }
+  }
+  const providers = (record as Record<string, unknown> & { providers?: unknown[] }).providers;
+  if (Array.isArray(providers)) {
+    for (const entry of providers) {
+      if (entry && typeof entry === 'object') {
+        sources.push(...collectLabelSources(entry as Record<string, unknown>));
+      }
+    }
+  }
+  const results = (record as Record<string, unknown> & { results?: unknown[] }).results;
+  if (Array.isArray(results)) {
+    for (const entry of results) {
+      if (entry && typeof entry === 'object') {
+        sources.push(...collectLabelSources(entry as Record<string, unknown>));
+      }
+    }
+  }
+  const outputs = (record as Record<string, unknown> & { outputs?: unknown[] }).outputs;
+  if (Array.isArray(outputs)) {
+    for (const entry of outputs) {
+      if (entry && typeof entry === 'object') {
+        sources.push(...collectLabelSources(entry as Record<string, unknown>));
+      }
+    }
+  }
+  const detections = (record as Record<string, unknown> & { detections?: unknown[] }).detections;
+  if (Array.isArray(detections)) {
+    for (const entry of detections) {
+      if (entry && typeof entry === 'object') {
+        sources.push(...collectLabelSources(entry as Record<string, unknown>));
+      }
+    }
+  }
+  const predictions = (record as Record<string, unknown> & { predictions?: unknown[] }).predictions;
+  if (Array.isArray(predictions)) {
+    for (const entry of predictions) {
+      if (entry && typeof entry === 'object') {
+        sources.push(...collectLabelSources(entry as Record<string, unknown>));
+      }
+    }
+  }
+  return sources;
+}
+
+export const config = {
+  api: {
+    bodyParser: false,
+    sizeLimit: '8mb',
+  },
+  memory: 256,
+  maxDuration: 10,
+} as const;
+
+export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
+  const diagId = createDiagId();
+  const corsDecision = ensureCors(req, res);
+
+  if (!corsDecision.allowed || !corsDecision.allowedOrigin) {
+    respondCorsDenied(req, res, corsDecision, diagId);
+    return;
+  }
 
   if (req.method === 'OPTIONS') {
-    res.statusCode = 200;
-    res.end();
+    handlePreflight(req, res, corsDecision);
     return;
   }
 
   if (req.method !== 'POST') {
-    res.statusCode = 405;
-    res.end(JSON.stringify({ ok: false, error: 'Method Not Allowed' }));
+    respondJson(req, res, corsDecision, 405, {
+      ok: false,
+      code: 'method_not_allowed',
+      diagId,
+    });
     return;
   }
 
-  res.statusCode = 200;
-  res.end(JSON.stringify({ ok: true, stub: true }));
+  let text: string | null = null;
+  let receivedBytes = 0;
+  try {
+    const body = await readRequestBody(req);
+    text = body.text;
+    receivedBytes = body.bytes;
+  } catch (err) {
+    if (err instanceof PayloadTooLargeError) {
+      respondJson(req, res, corsDecision, 413, {
+        ok: false,
+        code: 'payload_too_large',
+        diagId,
+        receivedBytes: err.bytes,
+        limitBytes: BODY_LIMIT_BYTES,
+      });
+      return;
+    }
+    logger.error?.('[moderate-image] body_read_failed', { diagId, error: err instanceof Error ? err.message : err });
+    respondJson(req, res, corsDecision, 400, {
+      ok: false,
+      code: 'invalid_body',
+      diagId,
+    });
+    return;
+  }
+
+  let payload: Record<string, unknown> = {};
+  if (text && text.trim()) {
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed && typeof parsed === 'object') {
+        payload = parsed as Record<string, unknown>;
+      } else {
+        payload = {};
+      }
+    } catch (err) {
+      logger.warn?.('[moderate-image] invalid_json', { diagId, error: err instanceof Error ? err.message : err });
+      respondJson(req, res, corsDecision, 400, {
+        ok: false,
+        code: 'invalid_json',
+        diagId,
+      });
+      return;
+    }
+  }
+
+  const isPreview =
+    parseBooleanish((req.query as Record<string, unknown> | undefined)?.['preview'])
+    || parseBooleanish(req.headers['x-preview']);
+
+  let previewBase64: string | null = null;
+  const previewCandidates = [
+    payload['imageBase64'],
+    payload['image_base64'],
+    payload['previewBase64'],
+    payload['preview_base64'],
+  ];
+  for (const candidate of previewCandidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      previewBase64 = candidate;
+      break;
+    }
+  }
+
+  const previewBytes = computeBase64Bytes(previewBase64);
+
+  if (isPreview && PREVIEW_LIMIT_BYTES > 0 && previewBytes > PREVIEW_LIMIT_BYTES) {
+    logger.info?.('[moderate-image] preview_too_large', {
+      diagId,
+      previewBytes,
+      limitBytes: PREVIEW_LIMIT_BYTES,
+    });
+    respondJson(req, res, corsDecision, 413, {
+      ok: false,
+      code: 'preview_too_large',
+      diagId,
+      limitBytes: PREVIEW_LIMIT_BYTES,
+      previewBytes,
+    });
+    return;
+  }
+
+  const labelSources = collectLabelSources(payload);
+  const normalizedLabels = normalizeLabels(labelSources);
+  const labelSet = new Set(normalizedLabels);
+
+  const hasNudity = normalizedLabels.some((label) => BLOCK_NUDITY.has(label));
+  const extremismMatches = normalizedLabels.filter((label) => BLOCK_EXTREMISM.has(label));
+  const hasExtremism = extremismMatches.length > 0;
+  const hasLabels = normalizedLabels.length > 0;
+  const onlyCurrency = hasLabels && normalizedLabels.every((label) => ALLOW_CURRENCY.has(label));
+  const currencyPresent = normalizedLabels.some((label) => ALLOW_CURRENCY.has(label));
+
+  const allowBanknotesRaw = process.env.MOD_ALLOW_BANKNOTES ?? '1';
+  const allowBanknotes = allowBanknotesRaw === '1';
+
+  let decision: 'allowed' | 'blocked_nudity' | 'blocked_extremism' | 'allowed_banknote' = 'allowed';
+
+  if (hasNudity) {
+    decision = 'blocked_nudity';
+  } else if (hasExtremism || (!allowBanknotes && onlyCurrency && currencyPresent)) {
+    decision = 'blocked_extremism';
+  } else if (onlyCurrency && currencyPresent) {
+    decision = 'allowed_banknote';
+  }
+
+  logger.info?.('[moderate-image] decision', {
+    diagId,
+    decision,
+    labels: Array.from(labelSet),
+    allowBanknotes: allowBanknotesRaw,
+    preview: isPreview,
+    receivedBytes,
+  });
+
+  if (decision === 'blocked_nudity') {
+    respondJson(req, res, corsDecision, 422, {
+      ok: false,
+      code: 'moderation_blocked',
+      reason: 'nudity',
+      diagId,
+    });
+    return;
+  }
+
+  if (decision === 'blocked_extremism') {
+    const extremismSet = new Set(extremismMatches);
+    const reason = resolveExtremismReason(extremismSet.size ? extremismSet : labelSet);
+    respondJson(req, res, corsDecision, 422, {
+      ok: false,
+      code: 'moderation_blocked',
+      reason,
+      diagId,
+    });
+    return;
+  }
+
+  respondJson(req, res, corsDecision, 200, {
+    ok: true,
+    diagId,
+  });
 }


### PR DESCRIPTION
## Summary
- add a shared moderation label normalizer that harmonizes provider label variants
- update the moderation endpoint to block nudity/extremism, allow banknote labels when enabled, and log decisions with CORS-compliant responses

## Testing
- `npx tsc --noEmit` *(fails: pre-existing type errors in unrelated analytics and shopify files)*

------
https://chatgpt.com/codex/tasks/task_e_68e531faa73483278e4c501df9938882