### PR TITLE
Handle payload limits and CORS on publish product route

### DIFF
--- a/api-routes/publish-product.js
+++ b/api-routes/publish-product.js
@@ -1,8 +1,162 @@
+import { randomUUID } from 'node:crypto';
 import publishProduct from '../lib/handlers/publishProduct.js';
 import { createApiHandler } from '../api/_lib/createHandler.js';
 import { resolveEnvRequirements } from '../api/_lib/envChecks.js';
+import { ensureCors, respondCorsDenied } from '../lib/cors.js';
 
-export default createApiHandler({
+const PAYLOAD_LIMIT_BYTES = 20 * 1024 * 1024; // 20 MiB
+const PAYLOAD_TOO_LARGE_HINT = 'El dataURL base64 agrega ~33% de tamaño. Subí el archivo original < 15 MB o usá /api/upload-original.';
+
+function sanitizeBase64Payload(raw) {
+  if (typeof raw !== 'string') return '';
+  return raw.replace(/\s+/g, '');
+}
+
+function estimateBase64Bytes(base64) {
+  const sanitized = sanitizeBase64Payload(base64);
+  if (!sanitized) return null;
+  const length = sanitized.length;
+  if (!length) return 0;
+  let padding = 0;
+  if (sanitized.endsWith('==')) padding = 2;
+  else if (sanitized.endsWith('=')) padding = 1;
+  const estimate = Math.floor((length * 3) / 4) - padding;
+  return estimate > 0 ? estimate : 0;
+}
+
+function resolveBinaryLength(candidate) {
+  if (!candidate) return null;
+  if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+    return candidate;
+  }
+  if (Buffer.isBuffer(candidate)) {
+    return candidate.length;
+  }
+  if (candidate instanceof ArrayBuffer) {
+    return candidate.byteLength;
+  }
+  if (ArrayBuffer.isView?.(candidate) && typeof candidate.byteLength === 'number') {
+    return candidate.byteLength;
+  }
+  if (typeof candidate === 'object' && typeof candidate.size === 'number') {
+    return candidate.size;
+  }
+  if (Array.isArray(candidate)) {
+    return candidate.length;
+  }
+  return null;
+}
+
+function estimatePayloadBytes(body) {
+  if (!body || typeof body !== 'object') return null;
+
+  if (typeof body.mockupDataUrl === 'string') {
+    const [, base64Part = ''] = body.mockupDataUrl.split(',');
+    const estimated = estimateBase64Bytes(base64Part);
+    if (typeof estimated === 'number' && estimated > 0) {
+      return estimated;
+    }
+  }
+
+  const binaryCandidates = [
+    body.mockupBuffer,
+    body.mockupBytes,
+    body.mockupArray,
+    body.mockupArrayBuffer,
+    body.mockupBinary,
+    body.mockup,
+  ];
+
+  for (const candidate of binaryCandidates) {
+    const length = resolveBinaryLength(candidate);
+    if (typeof length === 'number' && length > 0) {
+      return length;
+    }
+  }
+
+  return null;
+}
+
+function applyCustomCorsHeaders(res) {
+  res.setHeader?.('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader?.('Access-Control-Allow-Headers', 'content-type, authorization, x-diag');
+  res.setHeader?.('Access-Control-Max-Age', '86400');
+}
+
+function respondWithCorsJson(req, res, status, payload) {
+  const decision = ensureCors(req, res);
+  if (!decision?.allowed || !decision?.allowedOrigin) {
+    const diagId = randomUUID();
+    respondCorsDenied(req, res, decision, diagId);
+    return;
+  }
+
+  applyCustomCorsHeaders(res);
+
+  if (typeof res.status === 'function' && typeof res.json === 'function') {
+    res.status(status);
+    res.json(payload);
+    return;
+  }
+
+  if (typeof res.status === 'function') {
+    res.status(status);
+  } else {
+    res.statusCode = status;
+  }
+
+  try {
+    res.setHeader?.('Content-Type', 'application/json; charset=utf-8');
+  } catch {}
+
+  const body = JSON.stringify(payload);
+  if (typeof res.end === 'function') {
+    res.end(body);
+  } else if (typeof res.send === 'function') {
+    res.send(body);
+  }
+}
+
+function handleOptions(req, res) {
+  const decision = ensureCors(req, res);
+  if (!decision?.allowed || !decision?.allowedOrigin) {
+    const diagId = randomUUID();
+    respondCorsDenied(req, res, decision, diagId);
+    return;
+  }
+
+  applyCustomCorsHeaders(res);
+
+  if (typeof res.status === 'function') {
+    res.status(204);
+  } else {
+    res.statusCode = 204;
+  }
+
+  if (typeof res.end === 'function') {
+    res.end();
+  } else if (typeof res.send === 'function') {
+    res.send('');
+  }
+}
+
+function enforcePayloadLimit(req, res) {
+  const estimatedBytes = estimatePayloadBytes(req?.body);
+  if (typeof estimatedBytes === 'number' && estimatedBytes > PAYLOAD_LIMIT_BYTES) {
+    respondWithCorsJson(req, res, 413, {
+      ok: false,
+      reason: 'payload_too_large',
+      code: 'payload_too_large',
+      limitBytes: PAYLOAD_LIMIT_BYTES,
+      estimatedBytes,
+      hint: PAYLOAD_TOO_LARGE_HINT,
+    });
+    return true;
+  }
+  return false;
+}
+
+const baseHandler = createApiHandler({
   methods: 'POST',
   rateLimitKey: 'publish-product',
   context: 'publish-product',
@@ -10,4 +164,25 @@ export default createApiHandler({
   handler: publishProduct,
 });
 
-export const config = { runtime: 'nodejs' };
+export default async function publishProductRoute(req, res) {
+  const method = String(req?.method || '').toUpperCase();
+
+  if (method === 'OPTIONS') {
+    handleOptions(req, res);
+    return;
+  }
+
+  if (method === 'POST' && enforcePayloadLimit(req, res)) {
+    return;
+  }
+
+  return baseHandler(req, res);
+}
+
+export const config = {
+  runtime: 'nodejs',
+  api: {
+    bodyParser: true,
+    sizeLimit: '20mb',
+  },
+};

--- a/lib/handlers/publishProduct.js
+++ b/lib/handlers/publishProduct.js
@@ -14,6 +14,7 @@ import { applyStubCors, buildStubRequestId, handleStubOptions, isStubEnabled, re
 const DEFAULT_VENDOR = 'MgMGamers';
 const OUTPUT_BUCKET = 'outputs';
 const PUBLISH_PRODUCT_BODY_LIMIT = 20 * 1024 * 1024; // 20 MiB
+const PAYLOAD_TOO_LARGE_HINT = 'El dataURL base64 agrega ~33% de tamaño. Subí el archivo original < 15 MB o usá /api/upload-original.';
 const ONLINE_STORE_MISSING_MESSAGE = [
   'No pudimos encontrar el canal Online Store para publicar este producto.',
   'Revisá: 1) que el canal esté instalado, 2) que la app tenga el scope write_publications.',
@@ -134,6 +135,23 @@ function computeImageHash(buffer) {
     return createHash('sha256').update(Buffer.from(buffer)).digest('hex');
   }
   return createHash('sha256').update('empty').digest('hex');
+}
+
+function sanitizeBase64Payload(raw) {
+  if (typeof raw !== 'string') return '';
+  return raw.replace(/\s+/g, '');
+}
+
+function estimateBase64Bytes(base64) {
+  const sanitized = sanitizeBase64Payload(base64);
+  if (!sanitized) return 0;
+  const length = sanitized.length;
+  if (!length) return 0;
+  let padding = 0;
+  if (sanitized.endsWith('==')) padding = 2;
+  else if (sanitized.endsWith('=')) padding = 1;
+  const estimate = Math.floor((length * 3) / 4) - padding;
+  return estimate > 0 ? estimate : 0;
 }
 
 function buildMeasurement(widthCm, heightCm) {
@@ -1814,14 +1832,27 @@ export async function publishProduct(req, res) {
     try {
       body = await parseJsonBody(req, { limit: PUBLISH_PRODUCT_BODY_LIMIT });
     } catch (err) {
-      const code = err?.code === 'payload_too_large' ? 'payload_too_large'
-        : err?.code === 'invalid_json' ? 'invalid_body'
-          : 'invalid_body';
-      const status = err?.code === 'payload_too_large' ? 413 : 400;
-      const message = err?.code === 'payload_too_large'
-        ? 'El mockup es demasiado grande. Probá de nuevo con una imagen más liviana.'
-        : 'El cuerpo de la petición es inválido.';
-      return res.status(status).json({ ok: false, reason: code, message });
+      if (err?.code === 'payload_too_large') {
+        const headerLengthRaw = req?.headers?.['content-length'] || req?.headers?.['Content-Length'];
+        const headerCandidates = Array.isArray(headerLengthRaw) ? headerLengthRaw : [headerLengthRaw];
+        let estimatedBytes = PUBLISH_PRODUCT_BODY_LIMIT + 1;
+        for (const candidate of headerCandidates) {
+          const numeric = Number(candidate);
+          if (Number.isFinite(numeric) && numeric > 0) {
+            estimatedBytes = Math.floor(numeric);
+            break;
+          }
+        }
+        return res.status(413).json({
+          ok: false,
+          reason: 'payload_too_large',
+          code: 'payload_too_large',
+          limitBytes: PUBLISH_PRODUCT_BODY_LIMIT,
+          estimatedBytes,
+          hint: PAYLOAD_TOO_LARGE_HINT,
+        });
+      }
+      return res.status(400).json({ ok: false, reason: 'invalid_body', message: 'El cuerpo de la petición es inválido.' });
     }
     body = body && typeof body === 'object' ? body : {};
 
@@ -1834,8 +1865,23 @@ export async function publishProduct(req, res) {
     if (!mockupDataUrl) {
       return res.status(400).json({ ok: false, reason: 'missing_mockup_dataurl' });
     }
-    const b64 = (mockupDataUrl.split(',')[1] || '').trim();
-    if (!b64) return res.status(400).json({ ok: false, reason: 'invalid_mockup_dataurl' });
+    const rawBase64 = (mockupDataUrl.split(',')[1] || '').trim();
+    if (!rawBase64) return res.status(400).json({ ok: false, reason: 'invalid_mockup_dataurl' });
+    const sanitizedBase64 = sanitizeBase64Payload(rawBase64);
+    if (!sanitizedBase64) {
+      return res.status(400).json({ ok: false, reason: 'invalid_mockup_dataurl' });
+    }
+    const estimatedMockupBytes = estimateBase64Bytes(sanitizedBase64);
+    if (estimatedMockupBytes > PUBLISH_PRODUCT_BODY_LIMIT) {
+      return res.status(413).json({
+        ok: false,
+        reason: 'payload_too_large',
+        code: 'payload_too_large',
+        limitBytes: PUBLISH_PRODUCT_BODY_LIMIT,
+        estimatedBytes: estimatedMockupBytes,
+        hint: PAYLOAD_TOO_LARGE_HINT,
+      });
+    }
 
     const designNameRaw = typeof body.designName === 'string' ? body.designName.trim() : '';
     const { key: productTypeKey, label: productTypeLabel } = pickProductType(body.productType);
@@ -1896,7 +1942,7 @@ export async function publishProduct(req, res) {
       : title;
 
     const { mimeType } = parseDataUrlMeta(mockupDataUrl);
-    const imageBuffer = Buffer.from(b64, 'base64');
+    const imageBuffer = Buffer.from(sanitizedBase64, 'base64');
     if (!imageBuffer.length) {
       return res.status(400).json({ ok: false, reason: 'invalid_mockup_dataurl' });
     }


### PR DESCRIPTION
## Summary
- add an OPTIONS handler for /api/publish-product that always responds with the required CORS headers and configure Next.js to accept 20 MB bodies
- short-circuit overly large publish payloads before hitting Shopify, returning a CORS-aware 413 JSON response with diagnostics
- validate mockup data URLs inside the publishProduct handler and reuse the new payload_too_large response format

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e591d556f48327960126d299a1b9a0