### PR TITLE
Handle mockup image sources when publishing products

### DIFF
--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -151,6 +151,9 @@ const ROLLO_PRICING = {
 };
 
 const HTTP_URL_REGEX = /^https?:\/\//i;
+const DATA_URL_PREFIX_REGEX = /^data:/i;
+const SHOPIFY_IMAGE_SIGNED_URL_TTL_SECONDS = 1200;
+const SUPABASE_BUCKET_VISIBILITY_CACHE = new Map();
 
 function pickStringFromSources(sources, keys) {
   for (const source of sources) {
@@ -168,7 +171,7 @@ function pickStringFromSources(sources, keys) {
 }
 
 function normalizeMockupPayload(body) {
-  const empty = { originalUrl: '', previewUrl: '', dataUrl: '' };
+  const empty = { originalUrl: '', previewUrl: '', imageUrl: '', dataUrl: '' };
   if (!body || typeof body !== 'object') return empty;
 
   const mockup = body?.mockup && typeof body.mockup === 'object' ? body.mockup : null;
@@ -195,6 +198,14 @@ function normalizeMockupPayload(body) {
     'mockupUrl',
     'mockup_url',
   ]);
+  const imageUrlRaw = pickStringFromSources(sources, [
+    'imageUrl',
+    'image_url',
+    'mockupImageUrl',
+    'mockup_image_url',
+    'coverUrl',
+    'cover_url',
+  ]);
   const dataUrlRaw = pickStringFromSources(sources, [
     'dataUrl',
     'data_url',
@@ -208,14 +219,137 @@ function normalizeMockupPayload(body) {
     if (typeof value !== 'string') return '';
     const trimmed = value.trim();
     if (!trimmed) return '';
-    return HTTP_URL_REGEX.test(trimmed) ? trimmed : '';
+    if (DATA_URL_PREFIX_REGEX.test(trimmed)) return '';
+    if (/^(blob:|file:)/i.test(trimmed)) return '';
+    return trimmed;
   };
 
   return {
     originalUrl: normalizeUrl(originalUrlRaw),
     previewUrl: normalizeUrl(previewUrlRaw),
+    imageUrl: normalizeUrl(imageUrlRaw),
     dataUrl: typeof dataUrlRaw === 'string' ? dataUrlRaw.trim() : '',
   };
+}
+
+function parseSupabaseStoragePath(raw) {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (HTTP_URL_REGEX.test(trimmed)) return null;
+  if (DATA_URL_PREFIX_REGEX.test(trimmed)) return null;
+  const normalized = trimmed.replace(/^\/+/, '');
+  const segments = normalized.split('/');
+  if (segments.length < 2) return null;
+  const [bucket, ...rest] = segments;
+  const path = rest.join('/').replace(/^\/+/, '');
+  if (!bucket || !path) return null;
+  return { bucket, path };
+}
+
+async function resolveSupabaseImageUrl({ bucket, path, diagId, source }) {
+  try {
+    const supabase = getSupabaseAdmin();
+    const storage = supabase.storage.from(bucket);
+
+    let isPublic = null;
+    if (SUPABASE_BUCKET_VISIBILITY_CACHE.has(bucket)) {
+      const cached = SUPABASE_BUCKET_VISIBILITY_CACHE.get(bucket);
+      if (typeof cached === 'boolean') {
+        isPublic = cached;
+      }
+    }
+
+    if (isPublic === null) {
+      try {
+        const { data, error } = await supabase.storage.getBucket(bucket);
+        if (error) {
+          logger.warn('publish_product_bucket_lookup_failed', {
+            diagId: diagId || null,
+            bucket,
+            source: source || null,
+            status: error?.status || error?.statusCode || null,
+            message: error?.message || String(error),
+          });
+        } else if (data && typeof data.public === 'boolean') {
+          isPublic = data.public === true;
+          SUPABASE_BUCKET_VISIBILITY_CACHE.set(bucket, isPublic);
+        }
+      } catch (err) {
+        logger.warn('publish_product_bucket_lookup_exception', {
+          diagId: diagId || null,
+          bucket,
+          source: source || null,
+          message: err?.message || String(err),
+        });
+      }
+    }
+
+    if (isPublic === true) {
+      const { data } = storage.getPublicUrl(path);
+      if (data?.publicUrl) {
+        return { url: data.publicUrl, bucket, path, isSigned: false, visibility: 'public' };
+      }
+    }
+
+    try {
+      const { data: signedData, error: signedError } = await storage.createSignedUrl(
+        path,
+        SHOPIFY_IMAGE_SIGNED_URL_TTL_SECONDS,
+        { download: false },
+      );
+      if (signedError) {
+        logger.warn('publish_product_signed_url_failed', {
+          diagId: diagId || null,
+          bucket,
+          path,
+          source: source || null,
+          status: signedError?.status || signedError?.statusCode || null,
+          message: signedError?.message || String(signedError),
+        });
+      } else if (signedData?.signedUrl) {
+        return {
+          url: signedData.signedUrl,
+          bucket,
+          path,
+          isSigned: true,
+          visibility: 'signed',
+          expiresIn: signedData?.expiresIn || SHOPIFY_IMAGE_SIGNED_URL_TTL_SECONDS,
+        };
+      }
+    } catch (err) {
+      logger.warn('publish_product_signed_url_exception', {
+        diagId: diagId || null,
+        bucket,
+        path,
+        source: source || null,
+        message: err?.message || String(err),
+      });
+    }
+
+    if (isPublic !== false) {
+      const { data: publicFallback } = storage.getPublicUrl(path);
+      if (publicFallback?.publicUrl) {
+        return {
+          url: publicFallback.publicUrl,
+          bucket,
+          path,
+          isSigned: false,
+          visibility: isPublic === true ? 'public' : 'unknown',
+        };
+      }
+    }
+  } catch (err) {
+    logger.warn('publish_product_supabase_resolve_exception', {
+      diagId: diagId || null,
+      bucket,
+      path,
+      source: source || null,
+      message: err?.message || String(err),
+    });
+  }
+
+  return { url: '', bucket, path, isSigned: false, visibility: null };
 }
 
 function mapCalculatorMaterial(material, productTypeKey) {
@@ -1899,145 +2033,199 @@ export async function publishProduct(req, res) {
     let variantInventoryMode = 'not_tracked';
     let variantAvailableForSale = null;
 
-    if (!mockupPayload.originalUrl) {
-      return res.status(400).json({ ok: false, reason: 'missing_mockup_originalurl' });
-    }
+    const diagId = req?.mgmDiagId || null;
 
     const previewUrl = mockupPayload.previewUrl;
     const originalUrl = mockupPayload.originalUrl;
+    const imageUrl = mockupPayload.imageUrl;
     const rawDataUrl = typeof mockupPayload.dataUrl === 'string' ? mockupPayload.dataUrl.trim() : '';
     const hasPreview = Boolean(previewUrl);
     const hasOriginal = Boolean(originalUrl);
+    const hasImageUrl = Boolean(imageUrl);
+    const hasRawDataUrl = Boolean(rawDataUrl);
+    const hasDataUrl = hasRawDataUrl && rawDataUrl.toLowerCase().startsWith('data:image');
 
     let stagedImage = null;
     let coverImageSource = '';
     let coverSourceUsed = '';
+    let coverImageMode = '';
+    let coverImageAttachment = '';
+    let coverImageAttachmentMime = '';
+    let coverImageSupabase = null;
     let stagedDataUrlError = null;
 
-    if (hasPreview) {
-      coverImageSource = previewUrl;
-      coverSourceUsed = 'previewUrl';
-    }
-
-    if (!coverImageSource && rawDataUrl) {
-      if (HTTP_URL_REGEX.test(rawDataUrl)) {
-        coverImageSource = rawDataUrl;
-        coverSourceUsed = 'dataUrl';
-      } else if (rawDataUrl.startsWith('data:')) {
-        const base64Part = (rawDataUrl.split(',')[1] || '').trim();
-        if (!base64Part) {
+    if (hasDataUrl) {
+      const base64Part = (rawDataUrl.split(',')[1] || '').replace(/\s+/g, '');
+      if (!base64Part) {
+        stagedDataUrlError = 'invalid_mockup_dataurl';
+      } else {
+        const { mimeType } = parseDataUrlMeta(rawDataUrl);
+        if (!mimeType) {
           stagedDataUrlError = 'invalid_mockup_dataurl';
         } else {
-          const { mimeType } = parseDataUrlMeta(rawDataUrl);
-          if (!mimeType) {
+          let imageBuffer = null;
+          try {
+            imageBuffer = Buffer.from(base64Part, 'base64');
+          } catch (err) {
+            imageBuffer = null;
+          }
+          if (!imageBuffer || !imageBuffer.length) {
             stagedDataUrlError = 'invalid_mockup_dataurl';
           } else {
-            const imageBuffer = Buffer.from(base64Part, 'base64');
-            if (!imageBuffer.length) {
-              stagedDataUrlError = 'invalid_mockup_dataurl';
-            } else {
+            coverImageAttachment = base64Part;
+            coverImageAttachmentMime = mimeType;
+            try {
+              stagedImage = await stagedUploadImage({ filename, buffer: imageBuffer, mimeType });
+            } catch (err) {
+              const status = typeof err?.status === 'number' ? err.status : 502;
+              const formattedErrors = Array.isArray(err?.errors) && err.errors.length
+                ? err.errors
+                : formatGraphQLErrors(err?.body?.errors);
+              const stagedUserErrors = Array.isArray(err?.userErrors) && err.userErrors.length
+                ? err.userErrors
+                : sanitizeUserErrors(err?.body?.userErrors);
+              const combined = [
+                ...(Array.isArray(formattedErrors) ? formattedErrors : []),
+                ...(Array.isArray(stagedUserErrors) ? stagedUserErrors : []),
+              ];
+              const extraMessages = [
+                typeof err?.message === 'string' ? err.message : '',
+                typeof err?.body === 'string' ? err.body : '',
+                typeof err?.body?.message === 'string' ? err.body.message : '',
+              ];
+              const missingFilesScope = detectMissingFilesScope(combined)
+                || extraMessages.some((msg) => isMissingFilesScopeMessage(msg));
+
+              const stageRequestId = err?.requestId || null;
+              const uploadRequestId = err?.uploadRequestId || null;
+
+              const warningBase = {
+                code: missingFilesScope ? 'missing_write_files_scope' : 'image_upload_failed',
+                status,
+                requestId: stageRequestId,
+                uploadRequestId,
+                detail: formattedErrors?.length || stagedUserErrors?.length
+                  ? {
+                    ...(formattedErrors?.length ? { errors: formattedErrors } : {}),
+                    ...(stagedUserErrors?.length ? { userErrors: stagedUserErrors } : {}),
+                  }
+                  : err?.body || null,
+              };
+
+              const message = missingFilesScope
+                ? 'No se pudo subir la imagen porque falta el scope write_files. Se seguirá sin mockup.'
+                : 'No se pudo subir la imagen, se seguirá sin mockup.';
+
+              const warningPayload = {
+                ...warningBase,
+                message,
+                ...(missingFilesScope ? { missing: ['write_files'] } : {}),
+              };
+
+              warnings.push(warningPayload);
+
               try {
-                stagedImage = await stagedUploadImage({ filename, buffer: imageBuffer, mimeType });
-              } catch (err) {
-                const status = typeof err?.status === 'number' ? err.status : 502;
-                const formattedErrors = Array.isArray(err?.errors) && err.errors.length
-                  ? err.errors
-                  : formatGraphQLErrors(err?.body?.errors);
-                const stagedUserErrors = Array.isArray(err?.userErrors) && err.userErrors.length
-                  ? err.userErrors
-                  : sanitizeUserErrors(err?.body?.userErrors);
-                const combined = [
-                  ...(Array.isArray(formattedErrors) ? formattedErrors : []),
-                  ...(Array.isArray(stagedUserErrors) ? stagedUserErrors : []),
-                ];
-                const extraMessages = [
-                  typeof err?.message === 'string' ? err.message : '',
-                  typeof err?.body === 'string' ? err.body : '',
-                  typeof err?.body?.message === 'string' ? err.body.message : '',
-                ];
-                const missingFilesScope = detectMissingFilesScope(combined)
-                  || extraMessages.some((msg) => isMissingFilesScopeMessage(msg));
-
-                const stageRequestId = err?.requestId || null;
-                const uploadRequestId = err?.uploadRequestId || null;
-
-                const warningBase = {
-                  code: missingFilesScope ? 'missing_write_files_scope' : 'image_upload_failed',
+                logger.warn('product_image_upload_warning', {
+                  message,
                   status,
                   requestId: stageRequestId,
                   uploadRequestId,
-                  detail: formattedErrors?.length || stagedUserErrors?.length
-                    ? {
-                      ...(formattedErrors?.length ? { errors: formattedErrors } : {}),
-                      ...(stagedUserErrors?.length ? { userErrors: stagedUserErrors } : {}),
-                    }
-                    : err?.body || null,
-                };
+                  missingFilesScope,
+                  attempt: typeof err?.attempt === 'number' ? err.attempt : null,
+                  errors: Array.isArray(formattedErrors) && formattedErrors.length ? formattedErrors : undefined,
+                  userErrors: Array.isArray(stagedUserErrors) && stagedUserErrors.length ? stagedUserErrors : undefined,
+                });
+              } catch {}
 
-                const message = missingFilesScope
-                  ? 'No se pudo subir la imagen porque falta el scope write_files. Se seguirá sin mockup.'
-                  : 'No se pudo subir la imagen, se seguirá sin mockup.';
+              stagedImage = null;
+            }
 
-                const warningPayload = {
-                  ...warningBase,
-                  message,
-                  ...(missingFilesScope ? { missing: ['write_files'] } : {}),
-                };
-
-                warnings.push(warningPayload);
-
-                try {
-                  logger.warn('product_image_upload_warning', {
-                    message,
-                    status,
-                    requestId: stageRequestId,
-                    uploadRequestId,
-                    missingFilesScope,
-                    attempt: typeof err?.attempt === 'number' ? err.attempt : null,
-                    errors: Array.isArray(formattedErrors) && formattedErrors.length ? formattedErrors : undefined,
-                    userErrors: Array.isArray(stagedUserErrors) && stagedUserErrors.length ? stagedUserErrors : undefined,
-                  });
-                } catch {}
-
-                stagedImage = null;
-              }
+            if (stagedImage?.originalSource) {
+              coverImageSource = stagedImage.originalSource;
+              coverSourceUsed = 'dataUrl';
+              coverImageMode = 'attachment';
             }
           }
         }
-
-        if (!coverImageSource && stagedImage?.originalSource) {
-          coverImageSource = stagedImage.originalSource;
-          coverSourceUsed = 'dataUrl';
-        }
-      } else {
-        stagedDataUrlError = 'invalid_mockup_dataurl';
       }
-    }
-
-    if (!coverImageSource && hasOriginal) {
-      coverImageSource = originalUrl;
-      coverSourceUsed = 'originalUrl';
-    }
-
-    if (!coverImageSource && stagedImage?.originalSource) {
-      coverImageSource = stagedImage.originalSource;
-      coverSourceUsed = coverSourceUsed || 'dataUrl';
+    } else if (hasRawDataUrl) {
+      stagedDataUrlError = 'invalid_mockup_dataurl';
     }
 
     if (!coverImageSource) {
-      return res.status(400).json({ ok: false, reason: 'missing_mockup_originalurl' });
+      const candidates = [
+        { key: 'previewUrl', value: previewUrl },
+        { key: 'originalUrl', value: originalUrl },
+        { key: 'imageUrl', value: imageUrl },
+      ];
+
+      for (const candidate of candidates) {
+        const candidateValue = typeof candidate.value === 'string' ? candidate.value.trim() : '';
+        if (!candidateValue) continue;
+
+        if (HTTP_URL_REGEX.test(candidateValue)) {
+          coverImageSource = candidateValue;
+          coverSourceUsed = candidate.key;
+          coverImageMode = 'src';
+          break;
+        }
+
+        const storagePath = parseSupabaseStoragePath(candidateValue);
+        if (!storagePath) continue;
+
+        const resolved = await resolveSupabaseImageUrl({
+          ...storagePath,
+          diagId,
+          source: candidate.key,
+        });
+
+        if (resolved?.url) {
+          coverImageSource = resolved.url;
+          coverSourceUsed = candidate.key;
+          coverImageMode = 'src';
+          coverImageSupabase = {
+            bucket: resolved.bucket,
+            path: resolved.path,
+            signed: resolved.isSigned === true,
+            visibility: resolved.visibility || null,
+          };
+          break;
+        }
+      }
     }
 
-    if (stagedDataUrlError && !hasPreview && !hasOriginal) {
-      return res.status(400).json({ ok: false, reason: stagedDataUrlError });
+    const hasAnyUrlCandidate = hasPreview || hasOriginal || hasImageUrl;
+    if (!coverImageSource) {
+      if (stagedDataUrlError && !hasAnyUrlCandidate) {
+        return res.status(400).json({
+          ok: false,
+          reason: stagedDataUrlError,
+          error: stagedDataUrlError,
+          ...(diagId ? { diagId } : {}),
+        });
+      }
+      return res.status(400).json({
+        ok: false,
+        reason: 'missing_mockup_image_source',
+        error: 'missing_mockup_image_source',
+        message: 'No se pudo determinar una imagen de mockup para publicar el producto.',
+        ...(diagId ? { diagId } : {}),
+      });
     }
 
     try {
       logger.debug('publish_product_cover_source', {
+        diagId: diagId || null,
         coverSource: coverSourceUsed || null,
+        imageMode: coverImageMode || null,
         hasPreview,
-        hasDataUrl: Boolean(rawDataUrl),
         hasOriginal,
+        hasImageUrl,
+        hasDataUrl,
+        hasAttachment: Boolean(coverImageAttachment),
+        attachmentMime: coverImageAttachmentMime || null,
+        resolvedUrl: coverImageSource || null,
+        supabase: coverImageSupabase || null,
       });
     } catch {}
 


### PR DESCRIPTION
## Summary
- allow `/api/publish-product` to keep mockup data URLs in the payload while still scrubbing unrelated base64 blobs
- resolve the publish handler cover image by preferring `mockup.dataUrl` attachments, otherwise falling back to preview/original/image URLs or Supabase storage paths with signed URLs
- add detailed diagnostics for the chosen image mode and return a `missing_mockup_image_source` error when no usable image was supplied

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e55a66531083279ad83aba18fe3e58