### PR TITLE
Restore lossless original-image PDFs for print uploads

### DIFF
--- a/lib/_lib/generatePrintPdf.js
+++ b/lib/_lib/generatePrintPdf.js
@@ -1,4 +1,4 @@
-﻿import sharp from "sharp";
+import sharp from "sharp";
 import {
   PDFDocument,
   PDFName,
@@ -10,6 +10,9 @@ import logger from "./logger.js";
 const CM_PER_INCH = 2.54;
 const PDF_MAX_POINTS = 14_400;
 const MAX_USER_UNIT = 75;
+const DEFAULT_DPI = 300;
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+const JPEG_SIGNATURE = Buffer.from([0xff, 0xd8]);
 
 function normalizeColor(input) {
   const raw = String(input || "").trim().toLowerCase();
@@ -30,14 +33,6 @@ function hexToRgb(hexColor) {
   const g = Number.parseInt(value.slice(2, 4), 16);
   const b = Number.parseInt(value.slice(4, 6), 16);
   return { r, g, b };
-}
-
-function selectEmbedKind(format) {
-  if (!format) return "jpeg";
-  const normalized = String(format).trim().toLowerCase();
-  if (normalized === "jpeg" || normalized === "jpg") return "jpeg";
-  if (normalized === "png") return "png";
-  return null;
 }
 
 function resolveUserUnit(widthPt, heightPt) {
@@ -62,12 +57,97 @@ function pointsToCentimeters(points) {
   return (points / 72) * CM_PER_INCH;
 }
 
+function normalizeImageMime(input) {
+  if (!input) return null;
+  const raw = String(input).toLowerCase();
+  if (raw.includes("png")) return "image/png";
+  if (raw.includes("jpeg") || raw.includes("jpg")) return "image/jpeg";
+  return null;
+}
+
+function detectImageKind(buffer, declaredMime, metadataFormat) {
+  const normalizedDeclared = normalizeImageMime(declaredMime);
+  if (normalizedDeclared === "image/png") {
+    return { kind: "png", mime: "image/png" };
+  }
+  if (normalizedDeclared === "image/jpeg") {
+    return { kind: "jpeg", mime: "image/jpeg" };
+  }
+
+  if (buffer?.length >= 4 && buffer.subarray(0, 4).equals(PNG_SIGNATURE)) {
+    return { kind: "png", mime: "image/png" };
+  }
+  if (buffer?.length >= 2 && buffer.subarray(0, 2).equals(JPEG_SIGNATURE)) {
+    return { kind: "jpeg", mime: "image/jpeg" };
+  }
+
+  if (metadataFormat) {
+    const normalizedFormat = String(metadataFormat).trim().toLowerCase();
+    if (normalizedFormat === "png") {
+      return { kind: "png", mime: "image/png" };
+    }
+    if (normalizedFormat === "jpeg" || normalizedFormat === "jpg") {
+      return { kind: "jpeg", mime: "image/jpeg" };
+    }
+  }
+
+  return { kind: null, mime: normalizedDeclared || null };
+}
+
+function toDpi(value, unit) {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num <= 0) return null;
+  if (!unit) return num;
+  const normalized = String(unit).toLowerCase();
+  if (normalized.includes("metre")) {
+    return num / 39.3700787;
+  }
+  if (normalized.includes("centimet")) {
+    return num * CM_PER_INCH;
+  }
+  return num;
+}
+
+function extractDpi(metadata) {
+  const densityUnit = metadata?.densityUnits || metadata?.resolutionUnit || null;
+  const dpiCandidatesX = [
+    toDpi(metadata?.density, densityUnit),
+    toDpi(metadata?.xDensity, densityUnit),
+    toDpi(metadata?.xResolution, densityUnit),
+    toDpi(metadata?.resolution, densityUnit),
+  ].filter((value) => Number.isFinite(value) && value > 0);
+
+  const dpiCandidatesY = [
+    toDpi(metadata?.density, densityUnit),
+    toDpi(metadata?.yDensity, densityUnit),
+    toDpi(metadata?.yResolution, densityUnit),
+    toDpi(metadata?.resolution, densityUnit),
+  ].filter((value) => Number.isFinite(value) && value > 0);
+
+  const dpiX = dpiCandidatesX.length ? Math.max(...dpiCandidatesX) : DEFAULT_DPI;
+  const dpiY = dpiCandidatesY.length ? Math.max(...dpiCandidatesY) : DEFAULT_DPI;
+
+  return {
+    x: dpiX,
+    y: dpiY,
+    inferred: dpiCandidatesX.length === 0 && dpiCandidatesY.length === 0,
+  };
+}
+
+function computeDimensionPoints(pixels, dpi) {
+  if (!Number.isFinite(pixels) || pixels <= 0) return null;
+  if (!Number.isFinite(dpi) || dpi <= 0) return null;
+  return (pixels / dpi) * 72;
+}
+
 export async function generatePrintPdf({
   widthCm,
   heightCm,
   backgroundColor,
   imageBuffer,
   diagId,
+  imageMime,
+  source = "unknown",
 }) {
   if (!Buffer.isBuffer(imageBuffer) || imageBuffer.length === 0) {
     const error = new Error("invalid_image_buffer");
@@ -76,35 +156,44 @@ export async function generatePrintPdf({
   }
 
   const metadata = await readMetadata(imageBuffer);
-  const embedKind = selectEmbedKind(metadata?.format) || "jpeg";
-  let embedBuffer = imageBuffer;
-  let embedFormat = embedKind;
-  let convertedFrom = null;
-
-  if (embedKind !== "jpeg" && embedKind !== "png") {
-    convertedFrom = metadata?.format || "unknown";
-    embedFormat = "png";
-    embedBuffer = await sharp(imageBuffer, { failOnError: false })
-      .png({ compressionLevel: 0, progressive: false, adaptiveFiltering: false })
-      .toBuffer();
-  }
-
-  const pdfDoc = await PDFDocument.create();
-  const embedImage = embedFormat === "png"
-    ? await pdfDoc.embedPng(embedBuffer)
-    : await pdfDoc.embedJpg(embedBuffer);
-
-  const intrinsicWidthPt = embedImage.width;
-  const intrinsicHeightPt = embedImage.height;
-  if (!intrinsicWidthPt || !intrinsicHeightPt) {
+  const pixelWidth = Number(metadata?.width);
+  const pixelHeight = Number(metadata?.height);
+  if (!Number.isFinite(pixelWidth) || pixelWidth <= 0 || !Number.isFinite(pixelHeight) || pixelHeight <= 0) {
     const error = new Error("image_dimensions_invalid");
     error.code = "image_dimensions_invalid";
     throw error;
   }
 
-  const userUnit = resolveUserUnit(intrinsicWidthPt, intrinsicHeightPt);
-  const pageWidthPt = intrinsicWidthPt / userUnit;
-  const pageHeightPt = intrinsicHeightPt / userUnit;
+  const dpiInfo = extractDpi(metadata);
+  const widthPoints = computeDimensionPoints(pixelWidth, dpiInfo.x);
+  const heightPoints = computeDimensionPoints(pixelHeight, dpiInfo.y);
+  if (!Number.isFinite(widthPoints) || widthPoints <= 0 || !Number.isFinite(heightPoints) || heightPoints <= 0) {
+    const error = new Error("image_points_invalid");
+    error.code = "image_points_invalid";
+    throw error;
+  }
+
+  const imageKind = detectImageKind(imageBuffer, imageMime, metadata?.format);
+  if (imageKind.kind !== "jpeg" && imageKind.kind !== "png") {
+    logger.error("pdf_generate_unsupported_format", {
+      diagId,
+      source,
+      mime: imageKind.mime || imageMime || null,
+      metadataFormat: metadata?.format || null,
+    });
+    const error = new Error("unsupported_image_format");
+    error.code = "unsupported_image_format";
+    throw error;
+  }
+
+  const pdfDoc = await PDFDocument.create();
+  const embedImage = imageKind.kind === "png"
+    ? await pdfDoc.embedPng(imageBuffer)
+    : await pdfDoc.embedJpg(imageBuffer);
+
+  const userUnit = resolveUserUnit(widthPoints, heightPoints);
+  const pageWidthPt = widthPoints / userUnit;
+  const pageHeightPt = heightPoints / userUnit;
   const page = pdfDoc.addPage([pageWidthPt, pageHeightPt]);
   if (userUnit !== 1) {
     page.node.set(PDFName.of("UserUnit"), PDFNumber.of(userUnit));
@@ -130,20 +219,36 @@ export async function generatePrintPdf({
   const pdfBytes = await pdfDoc.save({ useObjectStreams: true, addDefaultPage: false });
   const pdfBuffer = Buffer.from(pdfBytes);
 
+  const pageWidthCm = pointsToCentimeters(widthPoints);
+  const pageHeightCm = pointsToCentimeters(heightPoints);
+  const areaWidthCm = widthCm ? Number(widthCm) : pageWidthCm;
+  const areaHeightCm = heightCm ? Number(heightCm) : pageHeightCm;
+
   logger.debug("pdf_generate_render", {
     diagId,
-    strategy: "original_1to1",
+    strategy: "original_bytes_embed",
+    source,
     userUnit,
-    imgFormat: embedFormat,
-    imgBytes: embedBuffer.length,
+    mime: imageKind.mime,
+    origBytes: imageBuffer.length,
     pdfBytes: pdfBuffer.length,
-    convertedFrom,
+    pixelWxH: { width: pixelWidth, height: pixelHeight },
+    dpi: { x: dpiInfo.x, y: dpiInfo.y, inferred: dpiInfo.inferred },
+    drawWxHpts: { width: widthPoints, height: heightPoints },
   });
 
-  const artworkWidthPx = intrinsicWidthPt;
-  const artworkHeightPx = intrinsicHeightPt;
-  const pageWidthCm = pointsToCentimeters(intrinsicWidthPt);
-  const pageHeightCm = pointsToCentimeters(intrinsicHeightPt);
+  if (pdfBuffer.length < imageBuffer.length * 0.5) {
+    logger.warn("pdf_generate_size_warning", {
+      diagId,
+      source,
+      mime: imageKind.mime,
+      origBytes: imageBuffer.length,
+      pdfBytes: pdfBuffer.length,
+    });
+  }
+
+  const artworkWidthPx = pixelWidth;
+  const artworkHeightPx = pixelHeight;
 
   return {
     buffer: pdfBuffer,
@@ -151,11 +256,11 @@ export async function generatePrintPdf({
       pageWidthCm,
       pageHeightCm,
       marginCm: 0,
-      dpi: null,
-      strategy: "original_1to1",
+      dpi: { x: dpiInfo.x, y: dpiInfo.y, inferred: dpiInfo.inferred },
+      strategy: "original_bytes_embed",
       area: {
-        widthCm: widthCm ? Number(widthCm) : pageWidthCm,
-        heightCm: heightCm ? Number(heightCm) : pageHeightCm,
+        widthCm: areaWidthCm,
+        heightCm: areaHeightCm,
         widthPx: artworkWidthPx,
         heightPx: artworkHeightPx,
       },
@@ -167,7 +272,7 @@ export async function generatePrintPdf({
         scale: 1,
       },
       backgroundColor: normalizedColor,
-      imageFormat: embedFormat,
+      imageFormat: imageKind.kind,
       userUnit,
     },
   };
@@ -275,4 +380,3 @@ export async function validatePrintPdf({
 }
 
 export default generatePrintPdf;
-

--- a/lib/_lib/imageToPdf.js
+++ b/lib/_lib/imageToPdf.js
@@ -1,4 +1,4 @@
-﻿import sharp from "sharp";
+import sharp from "sharp";
 import {
   PDFDocument,
   PDFName,
@@ -11,7 +11,9 @@ const CM_PER_INCH = 2.54;
 const PDF_MAX_POINTS = 14_400;
 const MAX_USER_UNIT = 75;
 const DEFAULT_BACKGROUND = "#ffffff";
-const DEFAULT_DENSITY = 300;
+const DEFAULT_DPI = 300;
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+const JPEG_SIGNATURE = Buffer.from([0xff, 0xd8]);
 
 const ENV_STRATEGY = String(process.env.PDF_IMAGE_STRATEGY || "lossless").trim().toLowerCase();
 const STRATEGY = ENV_STRATEGY === "contain" ? "contain" : "lossless";
@@ -45,67 +47,11 @@ function hexToRgb(hexColor) {
   return { r, g, b };
 }
 
-function selectEmbedKind(format) {
-  if (!format) return "jpeg";
-  const normalized = String(format).trim().toLowerCase();
-  if (normalized === "jpeg" || normalized === "jpg") return "jpeg";
-  if (normalized === "png") return "png";
-  return null;
-}
-
 function resolveUserUnit(widthPt, heightPt) {
   const maxDimension = Math.max(widthPt, heightPt);
   if (maxDimension <= PDF_MAX_POINTS) return 1;
   const computed = Math.ceil(maxDimension / PDF_MAX_POINTS);
   return Math.min(MAX_USER_UNIT, Math.max(1, computed));
-}
-
-function resolveDensity(options, metadata) {
-  const candidates = [];
-  if (options?.density && Number.isFinite(options.density)) {
-    candidates.push(Math.max(72, Number(options.density)));
-  }
-  const metadataDensities = [
-    metadata?.density,
-    metadata?.xDensity,
-    metadata?.yDensity,
-    metadata?.resolution,
-    metadata?.xResolution,
-    metadata?.yResolution,
-  ]
-    .map((value) => {
-      const numeric = Number(value);
-      return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
-    })
-    .filter((value) => value != null);
-  if (metadataDensities.length) {
-    candidates.push(Math.max(...metadataDensities));
-  }
-  const baseWidthCm = toNumber(options?.widthCm);
-  const baseHeightCm = toNumber(options?.heightCm);
-  const bleedValueCm = Math.max(0, toNumber(options?.bleedCm, 0));
-  const targetWidthCm = baseWidthCm ? baseWidthCm + bleedValueCm * 2 : baseWidthCm;
-  const targetHeightCm = baseHeightCm ? baseHeightCm + bleedValueCm * 2 : baseHeightCm;
-  const imageWidthPx = metadata?.width || null;
-  const imageHeightPx = metadata?.height || null;
-  const computeDensityCandidate = (pixels, cm) => {
-    if (!pixels || !cm || cm <= 0) return null;
-    const inches = cm / CM_PER_INCH;
-    if (inches <= 0) return null;
-    return pixels / inches;
-  };
-  if (imageWidthPx) {
-    if (baseWidthCm) candidates.push(computeDensityCandidate(imageWidthPx, baseWidthCm));
-    if (targetWidthCm) candidates.push(computeDensityCandidate(imageWidthPx, targetWidthCm));
-  }
-  if (imageHeightPx) {
-    if (baseHeightCm) candidates.push(computeDensityCandidate(imageHeightPx, baseHeightCm));
-    if (targetHeightCm) candidates.push(computeDensityCandidate(imageHeightPx, targetHeightCm));
-  }
-  if (ENV_DPI_VALID) candidates.push(ENV_DPI_VALID);
-  candidates.push(DEFAULT_DENSITY);
-  const filtered = candidates.filter((value) => Number.isFinite(value) && value > 0);
-  return filtered.length ? Math.max(...filtered) : DEFAULT_DENSITY;
 }
 
 function resolveStrategy() {
@@ -127,6 +73,129 @@ function pointsToCentimeters(points) {
   return (points / 72) * CM_PER_INCH;
 }
 
+function normalizeImageMime(input) {
+  if (!input) return null;
+  const raw = String(input).toLowerCase();
+  if (raw.includes("png")) return "image/png";
+  if (raw.includes("jpeg") || raw.includes("jpg")) return "image/jpeg";
+  return null;
+}
+
+function detectImageKind(buffer, declaredMime, metadataFormat) {
+  const normalizedDeclared = normalizeImageMime(declaredMime);
+  if (normalizedDeclared === "image/png") {
+    return { kind: "png", mime: "image/png" };
+  }
+  if (normalizedDeclared === "image/jpeg") {
+    return { kind: "jpeg", mime: "image/jpeg" };
+  }
+
+  if (buffer?.length >= 4 && buffer.subarray(0, 4).equals(PNG_SIGNATURE)) {
+    return { kind: "png", mime: "image/png" };
+  }
+  if (buffer?.length >= 2 && buffer.subarray(0, 2).equals(JPEG_SIGNATURE)) {
+    return { kind: "jpeg", mime: "image/jpeg" };
+  }
+
+  if (metadataFormat) {
+    const normalizedFormat = String(metadataFormat).trim().toLowerCase();
+    if (normalizedFormat === "png") {
+      return { kind: "png", mime: "image/png" };
+    }
+    if (normalizedFormat === "jpeg" || normalizedFormat === "jpg") {
+      return { kind: "jpeg", mime: "image/jpeg" };
+    }
+  }
+
+  return { kind: null, mime: normalizedDeclared || null };
+}
+
+function toDpi(value, unit) {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num <= 0) return null;
+  if (!unit) return num;
+  const normalized = String(unit).toLowerCase();
+  if (normalized.includes("metre")) {
+    return num / 39.3700787;
+  }
+  if (normalized.includes("centimet")) {
+    return num * CM_PER_INCH;
+  }
+  return num;
+}
+
+function computeDpiFromDimension(pixels, cm) {
+  if (!Number.isFinite(pixels) || pixels <= 0) return null;
+  if (!Number.isFinite(cm) || cm <= 0) return null;
+  const inches = cm / CM_PER_INCH;
+  if (!Number.isFinite(inches) || inches <= 0) return null;
+  return pixels / inches;
+}
+
+function extractEffectiveDpi({ metadata, options = {} }) {
+  const densityUnit = metadata?.densityUnits || metadata?.resolutionUnit || null;
+  const metadataDpiX = [
+    toDpi(metadata?.density, densityUnit),
+    toDpi(metadata?.xDensity, densityUnit),
+    toDpi(metadata?.xResolution, densityUnit),
+    toDpi(metadata?.resolution, densityUnit),
+  ].filter((value) => Number.isFinite(value) && value > 0);
+
+  const metadataDpiY = [
+    toDpi(metadata?.density, densityUnit),
+    toDpi(metadata?.yDensity, densityUnit),
+    toDpi(metadata?.yResolution, densityUnit),
+    toDpi(metadata?.resolution, densityUnit),
+  ].filter((value) => Number.isFinite(value) && value > 0);
+
+  const pixelWidth = Number(metadata?.width);
+  const pixelHeight = Number(metadata?.height);
+  const widthCm = toNumber(options?.widthCm);
+  const heightCm = toNumber(options?.heightCm);
+  const bleedCm = Math.max(0, toNumber(options?.bleedCm, 0));
+  const densityOverride = Number.isFinite(options?.density) ? Number(options.density) : null;
+
+  const dimensionDpiX = [
+    computeDpiFromDimension(pixelWidth, widthCm),
+    computeDpiFromDimension(pixelWidth, widthCm != null ? widthCm + bleedCm * 2 : null),
+  ].filter((value) => Number.isFinite(value) && value > 0);
+
+  const dimensionDpiY = [
+    computeDpiFromDimension(pixelHeight, heightCm),
+    computeDpiFromDimension(pixelHeight, heightCm != null ? heightCm + bleedCm * 2 : null),
+  ].filter((value) => Number.isFinite(value) && value > 0);
+
+  const candidatesX = [
+    ...metadataDpiX,
+    ...dimensionDpiX,
+  ];
+  const candidatesY = [
+    ...metadataDpiY,
+    ...dimensionDpiY,
+  ];
+
+  if (Number.isFinite(densityOverride) && densityOverride >= 72) {
+    candidatesX.push(densityOverride);
+    candidatesY.push(densityOverride);
+  }
+  if (ENV_DPI_VALID) {
+    candidatesX.push(ENV_DPI_VALID);
+    candidatesY.push(ENV_DPI_VALID);
+  }
+
+  const dpiX = candidatesX.length ? Math.max(...candidatesX) : DEFAULT_DPI;
+  const dpiY = candidatesY.length ? Math.max(...candidatesY) : DEFAULT_DPI;
+  const inferred = candidatesX.length === 0 && candidatesY.length === 0;
+
+  return { x: dpiX, y: dpiY, inferred };
+}
+
+function computeDimensionPoints(pixels, dpi) {
+  if (!Number.isFinite(pixels) || pixels <= 0) return null;
+  if (!Number.isFinite(dpi) || dpi <= 0) return null;
+  return (pixels / dpi) * 72;
+}
+
 export async function imageBufferToPdf({
   buffer,
   density,
@@ -135,6 +204,7 @@ export async function imageBufferToPdf({
   widthCm,
   heightCm,
   diagId,
+  imageMime,
 } = {}) {
   if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
     const error = new Error('invalid_image_buffer');
@@ -143,36 +213,43 @@ export async function imageBufferToPdf({
   }
 
   const metadata = await readMetadata(buffer);
-  const effectiveDensity = resolveDensity({ density, widthCm, heightCm, bleedCm }, metadata);
-  const embedKind = selectEmbedKind(metadata?.format) || 'jpeg';
-  let embedBuffer = buffer;
-  let embedFormat = embedKind;
-  let convertedFrom = null;
-
-  if (embedKind !== 'jpeg' && embedKind !== 'png') {
-    convertedFrom = metadata?.format || 'unknown';
-    embedFormat = 'png';
-    embedBuffer = await sharp(buffer, { failOnError: false })
-      .png({ compressionLevel: 0, progressive: false, adaptiveFiltering: false })
-      .toBuffer();
-  }
-
-  const pdfDoc = await PDFDocument.create();
-  const embedded = embedFormat === 'png'
-    ? await pdfDoc.embedPng(embedBuffer)
-    : await pdfDoc.embedJpg(embedBuffer);
-
-  const intrinsicWidthPt = embedded.width;
-  const intrinsicHeightPt = embedded.height;
-  if (!intrinsicWidthPt || !intrinsicHeightPt) {
+  const pixelWidth = Number(metadata?.width);
+  const pixelHeight = Number(metadata?.height);
+  if (!Number.isFinite(pixelWidth) || pixelWidth <= 0 || !Number.isFinite(pixelHeight) || pixelHeight <= 0) {
     const error = new Error('image_dimensions_invalid');
     error.code = 'image_dimensions_invalid';
     throw error;
   }
 
-  const userUnit = resolveUserUnit(intrinsicWidthPt, intrinsicHeightPt);
-  const pageWidthPt = intrinsicWidthPt / userUnit;
-  const pageHeightPt = intrinsicHeightPt / userUnit;
+  const dpiInfo = extractEffectiveDpi({ metadata, options: { density, widthCm, heightCm, bleedCm } });
+  const widthPoints = computeDimensionPoints(pixelWidth, dpiInfo.x);
+  const heightPoints = computeDimensionPoints(pixelHeight, dpiInfo.y);
+  if (!Number.isFinite(widthPoints) || widthPoints <= 0 || !Number.isFinite(heightPoints) || heightPoints <= 0) {
+    const error = new Error('image_points_invalid');
+    error.code = 'image_points_invalid';
+    throw error;
+  }
+
+  const imageKind = detectImageKind(buffer, imageMime, metadata?.format);
+  if (imageKind.kind !== 'jpeg' && imageKind.kind !== 'png') {
+    logger.error('image_to_pdf_unsupported_format', {
+      diagId,
+      mime: imageKind.mime || imageMime || null,
+      metadataFormat: metadata?.format || null,
+    });
+    const error = new Error('unsupported_image_format');
+    error.code = 'unsupported_image_format';
+    throw error;
+  }
+
+  const pdfDoc = await PDFDocument.create();
+  const embedded = imageKind.kind === 'png'
+    ? await pdfDoc.embedPng(buffer)
+    : await pdfDoc.embedJpg(buffer);
+
+  const userUnit = resolveUserUnit(widthPoints, heightPoints);
+  const pageWidthPt = widthPoints / userUnit;
+  const pageHeightPt = heightPoints / userUnit;
   const page = pdfDoc.addPage([pageWidthPt, pageHeightPt]);
   if (userUnit !== 1) {
     page.node.set(PDFName.of('UserUnit'), PDFNumber.of(userUnit));
@@ -198,35 +275,46 @@ export async function imageBufferToPdf({
   const pdfBytes = await pdfDoc.save({ useObjectStreams: true, addDefaultPage: false });
   const pdfBuffer = Buffer.from(pdfBytes);
 
+  const actualWidthCm = pointsToCentimeters(widthPoints);
+  const actualHeightCm = pointsToCentimeters(heightPoints);
+  const widthResultCm = toNumber(widthCm) ?? actualWidthCm;
+  const heightResultCm = toNumber(heightCm) ?? actualHeightCm;
+  const bleedValueCm = Math.max(0, toNumber(bleedCm, 0));
+  const dominantDpi = Math.max(dpiInfo.x, dpiInfo.y);
+
   logger.debug('image_to_pdf_render', {
     diagId,
     strategy: resolveStrategy(),
     userUnit,
-    dpi: effectiveDensity,
-    imgFormat: embedFormat,
-    imgBytes: embedBuffer.length,
+    dpi: { x: dpiInfo.x, y: dpiInfo.y, inferred: dpiInfo.inferred },
+    mime: imageKind.mime,
+    imgBytes: buffer.length,
     pdfBytes: pdfBuffer.length,
-    convertedFrom,
+    pixelWxH: { width: pixelWidth, height: pixelHeight },
+    drawWxHpts: { width: widthPoints, height: heightPoints },
   });
 
-  const widthPx = intrinsicWidthPt;
-  const heightPx = intrinsicHeightPt;
-  const contentWidthCm = toNumber(widthCm) ?? pointsToCentimeters(intrinsicWidthPt);
-  const contentHeightCm = toNumber(heightCm) ?? pointsToCentimeters(intrinsicHeightPt);
-  const bleedValueCm = Math.max(0, toNumber(bleedCm, 0));
+  if (pdfBuffer.length < buffer.length * 0.5) {
+    logger.warn('image_to_pdf_size_warning', {
+      diagId,
+      mime: imageKind.mime,
+      imgBytes: buffer.length,
+      pdfBytes: pdfBuffer.length,
+    });
+  }
 
   return {
     pdfBuffer,
-    density: effectiveDensity,
-    widthPx,
-    heightPx,
-    widthCm: contentWidthCm,
-    heightCm: contentHeightCm,
-    widthCmPrint: contentWidthCm + bleedValueCm * 2,
-    heightCmPrint: contentHeightCm + bleedValueCm * 2,
+    density: dominantDpi,
+    dpi: { x: dpiInfo.x, y: dpiInfo.y, inferred: dpiInfo.inferred },
+    widthPx: pixelWidth,
+    heightPx: pixelHeight,
+    widthCm: widthResultCm,
+    heightCm: heightResultCm,
+    widthCmPrint: widthResultCm + bleedValueCm * 2,
+    heightCmPrint: heightResultCm + bleedValueCm * 2,
     userUnit,
   };
 }
 
 export default imageBufferToPdf;
-

--- a/lib/api/handlers/printsUpload.js
+++ b/lib/api/handlers/printsUpload.js
@@ -84,6 +84,14 @@ async function readRawBody(req) {
   });
 }
 
+function normalizeImageMime(input) {
+  if (!input) return null;
+  const raw = String(input).toLowerCase();
+  if (raw.includes('png')) return 'image/png';
+  if (raw.includes('jpeg') || raw.includes('jpg')) return 'image/jpeg';
+  return null;
+}
+
 function parseDataUrl(value) {
   const match = /^data:([^;,]+);base64,(.+)$/i.exec(String(value || ''));
   if (!match) return null;
@@ -91,49 +99,69 @@ function parseDataUrl(value) {
   if (!mime || !data) return null;
   try {
     const buffer = Buffer.from(data, 'base64');
-    return buffer.length ? buffer : null;
+    if (!buffer.length) return null;
+    return { buffer, mime: normalizeImageMime(mime), source: 'dataurl' };
   } catch {
     return null;
   }
 }
 
-async function resolveImageBuffer(source) {
-  const trimmed = String(source || '').trim();
+async function resolveImageBuffer({ value, type }) {
+  const trimmed = String(value || '').trim();
   if (!trimmed) return null;
-  if (trimmed.startsWith('data:')) {
-    return parseDataUrl(trimmed);
+
+  if (type === 'dataurl' || trimmed.startsWith('data:')) {
+    const parsed = parseDataUrl(trimmed);
+    return parsed;
   }
-  if (/^https?:\/\//i.test(trimmed)) {
-    const response = await fetch(trimmed);
-    if (!response.ok) {
-      const error = new Error(`download_failed_${response.status}`);
-      error.status = response.status;
-      throw error;
-    }
-    const arrayBuffer = await response.arrayBuffer();
-    const buffer = Buffer.from(arrayBuffer);
-    return buffer.length ? buffer : null;
+
+  if (!/^https?:\/\//i.test(trimmed)) {
+    return null;
   }
-  return null;
+
+  const response = await fetch(trimmed);
+  if (!response.ok) {
+    const error = new Error(`download_failed_${response.status}`);
+    error.status = response.status;
+    throw error;
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  if (!buffer.length) return null;
+  const headerMime = normalizeImageMime(response.headers?.get?.('content-type') || null);
+  return { buffer, mime: headerMime, source: type || 'original' };
 }
 
 function extractImageSource(payload) {
-  const candidates = [
-    payload?.originalUrl,
-    payload?.original_url,
-    payload?.fileOriginalUrl,
-    payload?.file_original_url,
-    payload?.imageUrl,
-    payload?.image_url,
-    payload?.image,
-    payload?.imageBlob,
-    payload?.image_blob,
-    payload?.dataUrl,
-    payload?.data_url,
+  const originalKeys = [
+    'originalUrl',
+    'original_url',
+    'fileOriginalUrl',
+    'file_original_url',
   ];
-  for (const candidate of candidates) {
-    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  for (const key of originalKeys) {
+    const value = payload?.[key];
+    if (typeof value === 'string' && value.trim()) {
+      return { value, type: 'original', key };
+    }
   }
+
+  const dataUrlKeys = ['dataUrl', 'data_url'];
+  for (const key of dataUrlKeys) {
+    const value = payload?.[key];
+    if (typeof value === 'string' && value.trim()) {
+      return { value, type: 'dataurl', key };
+    }
+  }
+
+  if (payload && typeof payload === 'object') {
+    for (const [key, candidate] of Object.entries(payload)) {
+      if (typeof candidate === 'string' && candidate.trim().startsWith('data:')) {
+        return { value: candidate, type: 'dataurl', key };
+      }
+    }
+  }
+
   return null;
 }
 
@@ -218,9 +246,9 @@ export async function uploadPrintHandler(req, res) {
     return res.status(400).json({ ok: false, diagId, requestId, reason: 'missing_image_source' });
   }
 
-  let imageBuffer;
+  let imagePayload;
   try {
-    imageBuffer = await resolveImageBuffer(imageSource);
+    imagePayload = await resolveImageBuffer(imageSource);
   } catch (err) {
     logger.error('pdf_image_download_error', {
       diagId,
@@ -231,9 +259,13 @@ export async function uploadPrintHandler(req, res) {
     return res.status(400).json({ ok: false, diagId, requestId, reason: 'image_download_failed' });
   }
 
-  if (!imageBuffer || !imageBuffer.length) {
+  if (!imagePayload?.buffer || !imagePayload.buffer.length) {
     return res.status(400).json({ ok: false, diagId, requestId, reason: 'empty_image' });
   }
+
+  const imageBuffer = imagePayload.buffer;
+  const imageMime = normalizeImageMime(imagePayload.mime) || null;
+  const imageSourceType = imagePayload.source === 'dataurl' ? 'dataurl' : 'original';
 
   const safeSlugValue = safeSlug(slug);
   const safeMaterial = sanitizeMaterial(material);
@@ -260,6 +292,17 @@ export async function uploadPrintHandler(req, res) {
   const filename = storageDetails.filename;
 
   res.setHeader('X-Job-Key', jobKey);
+
+  logger.debug('prints_image_source_selected', {
+    diagId,
+    requestId,
+    jobId: safeJobId,
+    jobKey,
+    source: imageSourceType,
+    mime: imageMime,
+    hasOriginal: imageSourceType === 'original',
+    sourceKey: imageSource.key,
+  });
 
   const storage = supabase.storage.from(OUTPUT_BUCKET);
 
@@ -350,6 +393,8 @@ export async function uploadPrintHandler(req, res) {
       heightCm,
       backgroundColor,
       imageHash,
+      imageSource: imageSourceType,
+      imageMime,
       attempt,
       pageCm: { widthCm: expectedPageWidthCm, heightCm: expectedPageHeightCm },
       artCm: { widthCm, heightCm },
@@ -368,6 +413,8 @@ export async function uploadPrintHandler(req, res) {
         backgroundColor,
         imageBuffer,
         diagId,
+        imageMime,
+        source: imageSourceType,
       });
     } catch (err) {
       logger.error('pdf_generate_error', {
@@ -375,6 +422,8 @@ export async function uploadPrintHandler(req, res) {
         requestId,
         jobKey,
         attempt,
+        imageSource: imageSourceType,
+        imageMime,
         error: err?.code || err?.message || 'pdf_generate_error',
         message: err?.message || err,
       });
@@ -392,6 +441,8 @@ export async function uploadPrintHandler(req, res) {
       filename,
       attempt,
       sizeBytes: pdfResult.buffer.length,
+      imageSource: imageSourceType,
+      imageMime,
       pageCm: {
         widthCm: pdfResult.info.pageWidthCm,
         heightCm: pdfResult.info.pageHeightCm,


### PR DESCRIPTION
## Summary
- embed original JPEG/PNG bytes directly in generated print PDFs using the source image DPI for sizing
- update the shared image-to-PDF utility to avoid re-encoding, preserve diagnostics, and warn on suspicious size drops
- ensure the print upload handler always prefers original artwork URLs, logs the selected source, and passes MIME/source to PDF generation

## Testing
- node -e "import('./lib/_lib/generatePrintPdf.js').then(()=>console.log('generate ok'))"
- node -e "import('./lib/_lib/imageToPdf.js').then(()=>console.log('imageToPdf ok'))"
- node -e "import('./lib/api/handlers/printsUpload.js').then(()=>console.log('printsUpload ok'))"

------
https://chatgpt.com/codex/tasks/task_e_68e59768d63c832781753334929c3820