### PR TITLE
Allow publish product handler to accept mockup URLs

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -150,6 +150,74 @@ const ROLLO_PRICING = {
   Clasic: { width: 140, pricePerMeter: 23820, multiplier: 2.7, baselineArea: 0.36 },
 };
 
+const HTTP_URL_REGEX = /^https?:\/\//i;
+
+function pickStringFromSources(sources, keys) {
+  for (const source of sources) {
+    if (!source || typeof source !== 'object') continue;
+    for (const key of keys) {
+      if (!key) continue;
+      const value = source?.[key];
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed) return trimmed;
+      }
+    }
+  }
+  return '';
+}
+
+function normalizeMockupPayload(body) {
+  const empty = { originalUrl: '', previewUrl: '', dataUrl: '' };
+  if (!body || typeof body !== 'object') return empty;
+
+  const mockup = body?.mockup && typeof body.mockup === 'object' ? body.mockup : null;
+  const assets = body?.assets && typeof body.assets === 'object' ? body.assets : null;
+  const mockupAssets = mockup?.assets && typeof mockup.assets === 'object' ? mockup.assets : null;
+
+  const sources = [mockup, mockupAssets, assets, body];
+
+  const originalUrlRaw = pickStringFromSources(sources, [
+    'originalUrl',
+    'original_url',
+    'mockupOriginalUrl',
+    'mockup_original_url',
+    'designUrl',
+    'design_url',
+  ]);
+  const previewUrlRaw = pickStringFromSources(sources, [
+    'previewUrl',
+    'preview_url',
+    'mockupPreviewUrl',
+    'mockup_preview_url',
+    'previewImageUrl',
+    'preview_image_url',
+    'mockupUrl',
+    'mockup_url',
+  ]);
+  const dataUrlRaw = pickStringFromSources(sources, [
+    'dataUrl',
+    'data_url',
+    'mockupDataUrl',
+    'mockup_data_url',
+    'previewDataUrl',
+    'preview_data_url',
+  ]);
+
+  const normalizeUrl = (value) => {
+    if (typeof value !== 'string') return '';
+    const trimmed = value.trim();
+    if (!trimmed) return '';
+    return HTTP_URL_REGEX.test(trimmed) ? trimmed : '';
+  };
+
+  return {
+    originalUrl: normalizeUrl(originalUrlRaw),
+    previewUrl: normalizeUrl(previewUrlRaw),
+    dataUrl: typeof dataUrlRaw === 'string' ? dataUrlRaw.trim() : '',
+  };
+}
+
 function mapCalculatorMaterial(material, productTypeKey) {
   if (productTypeKey === 'glasspad') return 'Glasspad';
   const raw = typeof material === 'string' ? material.trim().toLowerCase() : '';
@@ -1825,17 +1893,153 @@ export async function publishProduct(req, res) {
     }
     body = body && typeof body === 'object' ? body : {};
 
-    const mockupDataUrl = typeof body.mockupDataUrl === 'string' ? body.mockupDataUrl : '';
+    const mockupPayload = normalizeMockupPayload(body);
     const filename = typeof body.filename === 'string' && body.filename ? body.filename : 'mockup.png';
     const warnings = [];
     let variantInventoryMode = 'not_tracked';
     let variantAvailableForSale = null;
 
-    if (!mockupDataUrl) {
-      return res.status(400).json({ ok: false, reason: 'missing_mockup_dataurl' });
+    if (!mockupPayload.originalUrl) {
+      return res.status(400).json({ ok: false, reason: 'missing_mockup_originalurl' });
     }
-    const b64 = (mockupDataUrl.split(',')[1] || '').trim();
-    if (!b64) return res.status(400).json({ ok: false, reason: 'invalid_mockup_dataurl' });
+
+    const previewUrl = mockupPayload.previewUrl;
+    const originalUrl = mockupPayload.originalUrl;
+    const rawDataUrl = typeof mockupPayload.dataUrl === 'string' ? mockupPayload.dataUrl.trim() : '';
+    const hasPreview = Boolean(previewUrl);
+    const hasOriginal = Boolean(originalUrl);
+
+    let stagedImage = null;
+    let coverImageSource = '';
+    let coverSourceUsed = '';
+    let stagedDataUrlError = null;
+
+    if (hasPreview) {
+      coverImageSource = previewUrl;
+      coverSourceUsed = 'previewUrl';
+    }
+
+    if (!coverImageSource && rawDataUrl) {
+      if (HTTP_URL_REGEX.test(rawDataUrl)) {
+        coverImageSource = rawDataUrl;
+        coverSourceUsed = 'dataUrl';
+      } else if (rawDataUrl.startsWith('data:')) {
+        const base64Part = (rawDataUrl.split(',')[1] || '').trim();
+        if (!base64Part) {
+          stagedDataUrlError = 'invalid_mockup_dataurl';
+        } else {
+          const { mimeType } = parseDataUrlMeta(rawDataUrl);
+          if (!mimeType) {
+            stagedDataUrlError = 'invalid_mockup_dataurl';
+          } else {
+            const imageBuffer = Buffer.from(base64Part, 'base64');
+            if (!imageBuffer.length) {
+              stagedDataUrlError = 'invalid_mockup_dataurl';
+            } else {
+              try {
+                stagedImage = await stagedUploadImage({ filename, buffer: imageBuffer, mimeType });
+              } catch (err) {
+                const status = typeof err?.status === 'number' ? err.status : 502;
+                const formattedErrors = Array.isArray(err?.errors) && err.errors.length
+                  ? err.errors
+                  : formatGraphQLErrors(err?.body?.errors);
+                const stagedUserErrors = Array.isArray(err?.userErrors) && err.userErrors.length
+                  ? err.userErrors
+                  : sanitizeUserErrors(err?.body?.userErrors);
+                const combined = [
+                  ...(Array.isArray(formattedErrors) ? formattedErrors : []),
+                  ...(Array.isArray(stagedUserErrors) ? stagedUserErrors : []),
+                ];
+                const extraMessages = [
+                  typeof err?.message === 'string' ? err.message : '',
+                  typeof err?.body === 'string' ? err.body : '',
+                  typeof err?.body?.message === 'string' ? err.body.message : '',
+                ];
+                const missingFilesScope = detectMissingFilesScope(combined)
+                  || extraMessages.some((msg) => isMissingFilesScopeMessage(msg));
+
+                const stageRequestId = err?.requestId || null;
+                const uploadRequestId = err?.uploadRequestId || null;
+
+                const warningBase = {
+                  code: missingFilesScope ? 'missing_write_files_scope' : 'image_upload_failed',
+                  status,
+                  requestId: stageRequestId,
+                  uploadRequestId,
+                  detail: formattedErrors?.length || stagedUserErrors?.length
+                    ? {
+                      ...(formattedErrors?.length ? { errors: formattedErrors } : {}),
+                      ...(stagedUserErrors?.length ? { userErrors: stagedUserErrors } : {}),
+                    }
+                    : err?.body || null,
+                };
+
+                const message = missingFilesScope
+                  ? 'No se pudo subir la imagen porque falta el scope write_files. Se seguirá sin mockup.'
+                  : 'No se pudo subir la imagen, se seguirá sin mockup.';
+
+                const warningPayload = {
+                  ...warningBase,
+                  message,
+                  ...(missingFilesScope ? { missing: ['write_files'] } : {}),
+                };
+
+                warnings.push(warningPayload);
+
+                try {
+                  logger.warn('product_image_upload_warning', {
+                    message,
+                    status,
+                    requestId: stageRequestId,
+                    uploadRequestId,
+                    missingFilesScope,
+                    attempt: typeof err?.attempt === 'number' ? err.attempt : null,
+                    errors: Array.isArray(formattedErrors) && formattedErrors.length ? formattedErrors : undefined,
+                    userErrors: Array.isArray(stagedUserErrors) && stagedUserErrors.length ? stagedUserErrors : undefined,
+                  });
+                } catch {}
+
+                stagedImage = null;
+              }
+            }
+          }
+        }
+
+        if (!coverImageSource && stagedImage?.originalSource) {
+          coverImageSource = stagedImage.originalSource;
+          coverSourceUsed = 'dataUrl';
+        }
+      } else {
+        stagedDataUrlError = 'invalid_mockup_dataurl';
+      }
+    }
+
+    if (!coverImageSource && hasOriginal) {
+      coverImageSource = originalUrl;
+      coverSourceUsed = 'originalUrl';
+    }
+
+    if (!coverImageSource && stagedImage?.originalSource) {
+      coverImageSource = stagedImage.originalSource;
+      coverSourceUsed = coverSourceUsed || 'dataUrl';
+    }
+
+    if (!coverImageSource) {
+      return res.status(400).json({ ok: false, reason: 'missing_mockup_originalurl' });
+    }
+
+    if (stagedDataUrlError && !hasPreview && !hasOriginal) {
+      return res.status(400).json({ ok: false, reason: stagedDataUrlError });
+    }
+
+    try {
+      logger.debug('publish_product_cover_source', {
+        coverSource: coverSourceUsed || null,
+        hasPreview,
+        hasDataUrl: Boolean(rawDataUrl),
+        hasOriginal,
+      });
+    } catch {}
 
     const designNameRaw = typeof body.designName === 'string' ? body.designName.trim() : '';
     const { key: productTypeKey, label: productTypeLabel } = pickProductType(body.productType);
@@ -1894,80 +2098,6 @@ export async function publishProduct(req, res) {
     const imageAlt = typeof body.imageAlt === 'string' && body.imageAlt.trim()
       ? body.imageAlt.trim().slice(0, 254)
       : title;
-
-    const { mimeType } = parseDataUrlMeta(mockupDataUrl);
-    const imageBuffer = Buffer.from(b64, 'base64');
-    if (!imageBuffer.length) {
-      return res.status(400).json({ ok: false, reason: 'invalid_mockup_dataurl' });
-    }
-
-    let stagedImage;
-    try {
-      stagedImage = await stagedUploadImage({ filename, buffer: imageBuffer, mimeType });
-    } catch (err) {
-      const status = typeof err?.status === 'number' ? err.status : 502;
-      const formattedErrors = Array.isArray(err?.errors) && err.errors.length
-        ? err.errors
-        : formatGraphQLErrors(err?.body?.errors);
-      const stagedUserErrors = Array.isArray(err?.userErrors) && err.userErrors.length
-        ? err.userErrors
-        : sanitizeUserErrors(err?.body?.userErrors);
-      const combined = [
-        ...(Array.isArray(formattedErrors) ? formattedErrors : []),
-        ...(Array.isArray(stagedUserErrors) ? stagedUserErrors : []),
-      ];
-      const extraMessages = [
-        typeof err?.message === 'string' ? err.message : '',
-        typeof err?.body === 'string' ? err.body : '',
-        typeof err?.body?.message === 'string' ? err.body.message : '',
-      ];
-      const missingFilesScope = detectMissingFilesScope(combined)
-        || extraMessages.some((msg) => isMissingFilesScopeMessage(msg));
-
-      const stageRequestId = err?.requestId || null;
-      const uploadRequestId = err?.uploadRequestId || null;
-
-      const warningBase = {
-        code: missingFilesScope ? 'missing_write_files_scope' : 'image_upload_failed',
-        status,
-        requestId: stageRequestId,
-        uploadRequestId,
-        detail: formattedErrors?.length || stagedUserErrors?.length
-          ? {
-            ...(formattedErrors?.length ? { errors: formattedErrors } : {}),
-            ...(stagedUserErrors?.length ? { userErrors: stagedUserErrors } : {}),
-          }
-          : err?.body || null,
-      };
-
-      const message = missingFilesScope
-        ? 'No se pudo subir la imagen porque falta el scope write_files. Se seguirá sin mockup.'
-        : 'No se pudo subir la imagen, se seguirá sin mockup.';
-
-      const warningPayload = {
-        ...warningBase,
-        message,
-        ...(missingFilesScope ? { missing: ['write_files'] } : {}),
-      };
-
-      warnings.push(warningPayload);
-
-      try {
-        logger.warn('product_image_upload_warning', {
-          message,
-          status,
-          requestId: stageRequestId,
-          uploadRequestId,
-          missingFilesScope,
-          attempt: typeof err?.attempt === 'number' ? err.attempt : null,
-          errors: Array.isArray(formattedErrors) && formattedErrors.length ? formattedErrors : undefined,
-          userErrors: Array.isArray(stagedUserErrors) && stagedUserErrors.length ? stagedUserErrors : undefined,
-        });
-      } catch {}
-
-      stagedImage = null;
-    }
-
 
     const basePrice = isFiniteNumber(priceTransfer) ? Math.max(priceTransfer, 0) : 0;
     const computedPrice = basePrice;
@@ -2127,8 +2257,8 @@ export async function publishProduct(req, res) {
       });
     }
 
-    const productMediaInput = stagedImage?.originalSource
-      ? [{ mediaContentType: 'IMAGE', originalSource: stagedImage.originalSource, alt: imageAlt }]
+    const productMediaInput = coverImageSource
+      ? [{ mediaContentType: 'IMAGE', originalSource: coverImageSource, alt: imageAlt }]
       : [];
 
     const productInput = {


### PR DESCRIPTION
## Summary
- normalize incoming mockup data so publishProduct accepts original and preview URLs in addition to legacy data URLs
- drop the hard requirement on mockup.dataUrl, returning a clearer error when the original URL is missing while falling back to preview/original URLs for media
- use the resolved cover image URL when creating Shopify media and log which source was selected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e554b99f14832794cda1f532a5c58c