### PR TITLE
Ensure print PDFs embed original image bytes losslessly

### DIFF
--- a/lib/_lib/generatePrintPdf.js
+++ b/lib/_lib/generatePrintPdf.js
@@ -3,6 +3,7 @@ import {
   PDFDocument,
   PDFName,
   PDFNumber,
+  PDFRawStream,
   rgb,
 } from "pdf-lib";
 import logger from "./logger.js";
@@ -12,7 +13,10 @@ const PDF_MAX_POINTS = 14_400;
 const MAX_USER_UNIT = 75;
 const DEFAULT_DPI = 300;
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+const PNG_IEND = Buffer.from([0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82]);
 const JPEG_SIGNATURE = Buffer.from([0xff, 0xd8]);
+const JPEG_EOI = Buffer.from([0xff, 0xd9]);
+const MIN_EMBED_RATIO = 0.8;
 
 function normalizeColor(input) {
   const raw = String(input || "").trim().toLowerCase();
@@ -140,6 +144,133 @@ function computeDimensionPoints(pixels, dpi) {
   return (pixels / dpi) * 72;
 }
 
+function findFirstImageRawStream(doc) {
+  if (!doc?.context?.enumerateIndirectObjects) return null;
+  const imageName = PDFName.of("Image");
+  const indirectObjects = doc.context.enumerateIndirectObjects();
+  for (const [, object] of indirectObjects) {
+    if (object instanceof PDFRawStream) {
+      const subtype = object.dict?.lookupMaybe?.(PDFName.of("Subtype"), PDFName);
+      if (subtype === imageName) {
+        return object;
+      }
+    }
+  }
+  return null;
+}
+
+async function verifyEmbeddedImage({
+  pdfBuffer,
+  imageBuffer,
+  diagId,
+  source,
+  mime,
+  scope = "generatePrintPdf",
+  pdfBytes,
+}) {
+  let loaded;
+  try {
+    loaded = await PDFDocument.load(pdfBuffer);
+  } catch (err) {
+    logger.error("pdf_embed_mismatch", {
+      diagId,
+      source,
+      mime: mime || null,
+      scope,
+      pdfBytes: pdfBytes ?? pdfBuffer.length,
+      reason: "pdf_parse_failed",
+      message: err?.message || err,
+    });
+    const error = new Error("pdf_embed_mismatch");
+    error.code = "pdf_embed_mismatch";
+    error.cause = err;
+    throw error;
+  }
+
+  const imageStream = findFirstImageRawStream(loaded);
+  if (!imageStream) {
+    logger.error("pdf_embed_mismatch", {
+      diagId,
+      source,
+      mime: mime || null,
+      scope,
+      pdfBytes: pdfBytes ?? pdfBuffer.length,
+      reason: "image_stream_missing",
+    });
+    const error = new Error("pdf_embed_mismatch");
+    error.code = "pdf_embed_mismatch";
+    error.reason = "image_stream_missing";
+    throw error;
+  }
+
+  let contents;
+  if (typeof imageStream.getContents === "function") {
+    contents = imageStream.getContents();
+  } else if (imageStream.contents) {
+    contents = imageStream.contents;
+  } else {
+    contents = [];
+  }
+  const streamBytes = Buffer.from(contents || []);
+  const embeddedLength = streamBytes.length;
+  const context = {
+    diagId,
+    source,
+    mime: mime || null,
+    origBytes: imageBuffer.length,
+    embeddedImageStreamLength: embeddedLength,
+    scope,
+    pdfBytes: pdfBytes ?? pdfBuffer.length,
+  };
+
+  if (embeddedLength < imageBuffer.length * MIN_EMBED_RATIO) {
+    logger.error("pdf_embed_mismatch", {
+      ...context,
+      reason: "stream_too_small",
+    });
+    const error = new Error("pdf_embed_mismatch");
+    error.code = "pdf_embed_mismatch";
+    error.reason = "stream_too_small";
+    throw error;
+  }
+
+  if (mime === "image/jpeg" || (imageBuffer.length >= 2 && imageBuffer.subarray(0, 2).equals(JPEG_SIGNATURE))) {
+    const startsWithSoi = streamBytes.length >= 2 && streamBytes[0] === JPEG_SIGNATURE[0] && streamBytes[1] === JPEG_SIGNATURE[1];
+    const endsWithEoi = streamBytes.length >= 2 && streamBytes[streamBytes.length - 2] === JPEG_EOI[0] && streamBytes[streamBytes.length - 1] === JPEG_EOI[1];
+    if (!startsWithSoi || !endsWithEoi) {
+      logger.error("pdf_embed_mismatch", {
+        ...context,
+        reason: "jpeg_markers_missing",
+        startsWithSoi,
+        endsWithEoi,
+      });
+      const error = new Error("pdf_embed_mismatch");
+      error.code = "pdf_embed_mismatch";
+      error.reason = "jpeg_markers_missing";
+      throw error;
+    }
+  } else if (mime === "image/png" || (imageBuffer.length >= 8 && imageBuffer.subarray(0, 4).equals(PNG_SIGNATURE))) {
+    const startsWithPng = streamBytes.length >= PNG_SIGNATURE.length && streamBytes.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE);
+    const endsWithIend =
+      streamBytes.length >= PNG_IEND.length &&
+      streamBytes.subarray(streamBytes.length - PNG_IEND.length).equals(PNG_IEND);
+    if (!startsWithPng || !endsWithIend) {
+      logger.error("pdf_embed_mismatch", {
+        ...context,
+        reason: "png_signature_mismatch",
+        startsWithPng,
+        endsWithIend,
+      });
+      const error = new Error("pdf_embed_mismatch");
+      error.code = "pdf_embed_mismatch";
+      error.reason = "png_signature_mismatch";
+      throw error;
+    }
+  }
+
+  return { embeddedImageStreamLength: embeddedLength };
+}
+
 export async function generatePrintPdf({
   widthCm,
   heightCm,
@@ -218,6 +349,15 @@ export async function generatePrintPdf({
 
   const pdfBytes = await pdfDoc.save({ useObjectStreams: true, addDefaultPage: false });
   const pdfBuffer = Buffer.from(pdfBytes);
+  const { embeddedImageStreamLength } = await verifyEmbeddedImage({
+    pdfBuffer,
+    imageBuffer,
+    diagId,
+    source,
+    mime: imageKind.mime,
+    scope: "generatePrintPdf",
+    pdfBytes: pdfBuffer.length,
+  });
 
   const pageWidthCm = pointsToCentimeters(widthPoints);
   const pageHeightCm = pointsToCentimeters(heightPoints);
@@ -232,9 +372,11 @@ export async function generatePrintPdf({
     mime: imageKind.mime,
     origBytes: imageBuffer.length,
     pdfBytes: pdfBuffer.length,
+    embeddedImageStreamLength,
     pixelWxH: { width: pixelWidth, height: pixelHeight },
     dpi: { x: dpiInfo.x, y: dpiInfo.y, inferred: dpiInfo.inferred },
-    drawWxHpts: { width: widthPoints, height: heightPoints },
+    pageWxHpt: { width: widthPoints, height: heightPoints },
+    pageWxHptUserUnit: { width: pageWidthPt, height: pageHeightPt },
   });
 
   if (pdfBuffer.length < imageBuffer.length * 0.5) {
@@ -274,6 +416,7 @@ export async function generatePrintPdf({
       backgroundColor: normalizedColor,
       imageFormat: imageKind.kind,
       userUnit,
+      embeddedImageStreamLength,
     },
   };
 }

--- a/lib/_lib/imageToPdf.js
+++ b/lib/_lib/imageToPdf.js
@@ -3,6 +3,7 @@ import {
   PDFDocument,
   PDFName,
   PDFNumber,
+  PDFRawStream,
   rgb,
 } from "pdf-lib";
 import logger from "./logger.js";
@@ -13,7 +14,10 @@ const MAX_USER_UNIT = 75;
 const DEFAULT_BACKGROUND = "#ffffff";
 const DEFAULT_DPI = 300;
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+const PNG_IEND = Buffer.from([0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82]);
 const JPEG_SIGNATURE = Buffer.from([0xff, 0xd8]);
+const JPEG_EOI = Buffer.from([0xff, 0xd9]);
+const MIN_EMBED_RATIO = 0.8;
 
 const ENV_STRATEGY = String(process.env.PDF_IMAGE_STRATEGY || "lossless").trim().toLowerCase();
 const STRATEGY = ENV_STRATEGY === "contain" ? "contain" : "lossless";
@@ -196,6 +200,133 @@ function computeDimensionPoints(pixels, dpi) {
   return (pixels / dpi) * 72;
 }
 
+function findFirstImageRawStream(doc) {
+  if (!doc?.context?.enumerateIndirectObjects) return null;
+  const imageName = PDFName.of("Image");
+  const indirectObjects = doc.context.enumerateIndirectObjects();
+  for (const [, object] of indirectObjects) {
+    if (object instanceof PDFRawStream) {
+      const subtype = object.dict?.lookupMaybe?.(PDFName.of("Subtype"), PDFName);
+      if (subtype === imageName) {
+        return object;
+      }
+    }
+  }
+  return null;
+}
+
+async function verifyEmbeddedImage({
+  pdfBuffer,
+  imageBuffer,
+  diagId,
+  source,
+  mime,
+  scope = "imageToPdf",
+  pdfBytes,
+}) {
+  let loaded;
+  try {
+    loaded = await PDFDocument.load(pdfBuffer);
+  } catch (err) {
+    logger.error("pdf_embed_mismatch", {
+      diagId,
+      source,
+      mime: mime || null,
+      scope,
+      pdfBytes: pdfBytes ?? pdfBuffer.length,
+      reason: "pdf_parse_failed",
+      message: err?.message || err,
+    });
+    const error = new Error("pdf_embed_mismatch");
+    error.code = "pdf_embed_mismatch";
+    error.cause = err;
+    throw error;
+  }
+
+  const imageStream = findFirstImageRawStream(loaded);
+  if (!imageStream) {
+    logger.error("pdf_embed_mismatch", {
+      diagId,
+      source,
+      mime: mime || null,
+      scope,
+      pdfBytes: pdfBytes ?? pdfBuffer.length,
+      reason: "image_stream_missing",
+    });
+    const error = new Error("pdf_embed_mismatch");
+    error.code = "pdf_embed_mismatch";
+    error.reason = "image_stream_missing";
+    throw error;
+  }
+
+  let contents;
+  if (typeof imageStream.getContents === 'function') {
+    contents = imageStream.getContents();
+  } else if (imageStream.contents) {
+    contents = imageStream.contents;
+  } else {
+    contents = [];
+  }
+  const streamBytes = Buffer.from(contents || []);
+  const embeddedLength = streamBytes.length;
+  const context = {
+    diagId,
+    source,
+    mime: mime || null,
+    origBytes: imageBuffer.length,
+    embeddedImageStreamLength: embeddedLength,
+    scope,
+    pdfBytes: pdfBytes ?? pdfBuffer.length,
+  };
+
+  if (embeddedLength < imageBuffer.length * MIN_EMBED_RATIO) {
+    logger.error("pdf_embed_mismatch", {
+      ...context,
+      reason: "stream_too_small",
+    });
+    const error = new Error("pdf_embed_mismatch");
+    error.code = "pdf_embed_mismatch";
+    error.reason = "stream_too_small";
+    throw error;
+  }
+
+  if (mime === "image/jpeg" || (imageBuffer.length >= 2 && imageBuffer.subarray(0, 2).equals(JPEG_SIGNATURE))) {
+    const startsWithSoi = streamBytes.length >= 2 && streamBytes[0] === JPEG_SIGNATURE[0] && streamBytes[1] === JPEG_SIGNATURE[1];
+    const endsWithEoi = streamBytes.length >= 2 && streamBytes[streamBytes.length - 2] === JPEG_EOI[0] && streamBytes[streamBytes.length - 1] === JPEG_EOI[1];
+    if (!startsWithSoi || !endsWithEoi) {
+      logger.error("pdf_embed_mismatch", {
+        ...context,
+        reason: "jpeg_markers_missing",
+        startsWithSoi,
+        endsWithEoi,
+      });
+      const error = new Error("pdf_embed_mismatch");
+      error.code = "pdf_embed_mismatch";
+      error.reason = "jpeg_markers_missing";
+      throw error;
+    }
+  } else if (mime === "image/png" || (imageBuffer.length >= 8 && imageBuffer.subarray(0, 4).equals(PNG_SIGNATURE))) {
+    const startsWithPng = streamBytes.length >= PNG_SIGNATURE.length && streamBytes.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE);
+    const endsWithIend =
+      streamBytes.length >= PNG_IEND.length &&
+      streamBytes.subarray(streamBytes.length - PNG_IEND.length).equals(PNG_IEND);
+    if (!startsWithPng || !endsWithIend) {
+      logger.error("pdf_embed_mismatch", {
+        ...context,
+        reason: "png_signature_mismatch",
+        startsWithPng,
+        endsWithIend,
+      });
+      const error = new Error("pdf_embed_mismatch");
+      error.code = "pdf_embed_mismatch";
+      error.reason = "png_signature_mismatch";
+      throw error;
+    }
+  }
+
+  return { embeddedImageStreamLength: embeddedLength };
+}
+
 export async function imageBufferToPdf({
   buffer,
   density,
@@ -205,6 +336,7 @@ export async function imageBufferToPdf({
   heightCm,
   diagId,
   imageMime,
+  source = "unknown",
 } = {}) {
   if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
     const error = new Error('invalid_image_buffer');
@@ -274,6 +406,15 @@ export async function imageBufferToPdf({
 
   const pdfBytes = await pdfDoc.save({ useObjectStreams: true, addDefaultPage: false });
   const pdfBuffer = Buffer.from(pdfBytes);
+  const { embeddedImageStreamLength } = await verifyEmbeddedImage({
+    pdfBuffer,
+    imageBuffer: buffer,
+    diagId,
+    source,
+    mime: imageKind.mime,
+    scope: "imageToPdf",
+    pdfBytes: pdfBuffer.length,
+  });
 
   const actualWidthCm = pointsToCentimeters(widthPoints);
   const actualHeightCm = pointsToCentimeters(heightPoints);
@@ -285,13 +426,16 @@ export async function imageBufferToPdf({
   logger.debug('image_to_pdf_render', {
     diagId,
     strategy: resolveStrategy(),
+    source,
     userUnit,
     dpi: { x: dpiInfo.x, y: dpiInfo.y, inferred: dpiInfo.inferred },
     mime: imageKind.mime,
     imgBytes: buffer.length,
     pdfBytes: pdfBuffer.length,
+    embeddedImageStreamLength,
     pixelWxH: { width: pixelWidth, height: pixelHeight },
-    drawWxHpts: { width: widthPoints, height: heightPoints },
+    pageWxHpt: { width: widthPoints, height: heightPoints },
+    pageWxHptUserUnit: { width: pageWidthPt, height: pageHeightPt },
   });
 
   if (pdfBuffer.length < buffer.length * 0.5) {
@@ -314,6 +458,7 @@ export async function imageBufferToPdf({
     widthCmPrint: widthResultCm + bleedValueCm * 2,
     heightCmPrint: heightResultCm + bleedValueCm * 2,
     userUnit,
+    embeddedImageStreamLength,
   };
 }
 

--- a/lib/_lib/uploadPrintPdf.js
+++ b/lib/_lib/uploadPrintPdf.js
@@ -207,6 +207,54 @@ export async function uploadPrintPdf({ buffer, filename, metadata = {}, diagId }
 
   const { data: publicData } = storage.getPublicUrl(path);
 
+  let remoteSize = null;
+  try {
+    const directory = path.includes('/') ? path.split('/').slice(0, -1).join('/') : '';
+    const searchName = safeFilename;
+    const { data: listData, error: listError } = await storage.list(directory || '', {
+      limit: 50,
+      search: searchName,
+    });
+    if (!listError && Array.isArray(listData)) {
+      const entry = listData.find((item) => item?.name === searchName) || null;
+      const candidateSizeRaw = entry?.metadata?.size ?? entry?.size ?? null;
+      const candidateSize = Number(candidateSizeRaw);
+      if (Number.isFinite(candidateSize)) {
+        remoteSize = candidateSize;
+      }
+    } else if (listError) {
+      logger.warn('pdf_upload_size_check_error', {
+        diagId: localDiag,
+        path,
+        message: listError?.message,
+        status: listError?.status || listError?.statusCode || null,
+      });
+    }
+  } catch (err) {
+    logger.warn('pdf_upload_size_check_error', {
+      diagId: localDiag,
+      path,
+      message: err?.message || err,
+    });
+  }
+
+  if (Number.isFinite(remoteSize)) {
+    const deltaBytes = Math.abs(remoteSize - size);
+    const ratio = size > 0 ? deltaBytes / size : null;
+    const payload = {
+      diagId: localDiag,
+      path,
+      localBytes: size,
+      remoteBytes: remoteSize,
+      deltaBytes,
+      deltaRatio: ratio,
+    };
+    logger.debug('pdf_upload_size_check', payload);
+    if (ratio != null && ratio > 0.2) {
+      logger.warn('pdf_upload_size_mismatch', payload);
+    }
+  }
+
   logger.debug('pdf_upload_ok', {
     diagId: localDiag,
     bucket: OUTPUT_BUCKET,

--- a/lib/api/handlers/printsUpload.js
+++ b/lib/api/handlers/printsUpload.js
@@ -427,6 +427,9 @@ export async function uploadPrintHandler(req, res) {
         error: err?.code || err?.message || 'pdf_generate_error',
         message: err?.message || err,
       });
+      if (err?.code === 'pdf_embed_mismatch') {
+        return res.status(500).json({ ok: false, diagId, requestId, reason: 'pdf_embed_mismatch' });
+      }
       if (attempt >= MAX_GENERATE_ATTEMPTS) {
         return res.status(500).json({ ok: false, diagId, requestId, reason: 'pdf_generate_failed' });
       }


### PR DESCRIPTION
## Summary
- embed original JPEG/PNG bytes directly into generated PDFs and log detailed diagnostics
- add automatic verification of embedded image streams to abort on recompression or corruption and surface pdf_embed_mismatch errors
- confirm Supabase upload sizes roughly match local files before completing the request

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e59ec321e88327ae1cafa90a13924e