### PR TITLE
Handle unsupported artwork when generating print PDFs

### DIFF
--- a/lib/_lib/generatePrintPdf.js
+++ b/lib/_lib/generatePrintPdf.js
@@ -57,6 +57,182 @@ async function readMetadata(buffer) {
   }
 }
 
+
+function shouldAttemptFallback(err) {
+  if (!err) return false;
+  if (err.code === "unsupported_image_format") return true;
+  if (err.code === "image_metadata_failed") return true;
+  if (err.code === "pdf_embed_mismatch") return true;
+  const message = typeof err.message === "string" ? err.message.toLowerCase() : "";
+  if (!message) return false;
+  if (message.includes("unsupported image format")) return true;
+  if (message.includes("unsupported image type")) return true;
+  if (message.includes("unsupported color")) return true;
+  if (message.includes("unsupported png")) return true;
+  if (message.includes("failed to parse image")) return true;
+  if (message.includes("input buffer contains unsupported")) return true;
+  return false;
+}
+
+async function convertBufferToPng(buffer) {
+  try {
+    const converted = await sharp(buffer, { failOnError: false })
+      .png({ force: true })
+      .toBuffer();
+    return { buffer: converted, mime: "image/png" };
+  } catch (err) {
+    const error = new Error("image_conversion_failed");
+    error.code = "image_conversion_failed";
+    error.cause = err;
+    throw error;
+  }
+}
+
+async function createPdfFromBuffer({
+  imageBuffer,
+  widthCm,
+  heightCm,
+  backgroundColor,
+  diagId,
+  imageMime,
+  source,
+}) {
+  const metadata = await readMetadata(imageBuffer);
+  const pixelWidth = Number(metadata?.width);
+  const pixelHeight = Number(metadata?.height);
+  if (!Number.isFinite(pixelWidth) || pixelWidth <= 0 || !Number.isFinite(pixelHeight) || pixelHeight <= 0) {
+    const error = new Error("image_dimensions_invalid");
+    error.code = "image_dimensions_invalid";
+    throw error;
+  }
+
+  const dpiInfo = extractDpi(metadata);
+  const widthPoints = computeDimensionPoints(pixelWidth, dpiInfo.x);
+  const heightPoints = computeDimensionPoints(pixelHeight, dpiInfo.y);
+  if (!Number.isFinite(widthPoints) || widthPoints <= 0 || !Number.isFinite(heightPoints) || heightPoints <= 0) {
+    const error = new Error("image_points_invalid");
+    error.code = "image_points_invalid";
+    throw error;
+  }
+
+  const imageKind = detectImageKind(imageBuffer, imageMime, metadata?.format);
+  if (imageKind.kind !== "jpeg" && imageKind.kind !== "png") {
+    logger.error("pdf_generate_unsupported_format", {
+      diagId,
+      source,
+      mime: imageKind.mime || imageMime || null,
+      metadataFormat: metadata?.format || null,
+    });
+    const error = new Error("unsupported_image_format");
+    error.code = "unsupported_image_format";
+    throw error;
+  }
+
+  const pdfDoc = await PDFDocument.create();
+  const embedImage = imageKind.kind === "png"
+    ? await pdfDoc.embedPng(imageBuffer)
+    : await pdfDoc.embedJpg(imageBuffer);
+
+  const userUnit = resolveUserUnit(widthPoints, heightPoints);
+  const pageWidthPt = widthPoints / userUnit;
+  const pageHeightPt = heightPoints / userUnit;
+  const page = pdfDoc.addPage([pageWidthPt, pageHeightPt]);
+  if (userUnit !== 1) {
+    page.node.set(PDFName.of("UserUnit"), PDFNumber.of(userUnit));
+  }
+
+  const normalizedColor = normalizeColor(backgroundColor);
+  const { r, g, b } = hexToRgb(normalizedColor);
+  page.drawRectangle({
+    x: 0,
+    y: 0,
+    width: pageWidthPt,
+    height: pageHeightPt,
+    color: rgb(r / 255, g / 255, b / 255),
+  });
+
+  page.drawImage(embedImage, {
+    x: 0,
+    y: 0,
+    width: pageWidthPt,
+    height: pageHeightPt,
+  });
+
+  const pdfBytes = await pdfDoc.save({ useObjectStreams: true, addDefaultPage: false });
+  const pdfBuffer = Buffer.from(pdfBytes);
+  const { embeddedImageStreamLength } = await verifyEmbeddedImage({
+    pdfBuffer,
+    imageBuffer,
+    diagId,
+    source,
+    mime: imageKind.mime,
+    scope: "generatePrintPdf",
+    pdfBytes: pdfBuffer.length,
+  });
+
+  const pageWidthCm = pointsToCentimeters(widthPoints);
+  const pageHeightCm = pointsToCentimeters(heightPoints);
+  const areaWidthCm = widthCm ? Number(widthCm) : pageWidthCm;
+  const areaHeightCm = heightCm ? Number(heightCm) : pageHeightCm;
+
+  logger.debug("pdf_generate_render", {
+    diagId,
+    strategy: "original_bytes_embed",
+    source,
+    userUnit,
+    mime: imageKind.mime,
+    origBytes: imageBuffer.length,
+    pdfBytes: pdfBuffer.length,
+    embeddedImageStreamLength,
+    pixelWxH: { width: pixelWidth, height: pixelHeight },
+    dpi: { x: dpiInfo.x, y: dpiInfo.y, inferred: dpiInfo.inferred },
+    pageWxHpt: { width: widthPoints, height: heightPoints },
+    pageWxHptUserUnit: { width: pageWidthPt, height: pageHeightPt },
+  });
+
+  if (pdfBuffer.length < imageBuffer.length * 0.5) {
+    logger.warn("pdf_generate_size_warning", {
+      diagId,
+      source,
+      mime: imageKind.mime,
+      origBytes: imageBuffer.length,
+      pdfBytes: pdfBuffer.length,
+    });
+  }
+
+  const artworkWidthPx = pixelWidth;
+  const artworkHeightPx = pixelHeight;
+
+  return {
+    buffer: pdfBuffer,
+    info: {
+      pageWidthCm,
+      pageHeightCm,
+      marginCm: 0,
+      dpi: { x: dpiInfo.x, y: dpiInfo.y, inferred: dpiInfo.inferred },
+      strategy: "original_bytes_embed",
+      area: {
+        widthCm: areaWidthCm,
+        heightCm: areaHeightCm,
+        widthPx: artworkWidthPx,
+        heightPx: artworkHeightPx,
+      },
+      artwork: {
+        widthPx: artworkWidthPx,
+        heightPx: artworkHeightPx,
+        offsetLeftPx: 0,
+        offsetTopPx: 0,
+        scale: 1,
+      },
+      backgroundColor: normalizedColor,
+      imageFormat: imageKind.kind,
+      userUnit,
+      embeddedImageStreamLength,
+    },
+  };
+}
+
+
 function pointsToCentimeters(points) {
   return (points / 72) * CM_PER_INCH;
 }
@@ -286,139 +462,57 @@ export async function generatePrintPdf({
     throw error;
   }
 
-  const metadata = await readMetadata(imageBuffer);
-  const pixelWidth = Number(metadata?.width);
-  const pixelHeight = Number(metadata?.height);
-  if (!Number.isFinite(pixelWidth) || pixelWidth <= 0 || !Number.isFinite(pixelHeight) || pixelHeight <= 0) {
-    const error = new Error("image_dimensions_invalid");
-    error.code = "image_dimensions_invalid";
-    throw error;
+  let attempt = 0;
+  let currentBuffer = imageBuffer;
+  let currentMime = imageMime;
+  let lastError = null;
+
+  while (attempt < 2) {
+    try {
+      return await createPdfFromBuffer({
+        imageBuffer: currentBuffer,
+        widthCm,
+        heightCm,
+        backgroundColor,
+        diagId,
+        imageMime: currentMime,
+        source,
+      });
+    } catch (err) {
+      lastError = err;
+      if (attempt === 0 && shouldAttemptFallback(err)) {
+        try {
+          logger.warn("pdf_generate_fallback_conversion", {
+            diagId,
+            source,
+            reason: err?.code || err?.message || "unknown",
+          });
+        } catch {}
+        let converted;
+        try {
+          converted = await convertBufferToPng(imageBuffer);
+        } catch (conversionErr) {
+          if (conversionErr?.code === "image_conversion_failed") {
+            try {
+              logger.error("pdf_generate_fallback_failed", {
+                diagId,
+                source,
+                reason: conversionErr?.cause?.message || conversionErr?.message || conversionErr,
+              });
+            } catch {}
+          }
+          throw err;
+        }
+        currentBuffer = converted.buffer;
+        currentMime = converted.mime;
+        attempt += 1;
+        continue;
+      }
+      throw err;
+    }
   }
 
-  const dpiInfo = extractDpi(metadata);
-  const widthPoints = computeDimensionPoints(pixelWidth, dpiInfo.x);
-  const heightPoints = computeDimensionPoints(pixelHeight, dpiInfo.y);
-  if (!Number.isFinite(widthPoints) || widthPoints <= 0 || !Number.isFinite(heightPoints) || heightPoints <= 0) {
-    const error = new Error("image_points_invalid");
-    error.code = "image_points_invalid";
-    throw error;
-  }
-
-  const imageKind = detectImageKind(imageBuffer, imageMime, metadata?.format);
-  if (imageKind.kind !== "jpeg" && imageKind.kind !== "png") {
-    logger.error("pdf_generate_unsupported_format", {
-      diagId,
-      source,
-      mime: imageKind.mime || imageMime || null,
-      metadataFormat: metadata?.format || null,
-    });
-    const error = new Error("unsupported_image_format");
-    error.code = "unsupported_image_format";
-    throw error;
-  }
-
-  const pdfDoc = await PDFDocument.create();
-  const embedImage = imageKind.kind === "png"
-    ? await pdfDoc.embedPng(imageBuffer)
-    : await pdfDoc.embedJpg(imageBuffer);
-
-  const userUnit = resolveUserUnit(widthPoints, heightPoints);
-  const pageWidthPt = widthPoints / userUnit;
-  const pageHeightPt = heightPoints / userUnit;
-  const page = pdfDoc.addPage([pageWidthPt, pageHeightPt]);
-  if (userUnit !== 1) {
-    page.node.set(PDFName.of("UserUnit"), PDFNumber.of(userUnit));
-  }
-
-  const normalizedColor = normalizeColor(backgroundColor);
-  const { r, g, b } = hexToRgb(normalizedColor);
-  page.drawRectangle({
-    x: 0,
-    y: 0,
-    width: pageWidthPt,
-    height: pageHeightPt,
-    color: rgb(r / 255, g / 255, b / 255),
-  });
-
-  page.drawImage(embedImage, {
-    x: 0,
-    y: 0,
-    width: pageWidthPt,
-    height: pageHeightPt,
-  });
-
-  const pdfBytes = await pdfDoc.save({ useObjectStreams: true, addDefaultPage: false });
-  const pdfBuffer = Buffer.from(pdfBytes);
-  const { embeddedImageStreamLength } = await verifyEmbeddedImage({
-    pdfBuffer,
-    imageBuffer,
-    diagId,
-    source,
-    mime: imageKind.mime,
-    scope: "generatePrintPdf",
-    pdfBytes: pdfBuffer.length,
-  });
-
-  const pageWidthCm = pointsToCentimeters(widthPoints);
-  const pageHeightCm = pointsToCentimeters(heightPoints);
-  const areaWidthCm = widthCm ? Number(widthCm) : pageWidthCm;
-  const areaHeightCm = heightCm ? Number(heightCm) : pageHeightCm;
-
-  logger.debug("pdf_generate_render", {
-    diagId,
-    strategy: "original_bytes_embed",
-    source,
-    userUnit,
-    mime: imageKind.mime,
-    origBytes: imageBuffer.length,
-    pdfBytes: pdfBuffer.length,
-    embeddedImageStreamLength,
-    pixelWxH: { width: pixelWidth, height: pixelHeight },
-    dpi: { x: dpiInfo.x, y: dpiInfo.y, inferred: dpiInfo.inferred },
-    pageWxHpt: { width: widthPoints, height: heightPoints },
-    pageWxHptUserUnit: { width: pageWidthPt, height: pageHeightPt },
-  });
-
-  if (pdfBuffer.length < imageBuffer.length * 0.5) {
-    logger.warn("pdf_generate_size_warning", {
-      diagId,
-      source,
-      mime: imageKind.mime,
-      origBytes: imageBuffer.length,
-      pdfBytes: pdfBuffer.length,
-    });
-  }
-
-  const artworkWidthPx = pixelWidth;
-  const artworkHeightPx = pixelHeight;
-
-  return {
-    buffer: pdfBuffer,
-    info: {
-      pageWidthCm,
-      pageHeightCm,
-      marginCm: 0,
-      dpi: { x: dpiInfo.x, y: dpiInfo.y, inferred: dpiInfo.inferred },
-      strategy: "original_bytes_embed",
-      area: {
-        widthCm: areaWidthCm,
-        heightCm: areaHeightCm,
-        widthPx: artworkWidthPx,
-        heightPx: artworkHeightPx,
-      },
-      artwork: {
-        widthPx: artworkWidthPx,
-        heightPx: artworkHeightPx,
-        offsetLeftPx: 0,
-        offsetTopPx: 0,
-        scale: 1,
-      },
-      backgroundColor: normalizedColor,
-      imageFormat: imageKind.kind,
-      userUnit,
-      embeddedImageStreamLength,
-    },
-  };
+  throw lastError || new Error("pdf_generate_failed");
 }
 
 export async function validatePrintPdf({


### PR DESCRIPTION
## Summary
- add a fallback conversion to PNG when generating print PDFs so unsupported or malformed images can still be embedded
- refactor the core PDF rendering into a reusable helper that runs metadata, DPI, and embed verification on each attempt
- add diagnostics around fallback conversion attempts and failures to aid troubleshooting

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e5a402e3a48327a8667e7acef784f3